### PR TITLE
Implement queue semantics 1/2

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -626,7 +626,7 @@ void CHIPContext::syncQueues(CHIPQueue *target_queue) {
   queues.erase(queues.begin());
 
   for (auto &q : queues)
-    if (q->getQueueType() == CHIPQueueType::Default)
+    if (q->getQueueType() == CHIPQueueType::Blocking)
       blocking_queues.push_back(q);
   logDebug("Num blocking queues: {}", blocking_queues.size());
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -630,14 +630,10 @@ void CHIPContext::syncQueues(CHIPQueue *target_queue) {
       blocking_queues.push_back(q);
   logDebug("Num blocking queues: {}", blocking_queues.size());
 
-  // default stream waits on all non-blocking streams to complete
+  // default stream waits on all blocking streams to complete
   std::vector<CHIPEvent *> events_to_wait_on;
   CHIPEvent *signal;
-  /**
-   * TODO:
-   * CHIPQueue->LastEvent must be initialized to marker event upon queue
-   * construction
-   */
+
   if (target_queue == default_queue) {
     for (auto &q : blocking_queues) events_to_wait_on.push_back(q->LastEvent);
     signal = target_queue->enqueueBarrier(&events_to_wait_on);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -34,6 +34,11 @@
 
 class CHIPEventMonitor;
 
+enum class CHIPQueueType : unsigned int {
+  Default = hipStreamDefault,
+  NonBlocking = hipStreamNonBlocking
+};
+
 class CHIPCallbackData {
  public:
   CHIPQueue* chip_queue;
@@ -727,10 +732,9 @@ class CHIPDevice {
    * @return CHIPQueue* pointer to the newly created queue (can also be found
    * in chip_queues vector)
    */
-  virtual CHIPQueue* addQueue(
-      unsigned int flags,
-      int priority) = 0;  // TODO how do I instantiate a CHIPQueue derived type
-                          // in a generic way?
+  virtual CHIPQueue* addQueue_(unsigned int flags, int priority) = 0;
+
+  CHIPQueue* addQueue(unsigned int flags, int priority);
 
   /**
    * @brief Add a queue to this device
@@ -943,6 +947,8 @@ class CHIPContext {
    *
    */
   ~CHIPContext();
+
+  virtual void syncQueues(CHIPQueue* target_queue);
 
   /**
    * @brief Add a device to this context
@@ -1426,6 +1432,7 @@ class CHIPQueue {
   std::mutex mtx;
   int priority;
   unsigned int flags;
+  CHIPQueueType queue_type;
   /// Device on which this queue will execute
   CHIPDevice* chip_device;
   /// Context to which device belongs to
@@ -1464,6 +1471,13 @@ class CHIPQueue {
    *
    */
   ~CHIPQueue();
+
+  CHIPQueueType getQueueType() { return queue_type; }
+  void updateLastEvent(CHIPEvent* ev) {
+    logDebug("CHIPQueue::updateLastEvent()");
+    if (LastEvent != nullptr) delete LastEvent;
+    LastEvent = ev;
+  }
 
   /**
    * @brief Blocking memory copy
@@ -1574,10 +1588,17 @@ class CHIPQueue {
    * @return false
    */
 
-  virtual void enqueueBarrier(CHIPEvent* eventToSignal,
-                              std::vector<CHIPEvent*>* eventsToWaitFor) = 0;
+  virtual CHIPEvent* enqueueBarrier(
+      std::vector<CHIPEvent*>* eventsToWaitFor) = 0;
 
-  virtual void enqueueSignal(CHIPEvent* eventToSignal) = 0;
+  CHIPEvent* enqueueMarker() {
+    chip_context->syncQueues(this);
+    auto ev = enqueueMarker_();
+    updateLastEvent(ev);
+    return ev;
+  }
+
+  virtual CHIPEvent* enqueueMarker_() = 0;
   /**
    * @brief Get the Flags object with which this queue was created.
    *

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -35,7 +35,7 @@
 class CHIPEventMonitor;
 
 enum class CHIPQueueType : unsigned int {
-  Default = hipStreamDefault,
+  Blocking = hipStreamDefault,
   NonBlocking = hipStreamNonBlocking
 };
 

--- a/src/backend/Level0/Level0Backend.hh
+++ b/src/backend/Level0/Level0Backend.hh
@@ -101,10 +101,9 @@ class CHIPQueueLevel0 : public CHIPQueue {
 
   virtual void getBackendHandles(unsigned long* nativeInfo, int* size) override;
 
-  virtual void enqueueSignal(CHIPEvent* eventToSignal) override;
+  virtual CHIPEvent* enqueueMarker_() override;
 
-  virtual void enqueueBarrier(
-      CHIPEvent* eventToSignal,
+  virtual CHIPEvent* enqueueBarrier(
       std::vector<CHIPEvent*>* eventsToWaitFor) override;
 };  // end CHIPQueueLevel0
 
@@ -222,7 +221,7 @@ class CHIPDeviceLevel0 : public CHIPDevice {
     return mod;
   }
 
-  virtual CHIPQueue* addQueue(unsigned int flags, int priority) override;
+  virtual CHIPQueue* addQueue_(unsigned int flags, int priority) override;
   ze_device_properties_t* getDeviceProps() { return &(this->ze_device_props); };
   virtual CHIPTexture* createTexture(
       const hipResourceDesc* pResDesc, const hipTextureDesc* pTexDesc,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -175,7 +175,7 @@ void CHIPModuleOpenCL::compile(CHIPDevice *chip_dev_) {
   }
 }
 
-CHIPQueue *CHIPDeviceOpenCL::addQueue(unsigned int flags, int priority) {
+CHIPQueue *CHIPDeviceOpenCL::addQueue_(unsigned int flags, int priority) {
   CHIPQueueOpenCL *new_q = new CHIPQueueOpenCL(this);
   chip_queues.push_back(new_q);
   return new_q;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -124,7 +124,7 @@ class CHIPDeviceOpenCL : public CHIPDevice {
     return mod;
   }
 
-  virtual CHIPQueue *addQueue(unsigned int flags, int priority) override;
+  virtual CHIPQueue *addQueue_(unsigned int flags, int priority) override;
   virtual CHIPTexture *createTexture(
       const hipResourceDesc *pResDesc, const hipTextureDesc *pTexDesc,
       const struct hipResourceViewDesc *pResViewDesc) override {
@@ -175,15 +175,12 @@ class CHIPQueueOpenCL : public CHIPQueue {
   virtual void getBackendHandles(unsigned long *nativeInfo,
                                  int *size) override {}  // TODO
 
-  virtual void enqueueBarrier(
-      CHIPEvent *eventToSignal,
+  virtual CHIPEvent *enqueueBarrier(
       std::vector<CHIPEvent *> *eventsToWaitFor) override {
-    UNIMPLEMENTED();
+    UNIMPLEMENTED(nullptr);
   }
 
-  virtual void enqueueSignal(CHIPEvent *eventToSignal) override {
-    UNIMPLEMENTED();
-  }
+  virtual CHIPEvent *enqueueMarker_() override { UNIMPLEMENTED(nullptr); }
 };
 
 class CHIPKernelOpenCL : public CHIPKernel {


### PR DESCRIPTION
* Introduce `CHIPContext::syncQueues()`
* Backend definitions expose wrapped functions to CHIP-SPV bindings. These wrapped functions enforce queue syncronization and last event updates. Backends must implement pure virtual function equivalents
* Enqueue commands now return `CHIPEvents*` 

This is PR 1/2. Next PR will propagate wrappers and `CHIPEvent*` returns. PRs are split for readability. 

