### PR TITLE
add CHIP_JIT_FLAGS env var

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -713,6 +713,17 @@ hipError_t CHIPContext::free(void *ptr) {
 // CHIPBackend
 //*************************************************************************************
 
+std::string CHIPBackend::getJitFlags() {
+  std::string flags;
+  if (custom_jit_flags != "") {
+    flags = custom_jit_flags;
+  } else {
+    flags = getDefaultJitFlags();
+  }
+  logDebug("JIT compiler flags: {}", flags);
+  return flags;
+}
+
 CHIPBackend::CHIPBackend() { logDebug("CHIPBackend Base Constructor"); };
 CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
@@ -726,6 +737,7 @@ void CHIPBackend::initialize(std::string platform_str,
                              std::string device_type_str,
                              std::string device_ids_str) {
   initialize_(platform_str, device_type_str, device_ids_str);
+  custom_jit_flags = read_env_var("CHIP_JIT_FLAGS", false);
   if (chip_devices.size() == 0) {
     std::string msg = "No CHIPDevices were initialized";
     CHIPERR_LOG_AND_THROW(msg, hipErrorInitializationError);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1158,6 +1158,28 @@ class CHIPBackend {
   std::vector<CHIPQueue*> chip_queues;
   std::vector<CHIPDevice*> chip_devices;
 
+  /**
+   * @brief User defined compiler options to pass to the JIT compiler
+   *
+   */
+  std::string custom_jit_flags;
+
+  /**
+   * @brief Get the default compiler flags for the JIT compiler
+   *
+   * @return std::string flags to pass to JIT compiler
+   */
+  virtual std::string getDefaultJitFlags() = 0;
+
+  /**
+   * @brief Get the jit options object
+   * return CHIP_JIT_FLAGS if it is set, otherwise return default options as
+   * defined by CHIPBackend<implementation>::getDefaultJitFlags()
+   *
+   * @return std::string flags to pass to JIT compiler
+   */
+  std::string getJitFlags();
+
   // TODO
   // key for caching compiled modules. To get a cached compiled module on a
   // particular device you must make sure that you have a module which matches

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -20,14 +20,16 @@ std::once_flag initialized;
 std::once_flag uninitialized;
 CHIPBackend* Backend;
 
-std::string read_env_var(std::string ENV_VAR) {
+std::string read_env_var(std::string ENV_VAR, bool lower = true) {
+  logDebug("Reading {} from env", ENV_VAR);
   const char* ENV_VAR_IN = std::getenv(ENV_VAR.c_str());
   if (ENV_VAR_IN == nullptr) {
     return std::string();
   }
   std::string var = std::string(ENV_VAR_IN);
-  std::transform(var.begin(), var.end(), var.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+  if (lower)
+    std::transform(var.begin(), var.end(), var.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
 
   return var;
 };
@@ -54,6 +56,9 @@ void CHIPInitializeCallOnce(std::string BE) {
   std::string CHIPPlatformStr, CHIPDeviceTypeStr, CHIPDeviceStr;
   read_env_vars(CHIPPlatformStr, CHIPDeviceTypeStr, CHIPDeviceStr);
   logDebug("CHIPDriver Initialize");
+
+  // Read JIT options from the env
+
   // Get the current Backend Env Var
 
   // If no BE is passed to init explicitly, read env var

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -55,7 +55,7 @@ void CHIPInitializeCallOnce(std::string BE = "");
  */
 void CHIPUninitializeCallOnce();
 
-std::string read_env_var(std::string ENV_VAR);
+std::string read_env_var(std::string ENV_VAR, bool lower);
 std::string read_backend_selection();
 
 #endif

--- a/src/backend/Level0/Level0Backend.cc
+++ b/src/backend/Level0/Level0Backend.cc
@@ -59,6 +59,12 @@ void CHIPEventMonitorLevel0::monitor() {
 
 // CHIPBackendLevel0
 // ***********************************************************************
+
+std::string CHIPBackendLevel0::getDefaultJitFlags() {
+  return std::string(
+      "-cl-std=CL2.0 -cl-take-global-address -cl-match-sincospi");
+}
+
 void CHIPBackendLevel0::initialize_(std::string CHIPPlatformStr,
                                     std::string CHIPDeviceTypeStr,
                                     std::string CHIPDeviceStr) {
@@ -722,8 +728,7 @@ void CHIPModuleLevel0::compile(CHIPDevice* chip_dev) {
   ze_result_t status;
 
   // Create module with global address aware
-  std::string compilerOptions =
-      " -cl-std=CL2.0 -cl-take-global-address -cl-match-sincospi ";
+  std::string compilerOptions = Backend->getJitFlags();
   ze_module_desc_t moduleDesc = {ZE_STRUCTURE_TYPE_MODULE_DESC,
                                  nullptr,
                                  ZE_MODULE_FORMAT_IL_SPIRV,

--- a/src/backend/Level0/Level0Backend.hh
+++ b/src/backend/Level0/Level0Backend.hh
@@ -422,6 +422,8 @@ class CHIPBackendLevel0 : public CHIPBackend {
                            std::string CHIPDeviceTypeStr,
                            std::string CHIPDeviceStr) override;
 
+  virtual std::string getDefaultJitFlags() override;
+
   void uninitialize() override { UNIMPLEMENTED(); }
 
   virtual CHIPTexture* createCHIPTexture(intptr_t image_,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -142,7 +142,7 @@ void CHIPModuleOpenCL::compile(CHIPDevice *chip_dev_) {
 
   //   for (CHIPDevice *chip_dev : chip_devices) {
   std::string name = chip_dev_ocl->getName();
-  err = Program.build("-x spir -cl-kernel-arg-info");
+  err = Program.build(Backend->getJitFlags().c_str());
 
   std::string log =
       Program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*chip_dev_ocl->cl_dev, &err);
@@ -466,6 +466,11 @@ int CHIPExecItemOpenCL::setupAllArgs(CHIPKernelOpenCL *kernel) {
 }
 // CHIPBackendOpenCL
 //*************************************************************************
+
+std::string CHIPBackendOpenCL::getDefaultJitFlags() {
+  return std::string("-x spir -cl-kernel-arg-info");
+}
+
 void CHIPBackendOpenCL::initialize_(std::string CHIPPlatformStr,
                                     std::string CHIPDeviceTypeStr,
                                     std::string CHIPDeviceStr) {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -597,44 +597,44 @@ std::string resultToString(int status) {
     case CL_DEVICE_NOT_FOUND:
       return "CL_DEVICE_NOT_FOUND";
     case CL_DEVICE_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_DEVICE_NOT_AVAILABLE";
     case CL_COMPILER_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_COMPILER_NOT_AVAILABLE";
     case CL_MEM_OBJECT_ALLOCATION_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MEM_OBJECT_ALLOCATION_FAILURE";
     case CL_OUT_OF_RESOURCES:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_OUT_OF_RESOURCES";
     case CL_OUT_OF_HOST_MEMORY:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_OUT_OF_HOST_MEMORY";
     case CL_PROFILING_INFO_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_PROFILING_INFO_NOT_AVAILABLE";
     case CL_MEM_COPY_OVERLAP:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MEM_COPY_OVERLAP";
     case CL_IMAGE_FORMAT_MISMATCH:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_IMAGE_FORMAT_MISMATCH";
     case CL_IMAGE_FORMAT_NOT_SUPPORTED:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_IMAGE_FORMAT_NOT_SUPPORTED";
     case CL_BUILD_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_BUILD_PROGRAM_FAILURE";
     case CL_MAP_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MAP_FAILURE";
 #ifdef CL_VERSION_1_1
     case CL_MISALIGNED_SUB_BUFFER_OFFSET:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MISALIGNED_SUB_BUFFER_OFFSET";
     case CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST";
 #endif
 #ifdef CL_VERSION_1_2
     case CL_COMPILE_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_COMPILE_PROGRAM_FAILURE";
     case CL_LINKER_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_LINKER_NOT_AVAILABLE";
     case CL_LINK_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_LINK_PROGRAM_FAILURE";
     case CL_DEVICE_PARTITION_FAILED:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_DEVICE_PARTITION_FAILED";
     case CL_KERNEL_ARG_INFO_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_KERNEL_ARG_INFO_NOT_AVAILABLE";
 #endif
     case (CL_INVALID_VALUE):
       return "CL_INVALID_VALUE";

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -288,7 +288,10 @@ CHIPQueueOpenCL::CHIPQueueOpenCL(CHIPDevice *chip_device_)
   cl_ctx = ((CHIPContextOpenCL *)chip_context)->get();
   cl_dev = ((CHIPDeviceOpenCL *)chip_device)->get();
 
-  cl_q = new cl::CommandQueue(*cl_ctx, *cl_dev);
+  cl_int status;
+  cl_q = new cl::CommandQueue(*cl_ctx, *cl_dev, CL_QUEUE_PROFILING_ENABLE,
+                              &status);
+  CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorInitializationError);
 
   chip_device_->addQueue(this);
 }

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -219,6 +219,8 @@ class CHIPBackendOpenCL : public CHIPBackend {
 
   void uninitialize() override;
 
+  virtual std::string getDefaultJitFlags() override;
+
   virtual CHIPTexture *createCHIPTexture(intptr_t image_,
                                          intptr_t sampler_) override {
     UNIMPLEMENTED(nullptr);


### PR DESCRIPTION
* CHIPModule<backend>::compile() should call Backend->get_jit_flags()
* CHIPBackend::get_jit_flags() returns the value of CHIP_JIT_FLAGS if it
is set, otherwise returns CHIPBackend<backend>::get_default_jit_flags()
* each backend must implement
CHIPBackend<backend>::get_default_jit_flags() which returns default JIT
flags
* Level Zero backend does not fail to JIT when a random string is
passed, whereas OpenCL fails to JIT.