### PR TITLE
enable hip-cuda samples

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -92,7 +92,8 @@ set(SAMPLES
     hipStreamSemantics
     hipInfo
     hipSymbol
-    hipDeviceLink
+    hip-cuda
+    hipDeviceLink # must be last in this list due to how hacky using multiple compilers with CMake is
 )
 
 # Add samples that depend on Intel's oneAPI compiler - if available.

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1047,7 +1047,8 @@ hipError_t hipHostGetDevicePointer(void **devPtr, void *hstPtr,
   CHIPInitialize();
   NULLCHECK(devPtr, hstPtr);
 
-  UNIMPLEMENTED(hipErrorNotSupported);
+  // FIX: use a hostPtr-to-devPtr map
+  *devPtr = hstPtr;
 
   RETURN(hipSuccess);
   CHIP_CATCH


### PR DESCRIPTION
* temporary implementation for hipHostGetDevicePointer returning device pointer same as host pointer