### PR TITLE
Fix an exec item was created with an incorrect queue

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1205,8 +1205,7 @@ void CHIPQueue::memPrefetch(const void *ptr, size_t count) {
 void CHIPQueue::launchHostFunc(const void *hostFunction, dim3 numBlocks,
                                dim3 dimBlocks, void **args,
                                size_t sharedMemBytes) {
-  CHIPExecItem e(numBlocks, dimBlocks, sharedMemBytes,
-                 Backend->getActiveQueue());
+  CHIPExecItem e(numBlocks, dimBlocks, sharedMemBytes, this);
   e.setArgPointer(args);
   auto ev = e.launchByHostPtr(hostFunction);
   ev->msg = "launchHostFunc";


### PR DESCRIPTION
One of the symptoms due to this was a double free of CHIPEvents which was encountered in #13.
