### PR TITLE
[OpenCL] Implement events

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -115,7 +115,7 @@ void CHIPAllocationTracker::recordAllocation(void *dev_ptr, size_t size_) {
 // CHIPEvent
 // ************************************************************************
 CHIPEvent::CHIPEvent(CHIPContext *ctx_in, CHIPEventType event_type_)
-    : event_status(EVENT_STATUS_RECORDING),
+    : event_status(EVENT_STATUS_INIT),
       flags(event_type_),
       chip_context(ctx_in) {}
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1401,7 +1401,6 @@ class CHIPBackend {
  */
 class CHIPQueue {
  protected:
-  std::mutex mtx;
   int priority;
   unsigned int flags;
   /// Device on which this queue will execute
@@ -1412,6 +1411,9 @@ class CHIPQueue {
   CHIPEventMonitor* event_monitor = nullptr;
 
  public:
+  // I want others to be able to lock this queue?
+  std::mutex mtx;
+
   /** Keep track of what was the last event submitted to this queue. Required
    * for enforcing proper queue syncronization as per HIP/CUDA API. */
   CHIPEvent* LastEvent;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -261,6 +261,49 @@ class CHIPEvent {
    *
    */
   virtual ~CHIPEvent() = default;
+
+  /**
+   * @brief Get the Context object
+   *
+   * @return CHIPContext* pointer to context on which this event was created
+   */
+  CHIPContext* getContext() { return chip_context; }
+
+  /**
+   * @brief Query the state of this event and update it's status
+   * Each backend must override this method with implementation specific calls
+   * e.x. clGetEventInfo()
+   *
+   * @return true event was in recording state, state might have changed
+   * @return false event was not in recording state
+   */
+  virtual bool updateFinishStatus() = 0;
+
+  /**
+   * @brief Check if this event is recording or already recorded
+   *
+   * @return true event is recording/recorded
+   * @return false event is in init or invalid state
+   */
+  bool isRecordingOrRecorded() {
+    return event_status >= EVENT_STATUS_RECORDING;
+  }
+
+  /**
+   * @brief check if this event is done recording
+   *
+   * @return true recoded
+   * @return false not recorded
+   */
+  bool isFinished() { return (event_status == EVENT_STATUS_RECORDED); }
+
+  /**
+   * @brief Get the Event Status object
+   *
+   * @return event_status_e current event status
+   */
+  event_status_e getEventStatus() { return event_status; }
+
   /**
    * @brief Enqueue this event in a given CHIPQueue
    *
@@ -276,13 +319,7 @@ class CHIPEvent {
    * @return false
    */
   virtual bool wait() = 0;
-  /**
-   * @brief Query the event to see if it completed
-   *
-   * @return true
-   * @return false
-   */
-  virtual bool isFinished() = 0;
+
   /**
    * @brief Calculate absolute difference between completion timestamps of this
    * event and other

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -125,6 +125,207 @@ void CHIPDeviceOpenCL::populateDeviceProperties_() {
 void CHIPDeviceOpenCL::reset() { UNIMPLEMENTED(); }
 // CHIPEventOpenCL
 // ************************************************************************
+CHIPEvent *CHIPContextOpenCL::createEvent(unsigned flags) {
+  CHIPEventType event_type{flags};
+  return new CHIPEventOpenCL(this, event_type);
+}
+
+CHIPEvent *CHIPBackendOpenCL::createCHIPEvent(CHIPContext *chip_ctx_,
+                                              CHIPEventType event_type_) {
+  return new CHIPEventOpenCL((CHIPContextOpenCL *)chip_ctx_, event_type_);
+}
+
+void CHIPEventOpenCL::recordStream(CHIPQueue *chip_queue_) {
+  logDebug("CHIPEventOpenCL::recordStream()");
+  /**
+   * each CHIPQueue keeps track of the status of the last enqueue command. This
+   * is done by creating a CHIPEvent and associating it with the newly submitted
+   * command. Each CHIPQueue has a LastEvent field.
+   *
+   * Recording is done by taking ownership of the target queues' LastEvent,
+   * incrementing that event's refcount.
+   */
+  std::lock_guard<std::mutex> Lock(mtx);
+  auto chip_queue = (CHIPQueueOpenCL *)chip_queue_;
+  auto last_chip_event = (CHIPEventOpenCL *)chip_queue->LastEvent;
+
+  // If this event was used previously, clear it
+  // can be >1 because recordEvent can be called >1 on the same event
+  if (ev != nullptr) {
+    logDebug("removing old event {}, refc: {}\n", (void *)ev, getRefCount());
+
+    clReleaseEvent(ev);
+  }
+
+  // if no previous event, create a marker event - we always need 2 events to
+  // measure differences
+  if (!chip_queue->LastEvent) {
+    cl::Event MarkerEvent;
+    auto status =
+        chip_queue->get()->enqueueMarkerWithWaitList(nullptr, &MarkerEvent);
+    CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd);
+
+    chip_queue->updateLastEvent(MarkerEvent.get());
+    CHIPEventOpenCL *e = (CHIPEventOpenCL *)(chip_queue->LastEvent);
+    clRetainEvent(e->get());
+    logDebug("Target queue LastEvent.refc {}", e->getRefCount());
+  }
+
+  // Take over target queues event
+  this->ev = chip_queue->LastEvent->get();
+  clRetainEvent(this->ev);
+  int refc1 = getRefCount();
+  logDebug("Refc: {} cl_event {}", refc1, (void *)get());
+
+  event_status = EVENT_STATUS_RECORDING;
+
+  /**
+   * There's nothing preventing you from calling hipRecordStream multiple times
+   * in a row on the same event. In such case, after the first call, this events
+   * clEvent field is no longer null and the event's refcount has been
+   * incremented.
+   *
+   * From HIP API: If hipEventRecord() has been previously called on this
+   * event, then this call will overwrite any existing state in event.
+   *
+   * hipEventCreate(myEvent); < clEvent is nullptr
+   * hipMemCopy(..., Q1)
+   * Q1.LastEvent = Q1_MemCopyEvent_0.refcount = 1
+   *
+   * hipStreamRecord(myEvent, Q1);
+   * clEvent== Q1_MemCopyEvent_0, refcount 1->2
+   *
+   * hipMemCopy(..., Q1)
+   * Q1.LastEvent = Q1_MemCopyEvent_1.refcount = 1
+   * Q1_MemCopyEvent_0.refcount 2->1
+   *
+   * hipStreamRecord(myEvent, Q1);
+   * Q1_MemCopyEvent_0.refcount 1->0
+   * clEvent==Q1_MemCopyEvent_1, refcount 1->2
+   */
+
+  // Kind of funky since cl::Event is a cpp wrapper for C interface of OpenCL
+  // cl::Event *e = last_chip_event->get();
+  // ev = new cl::Event(e->get(), true);
+  // clRetainEvent(get());
+
+  // int refc2 = getRefCount();
+  // logDebug("Refc: {} cl_event {}", refc2, (void *)get());
+
+  // assert(refc2 >= 2);
+  // assert(refc2 == (refc1 + 1));
+}
+
+bool CHIPEventOpenCL::wait() {
+  logDebug("CHIPEventOpenCL::wait()");
+  std::lock_guard<std::mutex> Lock(mtx);
+  if (event_status != EVENT_STATUS_RECORDING) {
+    logWarn("Called wait() on an event that isn't active.");
+    return false;
+  }
+
+  auto status = clWaitForEvents(1, &ev);
+
+  CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd);
+  return true;
+}
+
+bool CHIPEventOpenCL::updateFinishStatus() {
+  std::lock_guard<std::mutex> Lock(mtx);
+  logDebug("CHIPEventOpenCL::updateFinishStatus()");
+  if (event_status != EVENT_STATUS_RECORDING) return false;
+
+  int updated_status;
+  auto status = clGetEventInfo(ev, CL_EVENT_COMMAND_EXECUTION_STATUS,
+                               sizeof(int), &event_status, NULL);
+  CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd);
+
+  if (updated_status <= CL_COMPLETE) event_status = EVENT_STATUS_RECORDED;
+
+  return true;
+}
+
+float CHIPEventOpenCL::getElapsedTime(CHIPEvent *other_) {
+  // Why do I need to lock the context mutex?
+  // Can I lock the mutex of this and the other event?
+  // std::lock_guard<std::mutex> Lock(mtx);
+
+  CHIPEventOpenCL *other = (CHIPEventOpenCL *)other_;
+
+  if (this->getContext() != other->getContext())
+    CHIPERR_LOG_AND_THROW(
+        "Attempted to get elapsed time between two events that are not part of "
+        "the same context",
+        hipErrorTbd);
+
+  this->updateFinishStatus();
+  other->updateFinishStatus();
+
+  if (!this->isRecordingOrRecorded() || !other->isRecordingOrRecorded())
+    CHIPERR_LOG_AND_THROW("one of the events isn't/hasn't recorded",
+                          hipErrorTbd);
+
+  if (!this->isFinished() || !other->isFinished())
+    CHIPERR_LOG_AND_THROW("one of the events hasn't finished",
+                          hipErrorNotReady);
+
+  uint64_t Started = this->getFinishTime();
+  uint64_t Finished = other->getFinishTime();
+
+  logDebug("EventElapsedTime: STARTED {} / {} FINISHED {} / {} \n",
+           (void *)this, Started, (void *)other, Finished);
+
+  // apparently fails for Intel NEO, god knows why
+  // assert(Finished >= Started);
+  uint64_t Elapsed;
+  const uint64_t NANOSECS = 1000000000;
+  if (Finished < Started) {
+    logWarn("Finished < Started\n");
+    Elapsed = Started - Finished;
+  } else
+    Elapsed = Finished - Started;
+  uint64_t MS = (Elapsed / NANOSECS) * 1000;
+  uint64_t NS = Elapsed % NANOSECS;
+  float FractInMS = ((float)NS) / 1000000.0f;
+  return (float)MS + FractInMS;
+}
+
+void CHIPEventOpenCL::barrier(CHIPQueue *chip_queue_) {
+  // Makes all future work submitted to stream wait on this event
+  logDebug("CHIPEventOpenCL::barrier()");
+  CHIPQueueOpenCL *chip_queue = (CHIPQueueOpenCL *)chip_queue_;
+  std::lock_guard<std::mutex> Lock(chip_queue->mtx);
+
+  /**
+   * Do I need to do this?
+    if (this->getEventStatus() == EVENT_STATUS_INIT)
+      CHIPERR_LOG_AND_THROW("Attempted to wait on an event that's not active",
+                            hipErrorTbd);
+   */
+
+  // Insert a barrier into the target queue such that the target queue will
+  // execute all previously submitted commands until it hits this barrier
+  cl::vector<cl::Event> events_to_wait_on = {cl::Event(ev)};
+  cl::Event barrier;
+  auto status = chip_queue->get()->enqueueBarrierWithWaitList(
+      &events_to_wait_on, &barrier);
+  CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd,
+                              "failed to enqueue barrier");
+
+  // wrap the barrier event in CHIPEvent
+  CHIPEventOpenCL *chip_barrier_event = new CHIPEventOpenCL(
+      (CHIPContextOpenCL *)(chip_queue->getContext()), barrier.get());
+
+  CHIPEventOpenCL *target_queue_last_event =
+      (CHIPEventOpenCL *)chip_queue->LastEvent;
+
+  chip_queue->updateLastEvent(barrier.get());
+
+  // update the target queue's latest event to be the newly enqueued barrier
+  chip_queue->LastEvent = target_queue_last_event;
+}
+
+void CHIPEventOpenCL::hostSignal() { UNIMPLEMENTED(); }
 // CHIPModuleOpenCL
 //*************************************************************************
 void CHIPModuleOpenCL::compile(CHIPDevice *chip_dev_) {
@@ -240,6 +441,18 @@ hipError_t CHIPContextOpenCL::memCopy(void *dst, const void *src, size_t size,
 
 // CHIPQueueOpenCL
 //*************************************************************************
+void CHIPQueueOpenCL::updateLastEvent(cl_event e_) {
+  auto *LastEventCHIPOpenCL = (CHIPEventOpenCL *)LastEvent;
+
+  if (LastEventCHIPOpenCL) {
+    logDebug("updateLastEvent: LastEvent == {}, will be: {}",
+             (void *)LastEventCHIPOpenCL->get(), (void *)e_);
+    clReleaseEvent(LastEventCHIPOpenCL->get());
+  } else {
+    logDebug("updateLastEvent: LastEvent == NULL, will be: {}\n", (void *)e_);
+  }
+  LastEvent = new CHIPEventOpenCL((CHIPContextOpenCL *)chip_context, e_);
+}
 hipError_t CHIPQueueOpenCL::launch(CHIPExecItem *exec_item) {
   // std::lock_guard<std::mutex> Lock(mtx);
   logTrace("CHIPQueueOpenCL->launch()");
@@ -265,20 +478,8 @@ hipError_t CHIPQueueOpenCL::launch(CHIPExecItem *exec_item) {
   CHIPERR_CHECK_LOG_AND_THROW(err, CL_SUCCESS, hipErrorTbd);
   hipError_t retval = hipSuccess;
 
-  // TODO
-  // cl_event LastEvent;
-  // if (retval == hipSuccess) {
-  //   if (LastEvent != nullptr) {
-  //     logDebug("Launch: LastEvent == {}, will be: {}", (void *)LastEvent,
-  //              (void *)ev.get());
-  //     clReleaseEvent(LastEvent);
-  //   } else
-  //     logDebug("launch: LastEvent == NULL, will be: {}\n", (void *)ev.get());
-  //   LastEvent = ev.get();
-  //   clRetainEvent(LastEvent);
-  // }
-
-  // TODO remove this
+  clRetainEvent(ev.get());
+  updateLastEvent(ev.get());
   // delete chip_ocl_exec_item;
   return retval;
 }
@@ -288,9 +489,13 @@ CHIPQueueOpenCL::CHIPQueueOpenCL(CHIPDevice *chip_device_)
   cl_ctx = ((CHIPContextOpenCL *)chip_context)->get();
   cl_dev = ((CHIPDeviceOpenCL *)chip_device)->get();
 
-  cl_q = new cl::CommandQueue(*cl_ctx, *cl_dev);
+  cl_int status;
+  cl_q = new cl::CommandQueue(*cl_ctx, *cl_dev, CL_QUEUE_PROFILING_ENABLE,
+                              &status);
+  CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorInitializationError);
 
   chip_device_->addQueue(this);
+  LastEvent = nullptr;
 }
 
 CHIPQueueOpenCL::~CHIPQueueOpenCL() {
@@ -306,14 +511,7 @@ hipError_t CHIPQueueOpenCL::memCopy(void *dst, const void *src, size_t size) {
   int retval = ::clEnqueueSVMMemcpy(cl_q->get(), CL_FALSE, dst, src, size, 0,
                                     nullptr, &ev);
   CHIPERR_CHECK_LOG_AND_THROW(retval, CL_SUCCESS, hipErrorRuntimeMemory);
-  if (LastEvent != nullptr) {
-    logDebug("memCopy: LastEvent == {}, will be: {}", (void *)LastEvent,
-             (void *)ev);
-    clReleaseEvent(LastEvent);
-  } else {
-    logDebug("memCopy: LastEvent == NULL, will be: {}\n", (void *)ev);
-    LastEvent = ev;
-  }
+  updateLastEvent(ev);
   return hipSuccess;
 }
 
@@ -597,44 +795,44 @@ std::string resultToString(int status) {
     case CL_DEVICE_NOT_FOUND:
       return "CL_DEVICE_NOT_FOUND";
     case CL_DEVICE_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_DEVICE_NOT_AVAILABLE";
     case CL_COMPILER_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_COMPILER_NOT_AVAILABLE";
     case CL_MEM_OBJECT_ALLOCATION_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MEM_OBJECT_ALLOCATION_FAILURE";
     case CL_OUT_OF_RESOURCES:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_OUT_OF_RESOURCES";
     case CL_OUT_OF_HOST_MEMORY:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_OUT_OF_HOST_MEMORY";
     case CL_PROFILING_INFO_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_PROFILING_INFO_NOT_AVAILABLE";
     case CL_MEM_COPY_OVERLAP:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MEM_COPY_OVERLAP";
     case CL_IMAGE_FORMAT_MISMATCH:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_IMAGE_FORMAT_MISMATCH";
     case CL_IMAGE_FORMAT_NOT_SUPPORTED:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_IMAGE_FORMAT_NOT_SUPPORTED";
     case CL_BUILD_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_BUILD_PROGRAM_FAILURE";
     case CL_MAP_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MAP_FAILURE";
 #ifdef CL_VERSION_1_1
     case CL_MISALIGNED_SUB_BUFFER_OFFSET:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_MISALIGNED_SUB_BUFFER_OFFSET";
     case CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST";
 #endif
 #ifdef CL_VERSION_1_2
     case CL_COMPILE_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_COMPILE_PROGRAM_FAILURE";
     case CL_LINKER_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_LINKER_NOT_AVAILABLE";
     case CL_LINK_PROGRAM_FAILURE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_LINK_PROGRAM_FAILURE";
     case CL_DEVICE_PARTITION_FAILED:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_DEVICE_PARTITION_FAILED";
     case CL_KERNEL_ARG_INFO_NOT_AVAILABLE:
-      return "CL_DEVICE_NOT_FOUND";
+      return "CL_KERNEL_ARG_INFO_NOT_AVAILABLE";
 #endif
     case (CL_INVALID_VALUE):
       return "CL_INVALID_VALUE";

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -203,17 +203,6 @@ void CHIPEventOpenCL::recordStream(CHIPQueue *chip_queue_) {
    * Q1_MemCopyEvent_0.refcount 1->0
    * clEvent==Q1_MemCopyEvent_1, refcount 1->2
    */
-
-  // Kind of funky since cl::Event is a cpp wrapper for C interface of OpenCL
-  // cl::Event *e = last_chip_event->get();
-  // ev = new cl::Event(e->get(), true);
-  // clRetainEvent(get());
-
-  // int refc2 = getRefCount();
-  // logDebug("Refc: {} cl_event {}", refc2, (void *)get());
-
-  // assert(refc2 >= 2);
-  // assert(refc2 == (refc1 + 1));
 }
 
 bool CHIPEventOpenCL::wait() {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -102,8 +102,7 @@ class CHIPContextOpenCL : public CHIPContext {
   virtual hipError_t memCopy(void *dst, const void *src, size_t size,
                              hipStream_t stream) override;
   cl::Context *get() { return cl_ctx; }
-  virtual CHIPEvent *createEvent(unsigned flags) override{
-      UNIMPLEMENTED(nullptr)};  // TODO
+  virtual CHIPEvent *createEvent(unsigned flags) override;
 };
 
 class CHIPDeviceOpenCL : public CHIPDevice {
@@ -144,10 +143,13 @@ class CHIPQueueOpenCL : public CHIPQueue {
   cl::CommandQueue *cl_q;
 
  public:
+  CHIPEventOpenCL *LastEvent;
   CHIPQueueOpenCL() = delete;  // delete default constructor
   CHIPQueueOpenCL(const CHIPQueueOpenCL &) = delete;
   CHIPQueueOpenCL(CHIPDevice *chip_device);
   ~CHIPQueueOpenCL();
+
+  void updateLastEvent(cl_event e_);
 
   virtual hipError_t launch(CHIPExecItem *exec_item) override;
   virtual void finish() override;
@@ -226,8 +228,8 @@ class CHIPBackendOpenCL : public CHIPBackend {
   }
 
   virtual CHIPQueue *createCHIPQueue(CHIPDevice *chip_dev) override {
-    UNIMPLEMENTED(nullptr);
-    // return new CHIPQueueOpenCL();
+    CHIPDeviceOpenCL *chip_dev_cl = (CHIPDeviceOpenCL *)chip_dev;
+    return new CHIPQueueOpenCL(chip_dev_cl);
   }
 
   // virtual CHIPDevice *createCHIPDevice() override {
@@ -239,9 +241,7 @@ class CHIPBackendOpenCL : public CHIPBackend {
   // }
 
   virtual CHIPEvent *createCHIPEvent(CHIPContext *chip_ctx_,
-                                     CHIPEventType event_type_) override {
-    UNIMPLEMENTED(nullptr);
-  }
+                                     CHIPEventType event_type_) override;
 
   virtual CHIPCallbackData *createCallbackData(
       hipStreamCallback_t callback, void *userData,
@@ -255,16 +255,49 @@ class CHIPBackendOpenCL : public CHIPBackend {
 };
 
 class CHIPEventOpenCL : public CHIPEvent {
- protected:
-  cl::Event *cl_event;
+ public:
+  cl_event ev;
 
  public:
-  void recordStream(CHIPQueue *chip_queue_) override { UNIMPLEMENTED(); };
-  bool wait() override { UNIMPLEMENTED(true); };
-  bool isFinished() override { UNIMPLEMENTED(true); };
-  float getElapsedTime(CHIPEvent *other) override { UNIMPLEMENTED(true); };
+  CHIPEventOpenCL(CHIPContextOpenCL *chip_ctx_, cl_event ev_,
+                  CHIPEventType event_type_ = CHIPEventType::Default)
+      : CHIPEvent((CHIPContext *)(chip_ctx_), event_type_), ev(ev_) {}
 
-  virtual void barrier(CHIPQueue *chip_queue_) override { UNIMPLEMENTED(); }
+  CHIPEventOpenCL(CHIPContextOpenCL *chip_ctx_,
+                  CHIPEventType event_type_ = CHIPEventType::Default)
+      : CHIPEvent((CHIPContext *)(chip_ctx_), event_type_), ev(nullptr) {}
+
+  void recordStream(CHIPQueue *chip_queue_) override;
+  bool wait() override;
+  float getElapsedTime(CHIPEvent *other) override;
+
+  virtual void barrier(CHIPQueue *chip_queue_) override;
+
+  virtual void hostSignal() override;
+
+  virtual bool updateFinishStatus() override;
+
+  cl_event get() { return ev; }
+
+  uint64_t getFinishTime() {
+    std::lock_guard<std::mutex> Lock(mtx);
+    int status;
+    uint64_t ret;
+    status = clGetEventProfilingInfo(ev, CL_PROFILING_COMMAND_END, sizeof(ret),
+                                     &ret, NULL);
+
+    CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd,
+                                "Failed to query event for profiling info.");
+    return ret;
+  }
+
+  int getRefCount() {
+    cl_uint refc;
+    int status =
+        ::clGetEventInfo(this->get(), CL_EVENT_REFERENCE_COUNT, 4, &refc, NULL);
+    CHIPERR_CHECK_LOG_AND_THROW(status, CL_SUCCESS, hipErrorTbd);
+    return refc;
+  }
 };
 
 #endif


### PR DESCRIPTION
* CHIPEventOpenCL implementation
* Modified HIPCL implementation
* This version is done using cl_event as opposed to cl::Event (I have that one as well) 
* Using cl::Event as was done in HIPCL did not seem to make sense since you often need a handle on the inner cl_event
* Incrementing and decrementing the reference count explicitly is much easier to read (imo) than dealing with cl::Event constructors/destructors

This still needs cleanup and further checks that every enqueue command calls `updateLastEvent()` but this version passed hipEvent sample reporting reasonable timings. 

There's overlap between OpenCL implementation and Level Zero. Further work can be done to implement more logic at the CHIP-SPV level. 