### PR TITLE
Printf fixes

### DIFF
--- a/bitcode/CMakeLists.txt
+++ b/bitcode/CMakeLists.txt
@@ -37,6 +37,19 @@ add_custom_command( OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/mathlib.bc"
         VERBATIM)
 set(DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/mathlib.bc")
 
+# Support function(s) for printf().
+add_custom_command( OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc"
+                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/_cl_print_str.cl"
+        COMMAND "${CMAKE_CXX_COMPILER}"
+        "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
+        -O2 -x cl -cl-std=CL2.0
+        --target=spir64-unknown-unknown -emit-llvm
+        -o "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc"
+        -c "${CMAKE_CURRENT_SOURCE_DIR}/_cl_print_str.cl"
+        COMMENT "Building printf_support.bc"
+        VERBATIM)
+list(APPEND DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc")
+
 #add_custom_command( OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/mathlib.bc"
 #                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/mathlib.bc"
 #                    COMMAND "${CMAKE_COMMAND}" -E copy

--- a/bitcode/_cl_print_str.cl
+++ b/bitcode/_cl_print_str.cl
@@ -1,0 +1,9 @@
+
+void __attribute__((used)) _cl_print_str(__generic const char *S) {
+  unsigned Pos = 0;
+  char C;
+  while ((C = S[Pos]) != 0) {
+    printf("%c", C);
+    ++Pos;
+  }
+}

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 
+
 using namespace llvm;
 
 // A pass that removes noinline and optnone attributes from functions.
@@ -34,13 +35,11 @@ static void addFullLinkTimePasses(ModulePassManager &MPM) {
   MPM.addPass(HipStripCompilerUsedPass());
   MPM.addPass(HipDynMemExternReplaceNewPass());
   MPM.addPass(HipTextureExternReplaceNewPass());
-#if LLVM_VERSION_MAJOR < 14
   // TODO: Update printf pass for HIP-Clang 14+. It now triggers an assert:
   //
   //  Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"'
   //  failed.
-  MPM.addPass(createModuleToFunctionPassAdaptor(HipPrintfToOpenCLPrintfPass()));
-#endif
+  MPM.addPass(HipPrintfToOpenCLPrintfPass());
   MPM.addPass(createModuleToFunctionPassAdaptor(HipDefrostPass()));
   // This pass must appear after HipDynMemExternReplaceNewPass.
   MPM.addPass(HipGlobalVariablesPass());

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -144,7 +144,7 @@ getFormatStringPieces(Value *FmtStrArg, unsigned &NumberOfFormatSpecs) {
   size_t Pos = 0;
   while ((Pos = FmtStr.find("%s")) != std::string::npos &&
          // Without this we'd handle %%s wrongly.
-         (Pos > 1 && FmtStr[Pos - 1] != '%')) {
+         !(Pos > 0 && FmtStr[Pos - 1] == '%')) {
     std::string TokenBefore = FmtStr.substr(0, Pos);
     if (TokenBefore != "")
       FmtStrPieces.push_back(TokenBefore);
@@ -392,7 +392,6 @@ PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
   }
 
   SmallPtrSet<GlobalVariable *, 8> UnusedGlobals;
-
   return Modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -1,12 +1,47 @@
+//===- HipPrintf.cpp -----------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 // LLVM IR pass to convert calls to the CUDA/HIP printf() to OpenCL/SPIR-V
 // compatible ones.
 //
-// (c) 2021 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+// (c) 2021-2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+//===----------------------------------------------------------------------===//
 //
-// SPIRV-LLVM translator generates a wrong pointer address space to printf
-// format string if it's not the correct (constant) one in the input. This
-// pass moves the format string to constant address space before we pass the IR
-// to SPIRV emission.
+// This pass moves the format string from global to the OpenCL constant address
+// space before we pass the IR to SPIR-V emission, which is required by the
+// SPIR-V's OpenCL profile.
+//
+// More annoyingly, in OpenCL 1.2 the printf string args must be pointers to
+// _literal srings_ according to the specs.
+// https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
+// printfFunction.html
+//
+// This deviates from the C99 printf (and thus CUDA) which allows dynamic
+// string arguments. To implement this on top of the OpenCL printf, we split the
+// format string such that whenever there's a %s we print the string using
+// a printf("%c", c) loop and delegate the surrounding parts format string
+// parts to the printf as is.
+//
+// E.g. printf("%d %s %d", ...) would be converted to a chain of calls:
+// printf("%d ", ...), _putstr(...), ... printf(" %d", ...)
+//
+// This works as long as we can analyze the format string at compile time to
+// detect the string arg positions,  thus dynamic _format_ strings are still
+// not supported.
+//
+// However, since SPIR-V doesn't mention a need of the string arguments to
+// be in the constant space, we by default let them pass since implementations
+// appear to allow it.
+//
+// Also counts the number of format args for replacing the return value of
+// the printf() call with it for rough CUDA-behavior emulation.
+//
+//===----------------------------------------------------------------------===//
 
 #include "HipPrintf.h"
 
@@ -18,157 +53,357 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 
+#include <vector>
+#include <string>
+#include <iostream>
+
+#define SPIRV_OPENCL_CONSTANT_AS 2
+#define SPIRV_OPENCL_GENERIC_AS 4
+#define SPIRV_OPENCL_PRINTF_FMT_ARG_AS SPIRV_OPENCL_CONSTANT_AS
+
+#define ORIG_PRINTF_FUNC_NAME "_hip_printf"
+#define ORIG_PRINT_STRING_FUNC_NAME "_cl_print_str"
+
+// The SPIR-V specification doesn't especially forbid %s
+// arguments that are not "literals" (in constant address
+// space as specified by OpenCL). Assume a SPIR-V printf
+// can print strings that are not moved to constant space
+// and no special functions is needed for their printout.
+// The SPIR-V implementations seen so far do not care about this.
+#define ASSUME_PRINTF_SUPPORTS_GLOBAL_STRING_ARGS 1
+
 using namespace llvm;
 
-class HipPrintfToOpenCLPrintfLegacyPass : public ModulePass {
-public:
-  static char ID;
-  HipPrintfToOpenCLPrintfLegacyPass() : ModulePass(ID) {}
-
-  bool runOnModule(Module &M) override {
-    return false;
-  }
-
-  StringRef getPassName() const override {
-    return "Convert printf calls to OpenCL compatible ones.";
-  }
-};
-
-char HipPrintfToOpenCLPrintfLegacyPass::ID = 0;
-static RegisterPass<HipPrintfToOpenCLPrintfLegacyPass>
-    X("hip-printf", "Convert printf calls to OpenCL compatible ones.");
-
-// Converts the address space of the format string to OpenCL compatible one
-// by creating a copy of it in the module global scope.
-//
-// Also counts the number of format args for replacing the return
-// value of the printf() call with it for CUDA emulation.
-Value* convertFormatString(Value *HipFmtStrArg, Instruction *Before,
-                           unsigned &NumberOfFormatSpecs) {
-
-  Module *M = Before->getParent()->getParent()->getParent();
-
-  ConstantExpr *CE = cast<ConstantExpr>(HipFmtStrArg);
-
-  Value *FmtStrOpr = CE->getOperand(0);
-
-  GlobalVariable *OrigFmtStr =
-    isa<GetElementPtrInst>(FmtStrOpr) ?
-    cast<GlobalVariable>(
-      cast<GetElementPtrInst>(FmtStrOpr)->getPointerOperand()) :
-    cast<GlobalVariable>(FmtStrOpr);
-
-  ConstantDataSequential *FmtStrData =
-    cast<ConstantDataSequential>(OrigFmtStr->getInitializer());
-
-  NumberOfFormatSpecs =
-    FmtStrData->getAsString().count("%") -
-    FmtStrData->getAsString().count("%%");
-
-  GlobalVariable *NewFmtStr = new GlobalVariable(
-      *M, OrigFmtStr->getValueType(), true, OrigFmtStr->getLinkage(),
-      FmtStrData, OrigFmtStr->getName() + ".cl",
-      (GlobalVariable *)nullptr, OrigFmtStr->getThreadLocalMode(),
-      SPIRV_OPENCL_PRINTF_FMT_ARG_AS);
-  NewFmtStr->copyAttributesFrom(OrigFmtStr);
-
-  IntegerType *Int64Ty = Type::getInt64Ty(M->getContext());
-  ConstantInt *Zero = ConstantInt::get(Int64Ty, 0);
-  std::array<Constant*, 2> Indices = {Zero, Zero};
-
-  PointerType *PtrTy =
-    cast<PointerType>(NewFmtStr->getType()->getScalarType());
-
-  return llvm::ConstantExpr::getGetElementPtr(
-    PtrTy->getElementType(), NewFmtStr, Indices);
+unsigned NumFormatSpecs(StringRef FmtString) {
+  return FmtString.count("%") - 2 * FmtString.count("%%");
 }
 
+// Strip address space casts, GEPs etc. towards the global string
+// literal and return it.
+GlobalVariable *findGlobalStr(Value *Arg) {
 
-PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(
-  Function &F,
-  FunctionAnalysisManager &AM) {
+  if (auto GEP = dyn_cast<GetElementPtrInst>(Arg)) {
+    Arg = GEP->getPointerOperand();
+    assert(GEP->hasAllZeroIndices());
+  }
+  if (auto ASCast = dyn_cast<AddrSpaceCastInst>(Arg)) {
+    Arg = ASCast->getPointerOperand();
+  } else if (auto CE = dyn_cast<ConstantExpr>(Arg)) {
+    if (CE->getOpcode() == llvm::Instruction::AddrSpaceCast) {
+      Arg = CE->getOperand(0);
+    } else {
+      llvm_unreachable("Unexpected printf format string format!");
+    }
+  }
+  return cast<GlobalVariable>(Arg);
+}
 
-  Module *M = F.getParent();
-  GlobalValue *Printf = M->getNamedValue("printf");
-  GlobalValue *HipPrintf = M->getNamedValue("_hip_printf");
+// Extracts the format string in the printf argument passed as FmtStrArg,
+// and (possibly) splits it to a number of format strings if there are %s
+// format args. In such a case the %s format string is returned as a separate
+// "%s" format string. Also counts the total number of format specifiers in
+// NumberOfFormatSpecs to returns it as a final return value.
+static std::vector<std::string>
+getFormatStringPieces(Value *FmtStrArg, unsigned &NumberOfFormatSpecs) {
 
-  if (Printf == nullptr) {
-    // No printf decl in module, no printf calls in the function.
-    return PreservedAnalyses::all();
+  Type *Int8Ty = IntegerType::get(FmtStrArg->getContext(), 8);
+
+  ConstantExpr *CE = cast<ConstantExpr>(FmtStrArg);
+
+  Value *FmtStrOpr = findGlobalStr(CE->getOperand(0));
+
+  GlobalVariable *OrigFmtStr = findGlobalStr(CE->getOperand(0));
+
+  std::vector<std::string> FmtStrPieces;
+  ConstantDataSequential *FmtStrData =
+      dyn_cast<ConstantDataSequential>(OrigFmtStr->getInitializer());
+
+  if (FmtStrData == nullptr) {
+    assert(OrigFmtStr->getInitializer()->isZeroValue());
+    FmtStrPieces.push_back("");
+    NumberOfFormatSpecs = 0;
+    return FmtStrPieces;
   }
 
-  auto *Int8Ty = IntegerType::get(F.getContext(), 8);
-  auto *Int32Ty = IntegerType::get(F.getContext(), 32);
+  auto FmtString = FmtStrData->getAsString();
 
-  PointerType *OCLPrintfFmtArgT =
-    PointerType::get(Int8Ty, SPIRV_OPENCL_PRINTF_FMT_ARG_AS);
+  // Counting the format specs is a more accurate approximation for the return
+  // value than counting the passed arguments due to the dynamic width
+  // specifier (*) which is given as an argument and should not be counted
+  // in to the processed arguments (I believe).
+  NumberOfFormatSpecs = NumFormatSpecs(FmtString);
+
+  // FmtStrData has one byte larger size since it includes the trailing
+  // byte, so if we convert it directly to a std::string, it gets a corrupted
+  // string due to the wrong size passed to it (occurs at least with LLVM 13)?
+  // TO CHECK again.
+  std::string FmtStr = std::string(FmtStrData->getAsCString());
+
+  // TODO: %s can also have * specifier. We have to treat it as a special
+  // case, adding strlen() - width for padding.
+  size_t Pos = 0;
+  while ((Pos = FmtStr.find("%s")) != std::string::npos &&
+         // Without this we'd handle %%s wrongly.
+         (Pos > 1 && FmtStr[Pos - 1] != '%')) {
+    std::string TokenBefore = FmtStr.substr(0, Pos);
+    if (TokenBefore != "")
+      FmtStrPieces.push_back(TokenBefore);
+    assert(FmtStr.size() > Pos + 2 - 1);
+    FmtStr.erase(0, Pos + 2);
+    FmtStrPieces.push_back("%s");
+  }
+  if (FmtStr != "")
+    FmtStrPieces.push_back(FmtStr);
+  return FmtStrPieces;
+}
+
+std::string getCDSAsString(GlobalVariable *OrigStr, bool &IsEmpty) {
+
+  assert(OrigStr != nullptr && OrigStr->hasInitializer());
+
+  ConstantDataSequential *CDSInitializer =
+      dyn_cast<ConstantDataSequential>(OrigStr->getInitializer());
+
+  assert(OrigStr->getInitializer()->isZeroValue() || CDSInitializer != nullptr);
+
+  IsEmpty = OrigStr->getInitializer()->isZeroValue();
+  return (IsEmpty ? "" : std::string(CDSInitializer->getAsCString()));
+}
+
+// Tries to convert the string argument to an OpenCL compatible one
+// by creating a copy of it in the module global scope. Returns nullptr
+// if unable to do so.
+Value *HipPrintfToOpenCLPrintfPass::cloneStrArgToConstantAS(
+    Value *StrArg, llvm::IRBuilder<> &B, bool *IsEmpty) {
+
+  ConstantExpr *CE = dyn_cast<ConstantExpr>(StrArg);
+  if (CE == nullptr)
+    return nullptr;
+
+  Type *Int8Ty = IntegerType::get(M_->getContext(), 8);
+
+  Value *StrOpr = CE->getOperand(0);
+
+  GlobalVariable *OrigStr = findGlobalStr(StrOpr);
+  if (OrigStr == nullptr || !OrigStr->hasInitializer())
+    return nullptr;
+
+  std::string NewStr = getCDSAsString(OrigStr, *IsEmpty);
+  return getOrCreateStrLiteralArg(NewStr, B);
+}
+
+// Checks if the GlobalVariable a literal string.
+bool isLiteralString(const GlobalVariable &Var) {
+
+  if (!Var.isConstant())
+    return false;
+
+  auto ArrayTy = dyn_cast<ArrayType>(Var.getType()->getElementType());
+  if (!ArrayTy)
+    return false;
+
+  auto IntTy = dyn_cast<IntegerType>(ArrayTy->getElementType());
+  if (!IntTy)
+    return false;
+
+  return IntTy->getBitWidth() == 8;
+}
+
+// Create a new string literal that can be passed to an OpenCL printf
+// as an argument. Try to reuse previously created ones, if possible.
+Constant *
+HipPrintfToOpenCLPrintfPass::getOrCreateStrLiteralArg(const std::string &Str,
+                                                      llvm::IRBuilder<> &B) {
+
+  auto &LiteralArg = LiteralArgs_[Str];
+  if (LiteralArg != nullptr)
+    return LiteralArg;
+
+  auto *LiteralStr = B.CreateGlobalString(Str.c_str(), ".cl_printf_fmt_str",
+                                          SPIRV_OPENCL_PRINTF_FMT_ARG_AS);
+
+  IntegerType *Int64Ty = Type::getInt64Ty(M_->getContext());
+  ConstantInt *Zero = ConstantInt::get(Int64Ty, 0);
+  std::array<Constant *, 2> Indices = {Zero, Zero};
+
+  PointerType *PtrTy =
+      cast<PointerType>(LiteralStr->getType()->getScalarType());
+
+  return LiteralArg = llvm::ConstantExpr::getGetElementPtr(
+             PtrTy->getElementType(), LiteralStr, Indices);
+}
+
+Function *HipPrintfToOpenCLPrintfPass::getOrCreatePrintStringF() {
+
+  if (GlobalValue *OldPrintStrF =
+          M_->getNamedValue(ORIG_PRINT_STRING_FUNC_NAME))
+    return cast<Function>(OldPrintStrF);
+
+  auto *Int8Ty = IntegerType::get(M_->getContext(), 8);
+  PointerType *GenericCStrArgT =
+      PointerType::get(Int8Ty, SPIRV_OPENCL_GENERIC_AS);
+
+  FunctionType *PrintStrFTy = FunctionType::get(
+      Type::getVoidTy(M_->getContext()), {GenericCStrArgT}, false);
+
+  FunctionCallee PrintStrF =
+      M_->getOrInsertFunction(ORIG_PRINT_STRING_FUNC_NAME, PrintStrFTy);
+  cast<Function>(PrintStrF.getCallee())
+      ->setCallingConv(llvm::CallingConv::SPIR_FUNC);
+  return cast<Function>(PrintStrF.getCallee());
+}
+
+PreservedAnalyses HipPrintfToOpenCLPrintfPass::run(Module &Mod,
+                                                   ModuleAnalysisManager &AM) {
+
+  M_ = &Mod;
+  LiteralArgs_.clear();
+
+  GlobalValue *Printf = Mod.getNamedValue("printf");
+  GlobalValue *HipPrintf = Mod.getNamedValue(ORIG_PRINTF_FUNC_NAME);
+
+  // No printf decl in the module, no printf calls to handle.
+  if (Printf == nullptr)
+    return PreservedAnalyses::all();
+
+  Function *PrintfF = cast<Function>(Printf);
+
+  LLVMContext &Ctx = Mod.getContext();
+  auto *Int8Ty = IntegerType::get(Ctx, 8);
+  auto *Int32Ty = IntegerType::get(Ctx, 32);
+
+  PointerType *ConstStrPtrT =
+      PointerType::get(Int8Ty, SPIRV_OPENCL_CONSTANT_AS);
+
+  PointerType *OCLPrintfFmtArgT = ConstStrPtrT;
+
   FunctionType *OpenCLPrintfTy =
       FunctionType::get(Int32Ty, {OCLPrintfFmtArgT}, true);
 
-  FunctionCallee OpenCLPrintf;
+  FunctionCallee OpenCLPrintfF;
 
   if (HipPrintf == nullptr) {
-    // Create the OpenCL printf which will be used instead. Rename the
+    // Create the OpenCL printf decl which will be used instead. Rename the
     // old one away to _hip_printf.
-    Printf->setName("_hip_printf");
-    HipPrintf = Printf;
-    OpenCLPrintf =
-      M->getOrInsertFunction(
+    PrintfF->setName(ORIG_PRINTF_FUNC_NAME);
+    HipPrintf = PrintfF;
+    OpenCLPrintfF = Mod.getOrInsertFunction(
         "printf", OpenCLPrintfTy, cast<Function>(HipPrintf)->getAttributes());
+    Function *PrintfF = cast<Function>(OpenCLPrintfF.getCallee());
+    PrintfF->setCallingConv(llvm::CallingConv::SPIR_FUNC);
+    PrintfF->setVisibility(llvm::GlobalValue::HiddenVisibility);
   } else {
-    OpenCLPrintf = FunctionCallee(OpenCLPrintfTy, Printf);
+    OpenCLPrintfF = FunctionCallee(OpenCLPrintfTy, PrintfF);
   }
 
-  SmallPtrSet<Instruction *, 8> EraseList;
-  for (auto &BB : F) {
-    for (auto &I : BB) {
-      if (!isa<CallInst>(I) ||
-          (cast<CallInst>(I).getCalledFunction()->getName() != "_hip_printf"))
-        continue;
-      CallInst &OrigCall = cast<CallInst>(I);
-      std::vector<Value *> Args;
-      unsigned FmtSpecCount;
-      for (auto &OrigArg : OrigCall.args()) {
-        if (Args.size() == 0) {
-          Args.push_back(
-            convertFormatString(OrigArg, &OrigCall, FmtSpecCount));
+  bool Modified = false;
+
+  for (auto &F : Mod) {
+    SmallPtrSet<Instruction *, 8> EraseList;
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        if (!isa<CallInst>(I) ||
+            (cast<CallInst>(I).getCalledFunction()->getName() !=
+             ORIG_PRINTF_FUNC_NAME))
           continue;
+
+        CallInst &OrigCall = cast<CallInst>(I);
+        unsigned TotalFmtSpecCount;
+        auto FmtSpecPieces =
+            getFormatStringPieces(*OrigCall.args().begin(), TotalFmtSpecCount);
+        auto FmtI = FmtSpecPieces.begin();
+
+        IRBuilder<> B(&I);
+
+        auto OrigCallArgs = OrigCall.args();
+        auto OrigCallArgI = OrigCallArgs.begin();
+        // Skip the original format string arg and recreate it.
+        OrigCallArgI++;
+
+        for (auto FmtStr : FmtSpecPieces) {
+          unsigned FormatSpecCount = NumFormatSpecs(FmtStr);
+          std::vector<Value *> Args;
+
+          // TODO: handle a (compile time known) null ptr format string arg and
+          // return -1 like CUDA does.
+          if (FmtStr == "") {
+            // No output, the return value suffices.
+            continue;
+          } else if (FmtStr == "%s" || FmtStr == "%*s") {
+            // This is a string printout, we do not pass the format string
+            // in that case, but just call a string printer.
+            // We can use the normal printf if the %s arg can be resolved to
+            // a literal C string. However, it must be moved to constant AS
+            // for OpenCL compatibility.
+            Value *OrigArg = *OrigCallArgI++;
+            bool IsEmpty = false;
+            if (Value *ConstantSpaceCStr =
+                    cloneStrArgToConstantAS(OrigArg, B, &IsEmpty)) {
+              if (IsEmpty)
+                continue; // empty str arg to a %s, no output needed
+              // We could copy the arg to constant space, printf it
+              // directly. No format string needed.
+              Args.push_back(ConstantSpaceCStr);
+              CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+            } else if (ASSUME_PRINTF_SUPPORTS_GLOBAL_STRING_ARGS) {
+              if (IsEmpty)
+                continue;
+              // Create a constant space format string for %s.
+              Args.push_back(getOrCreateStrLiteralArg("%s", B));
+              // ...and then assume the data arg can point to a generic
+              // address space string (eventually residing in global AS).
+              Args.push_back(OrigArg);
+              CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
+            } else {
+              assert("Support for printfs which require %s args in "
+                     "constant aspace is not implemented." &&
+                     false);
+              Args.push_back(OrigArg);
+              CallInst::Create(getOrCreatePrintStringF(), Args, "", &OrigCall);
+            }
+            continue;
+          }
+
+          // Handle as a normal printf() call.
+          Args.push_back(getOrCreateStrLiteralArg(FmtStr, B));
+          while (FormatSpecCount--) {
+            assert(OrigCallArgI != OrigCallArgs.end());
+            Value *OrigArg = *OrigCallArgI++;
+            Args.push_back(OrigArg);
+          }
+          CallInst::Create(OpenCLPrintfF, Args, "", &OrigCall);
         }
-        Args.push_back(OrigArg);
+
+        // Instead of returning the success/failure from the OpenCL printf(),
+        // assume that the parsing succeeds and return the number of format
+        // strings. A slight improvement would be to return 0 in case of a
+        // failure, but it still would not necessarily match CUDA nor HIP
+        // since it should return the number of _valid_ format replacements.
+        IntegerType *Int32Ty = Type::getInt32Ty(Ctx);
+        ConstantInt *RV = ConstantInt::get(Int32Ty, TotalFmtSpecCount);
+        OrigCall.replaceAllUsesWith(RV);
+
+        EraseList.insert(&I);
       }
-      CallInst *NewCall =
-        CallInst::Create(OpenCLPrintf, Args, "", &OrigCall);
-
-      // CHECK: Does this invalidate I?
-      OrigCall.replaceAllUsesWith(NewCall);
-
-
-      // Instead of returning the success/failure from the OpenCL printf(),
-      // assume that the parsing succeeds and return the number of format
-      // strings. A slight improvement would be to return 0 in case of a
-      // failure, but it still would not necessary conform to CUDA nor HIP
-      // since it should return the number of valid format replacements?
-      IntegerType *Int32Ty = Type::getInt32Ty(M->getContext());
-      ConstantInt *RV = ConstantInt::get(Int32Ty, FmtSpecCount);
-      NewCall->replaceAllUsesWith(RV);
-
-      EraseList.insert(&I);
     }
+    for (auto I : EraseList)
+      I->eraseFromParent();
+    Modified |= EraseList.size() > 0;
   }
-  for (auto I : EraseList)
-    I->eraseFromParent();
-  return EraseList.size() > 0 ?
-    PreservedAnalyses::none() : PreservedAnalyses::all();
+
+  SmallPtrSet<GlobalVariable *, 8> UnusedGlobals;
+
+  return Modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 
 namespace {
 
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
 llvmGetPassPluginInfo() {
-  return {LLVM_PLUGIN_API_VERSION, "hip-printf",
-          LLVM_VERSION_STRING, [](PassBuilder &PB) {
+  return {LLVM_PLUGIN_API_VERSION, "hip-printf", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
             PB.registerPipelineParsingCallback(
-                [](StringRef Name, FunctionPassManager &FPM,
+                [](StringRef Name, ModulePassManager &FPM,
                    ArrayRef<PassBuilder::PipelineElement>) {
                   if (Name == "hip-printf") {
                     FPM.addPass(HipPrintfToOpenCLPrintfPass());
@@ -178,4 +413,4 @@ llvmGetPassPluginInfo() {
                 });
           }};
 }
-}
+} // namespace

--- a/llvm_passes/HipPrintf.h
+++ b/llvm_passes/HipPrintf.h
@@ -1,19 +1,42 @@
+//===- HipPrintf.cppp -----------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// LLVM IR pass to convert calls to the CUDA/HIP printf() to OpenCL/SPIR-V
+// compatible ones.
+//
+// (c) 2021-2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+//===----------------------------------------------------------------------===//
+
 #ifndef LLVM_PASSES_HIP_PRINTF_H
 #define LLVM_PASSES_HIP_PRINTF_H
 
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PassManager.h"
+
+#include <map>
 
 using namespace llvm;
 
-#define SPIRV_OPENCL_PRINTF_FMT_ARG_AS 2
-
-#if LLVM_VERSION_MAJOR > 11
 class HipPrintfToOpenCLPrintfPass
     : public PassInfoMixin<HipPrintfToOpenCLPrintfPass> {
 public:
-  PreservedAnalyses run(Function &M, FunctionAnalysisManager &AM);
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
   static bool isRequired() { return true; }
+
+private:
+  Constant *getOrCreateStrLiteralArg(
+      const std::string& Str, llvm::IRBuilder<>& B);
+  Function *getOrCreatePrintStringF();
+  Value* cloneStrArgToConstantAS(
+    Value *StrArg, llvm::IRBuilder<>& B, bool *IsEmpty);
+
+  std::map<std::string, Constant*> LiteralArgs_;
+  Module *M_;
 };
-#endif
 
 #endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SAMPLES
     hipInfo
     hipSymbol
     hip-cuda
+    printf
     hipDeviceLink # must be last in this list due to how hacky using multiple compilers with CMake is
 )
 

--- a/samples/printf/CMakeLists.txt
+++ b/samples/printf/CMakeLists.txt
@@ -8,9 +8,3 @@ add_chip_test(nop_printfs PrintfNOP ${NOP_PRINTFS_XSTDOUT} nop_printfs.cc)
 
 file(READ dynamic_str_args.xstdout DYNAMIC_STR_ARGS_XSTDOUT)
 add_chip_test(dynamic_str_args PrintfDynamic ${DYNAMIC_STR_ARGS_XSTDOUT} dynamic_str_args.cc)
-
-# Fails on Level0.
-# We need to somehow check if we are running with L0 or OpenCL at execution
-# time. Enabling and assuming an OpenCL/PoCL test run for now.
-set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
-

--- a/samples/printf/CMakeLists.txt
+++ b/samples/printf/CMakeLists.txt
@@ -9,7 +9,8 @@ add_chip_test(nop_printfs PrintfNOP ${NOP_PRINTFS_XSTDOUT} nop_printfs.cc)
 file(READ dynamic_str_args.xstdout DYNAMIC_STR_ARGS_XSTDOUT)
 add_chip_test(dynamic_str_args PrintfDynamic ${DYNAMIC_STR_ARGS_XSTDOUT} dynamic_str_args.cc)
 
-# Fails on Level0, so disabled for now.
-# We'd need to check this at test execution time.
-set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
+# Fails on Level0.
+# We need to somehow check if we are running with L0 or OpenCL at execution
+# time. Enabling and assuming an OpenCL/PoCL test run for now.
+# set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
 

--- a/samples/printf/CMakeLists.txt
+++ b/samples/printf/CMakeLists.txt
@@ -12,5 +12,5 @@ add_chip_test(dynamic_str_args PrintfDynamic ${DYNAMIC_STR_ARGS_XSTDOUT} dynamic
 # Fails on Level0.
 # We need to somehow check if we are running with L0 or OpenCL at execution
 # time. Enabling and assuming an OpenCL/PoCL test run for now.
-# set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
+set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
 

--- a/samples/printf/CMakeLists.txt
+++ b/samples/printf/CMakeLists.txt
@@ -1,0 +1,15 @@
+# hiptest
+
+file(READ strings.xstdout STRINGS_XSTDOUT)
+add_chip_test(strings PrintfSimple ${STRINGS_XSTDOUT} strings.cc)
+
+file(READ nop_printfs.xstdout NOP_PRINTFS_XSTDOUT)
+add_chip_test(nop_printfs PrintfNOP ${NOP_PRINTFS_XSTDOUT} nop_printfs.cc)
+
+file(READ dynamic_str_args.xstdout DYNAMIC_STR_ARGS_XSTDOUT)
+add_chip_test(dynamic_str_args PrintfDynamic ${DYNAMIC_STR_ARGS_XSTDOUT} dynamic_str_args.cc)
+
+# Fails on Level0, so disabled for now.
+# We'd need to check this at test execution time.
+set_tests_properties(PrintfDynamic PROPERTIES DISABLED YES)
+

--- a/samples/printf/dynamic_str_args.cc
+++ b/samples/printf/dynamic_str_args.cc
@@ -31,17 +31,8 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include "printf_tests_common.h"
 
-extern "C" __device__ void _cl_print_str(const char *s) {
-  unsigned pos = 0;
-  char c;
-  while ((c = s[pos]) != 0) {
-    printf("%c", c);
-    ++pos;
-  }
-}
-
 __global__ void conditional_string(int *io) {
-  _cl_print_str("## conditional string\n");
+  printf("## conditional string\n");
 
   const char *dyn_a = "inout[0] was 1";
   const char *dyn_b = "inout[0] was something else than 1, it was";

--- a/samples/printf/dynamic_str_args.cc
+++ b/samples/printf/dynamic_str_args.cc
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+ * Test cases for %s with dynamic arguments.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+
+#include "hip/hip_runtime.h"
+#include "printf_tests_common.h"
+
+extern "C" __device__ void _cl_print_str(const char *s) {
+  unsigned pos = 0;
+  char c;
+  while ((c = s[pos]) != 0) {
+    printf("%c", c);
+    ++pos;
+  }
+}
+
+__global__ void conditional_string(int *io) {
+  _cl_print_str("## conditional string\n");
+
+  const char *dyn_a = "inout[0] was 1";
+  const char *dyn_b = "inout[0] was something else than 1, it was";
+  const char *str = nullptr;
+
+  if (io[0] == 1) {
+    str = dyn_a;
+  } else {
+    str = dyn_b;
+  }
+  io[0] = printf("%s %d\n", str, io[0]);
+}
+
+__global__ void array_of_strings(int *io) {
+  printf("## array of strings, selecting index %d\n", io[0]);
+
+  const char *dyn_a = "I am a dynamic str arg A.\n";
+  const char *dyn_b = "I am a dynamic str arg B.\n";
+
+  const char *array_of_strings[] = {dyn_a, dyn_b};
+
+  io[0] = printf("%s\n", array_of_strings[io[0]]);
+}
+
+__global__ void host_defined_strings(int *io, const char *str) {
+  io[0] = printf("## host defined string: %s", str);
+  io[0] += printf("## host defined string with skip: %s", str + 5);
+}
+
+int main(int argc, char *argv[]) {
+  uint num_threads = 1;
+  uint failures = 0;
+
+  void *retval_void;
+  CHECK(hipHostMalloc(&retval_void, 4 * num_threads), hipSuccess);
+  auto io = reinterpret_cast<int *>(retval_void);
+
+  io[0] = 1;
+  hipLaunchKernelGGL(conditional_string, dim3(1), dim3(1), 0, 0, io);
+  hipStreamSynchronize(0);
+
+  // Just smoke check the return values, the std output is verified by ctest.
+  CHECK_GT(io[0], 1);
+
+  io[0] = 1;
+
+  hipLaunchKernelGGL(array_of_strings, dim3(1), dim3(1), 0, 0, io);
+  hipStreamSynchronize(0);
+
+  CHECK_GT(io[0], 0);
+
+  const char *TrulyDyn = "Extremely dynamic printf str!\n";
+  char *TrulyDynB;
+  hipHostMalloc(&TrulyDynB, strlen(TrulyDyn) + 1);
+  memcpy(TrulyDynB, TrulyDyn, strlen(TrulyDyn) + 1);
+
+  hipLaunchKernelGGL(host_defined_strings, dim3(1), dim3(1), 0, 0, io,
+                     TrulyDynB);
+  hipStreamSynchronize(0);
+
+  CHECK_GT(io[0], 1);
+
+  printf((failures == 0) ? "PASSED!\n" : "FAILED!\n");
+  return (failures == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/samples/printf/dynamic_str_args.xstdout
+++ b/samples/printf/dynamic_str_args.xstdout
@@ -1,8 +1,1 @@
-## conditional string
-inout\[0\] was 1 1
-## array of strings, selecting index 1
-I am a dynamic str arg B.
-
-## host defined string: Extremely dynamic printf str!
-## host defined string with skip: mely dynamic printf str!
-PASSED!
+## conditional string.*inout\[0\] was 1 1.*## array of strings, selecting index 1.*I am a dynamic str arg B.*## host defined string: Extremely dynamic printf str!.*## host defined string with skip: mely dynamic printf str!.*PASSED!

--- a/samples/printf/dynamic_str_args.xstdout
+++ b/samples/printf/dynamic_str_args.xstdout
@@ -1,0 +1,8 @@
+## conditional string
+inout\[0\] was 1 1
+## array of strings, selecting index 1
+I am a dynamic str arg B.
+
+## host defined string: Extremely dynamic printf str!
+## host defined string with skip: mely dynamic printf str!
+PASSED!

--- a/samples/printf/nop_printfs.cc
+++ b/samples/printf/nop_printfs.cc
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+ * Test cases for NOP printfs which generate illegal output.
+ * The empty string (with a zeroinitializer) is converted to an
+ * OpConstantNull which causes (at least with LZ implementation)
+ * to print the first printed string again as it happens to be
+ * at 0 in the constant AS.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+
+#include "hip/hip_runtime.h"
+#include "printf_tests_common.h"
+
+__global__ void nop_str_arg(int *out) {
+  uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+  printf("Howdy HIPpies!\n");
+  out[tid] = printf("%s", ""); // Should be NOP except for the retval (1).
+  out[tid] += printf("");      // Should be NOP except for the retval (0).
+  out[tid] += printf("I'm correct since I'm not an empty string!\n");
+}
+
+int main(int argc, char *argv[]) {
+  uint num_threads = 1;
+  uint failures = 0;
+
+  void *retval_void;
+  CHECK(hipHostMalloc(&retval_void, 4 * num_threads), hipSuccess);
+  auto retval = reinterpret_cast<int *>(retval_void);
+
+  hipLaunchKernelGGL(nop_str_arg, dim3(1), dim3(1), 0, 0, retval);
+  hipStreamSynchronize(0);
+
+  for (uint ii = 0; ii != num_threads; ++ii) {
+#ifdef __HIP_PLATFORM_AMD__
+    CHECK(retval[ii], strlen(""));
+#else
+    CHECK(retval[ii], 1);
+#endif
+  }
+  printf((failures == 0) ? "PASSED!\n" : "FAILED!\n");
+}

--- a/samples/printf/nop_printfs.xstdout
+++ b/samples/printf/nop_printfs.xstdout
@@ -1,0 +1,3 @@
+Howdy HIPpies!
+I'm correct since I'm not an empty string!
+PASSED!

--- a/samples/printf/nop_printfs.xstdout
+++ b/samples/printf/nop_printfs.xstdout
@@ -1,3 +1,1 @@
-Howdy HIPpies!
-I'm correct since I'm not an empty string!
-PASSED!
+Howdy HIPpies!.*I'm correct since I'm not an empty string!.*PASSED!

--- a/samples/printf/printf_tests_common.h
+++ b/samples/printf/printf_tests_common.h
@@ -1,0 +1,47 @@
+/*
+Cpyright (c) -2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef CHIP_PRINTF_TESTS_COMMON_H
+#define CHIP_PRINTF_TESTS_COMMON_H
+
+#define CHECK(cmd, golden)                                              \
+  do {                                                                  \
+    auto produced = (cmd);                                              \
+    if (produced != golden) {                                           \
+      std::cerr << "Check failed: " << produced << " is not "           \
+                << golden << " at line " << __LINE__ << std::endl;      \
+      failures++;                                                       \
+    }                                                                   \
+  } while (0)                                                           \
+
+#define CHECK_GT(cmd, golden)                                           \
+  do {                                                                  \
+    auto produced = (cmd);                                              \
+    if (produced <= golden) {                                           \
+      std::cerr << "Check failed: " << produced << " is not greater "   \
+                << "than " << golden << " at line "                     \
+                << __LINE__ << std::endl;                               \
+      failures++;                                                       \
+    }                                                                   \
+  } while (0)                                                           \
+
+#endif

--- a/samples/printf/strings.cc
+++ b/samples/printf/strings.cc
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All rights reserved
+and 2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+ * Test cases for %s which are special cases due to OpenCL requiring their
+ * arguments to be literals. Some code adopted from hipPrintfBasic.cpp of
+ * the HIP test suite. Run only one work-item at a time since otherwise
+ * the printout (order) is undefined and difficult to check.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+
+#include "hip/hip_runtime.h"
+#include "printf_tests_common.h"
+
+__global__ void no_args(int *out) {
+  uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+  printf("## no_args\n");
+  out[tid] = printf("Hello\n");
+}
+
+__global__ void literal_str_arg(int *out) {
+  uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+  printf("## literal_str_arg\n");
+  out[tid] = printf("%s", "Hello");
+  out[tid] += printf(" %s\n", "strings.");
+}
+
+int main(int argc, char *argv[]) {
+  uint num_threads = 1;
+  uint failures = 0;
+
+  void *retval_void;
+  CHECK(hipHostMalloc(&retval_void, 4 * num_threads), hipSuccess);
+  auto retval = reinterpret_cast<int *>(retval_void);
+
+  hipLaunchKernelGGL(no_args, dim3(1), dim3(1), 0, 0, retval);
+  hipStreamSynchronize(0);
+
+  for (uint ii = 0; ii != num_threads; ++ii) {
+#ifdef __HIP_PLATFORM_AMD__
+    CHECK(retval[ii], strlen("Hello there.\n"));
+#else
+    CHECK(retval[ii], 0);
+#endif
+  }
+
+  hipLaunchKernelGGL(literal_str_arg, dim3(1), dim3(1), 0, 0, retval);
+  hipStreamSynchronize(0);
+
+  for (uint ii = 0; ii != num_threads; ++ii) {
+#ifdef __HIP_PLATFORM_AMD__
+    CHECK(retval[ii], 0);
+#else
+    CHECK(retval[ii], 2);
+#endif
+  }
+
+  printf((failures == 0) ? "PASSED!\n" : "FAILED!\n");
+}

--- a/samples/printf/strings.cc
+++ b/samples/printf/strings.cc
@@ -48,6 +48,9 @@ __global__ void literal_str_arg(int *out) {
   out[tid] += printf(" %s\n", "strings.");
 }
 
+#ifdef GENERIC_STR_ARGS_SUPPORTED
+// This ends up being a generic str arg case as the strings are casted to
+// generic before passing to the printf arg list.
 __global__ void var_str_arg(int *out) {
   uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
   const char *hello = "HELLO\n";
@@ -56,6 +59,7 @@ __global__ void var_str_arg(int *out) {
   out[tid] = printf("%s", hello);
   out[tid] += printf(" %s\n", strings);
 }
+#endif
 
 int main(int argc, char *argv[]) {
   uint num_threads = 1;
@@ -87,6 +91,7 @@ int main(int argc, char *argv[]) {
 #endif
   }
 
+#if GENERIC_STR_ARGS_SUPPORTED
   hipLaunchKernelGGL(var_str_arg, dim3(1), dim3(1), 0, 0, retval);
   hipStreamSynchronize(0);
 
@@ -97,5 +102,6 @@ int main(int argc, char *argv[]) {
     CHECK(retval[ii], 2);
 #endif
   }
+#endif
   printf((failures == 0) ? "PASSED!\n" : "FAILED!\n");
 }

--- a/samples/printf/strings.cc
+++ b/samples/printf/strings.cc
@@ -48,9 +48,6 @@ __global__ void literal_str_arg(int *out) {
   out[tid] += printf(" %s\n", "strings.");
 }
 
-#ifdef GENERIC_STR_ARGS_SUPPORTED
-// This ends up being a generic str arg case as the strings are casted to
-// generic before passing to the printf arg list.
 __global__ void var_str_arg(int *out) {
   uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
   const char *hello = "HELLO\n";
@@ -59,7 +56,6 @@ __global__ void var_str_arg(int *out) {
   out[tid] = printf("%s", hello);
   out[tid] += printf(" %s\n", strings);
 }
-#endif
 
 int main(int argc, char *argv[]) {
   uint num_threads = 1;
@@ -91,7 +87,6 @@ int main(int argc, char *argv[]) {
 #endif
   }
 
-#if GENERIC_STR_ARGS_SUPPORTED
   hipLaunchKernelGGL(var_str_arg, dim3(1), dim3(1), 0, 0, retval);
   hipStreamSynchronize(0);
 
@@ -102,6 +97,5 @@ int main(int argc, char *argv[]) {
     CHECK(retval[ii], 2);
 #endif
   }
-#endif
   printf((failures == 0) ? "PASSED!\n" : "FAILED!\n");
 }

--- a/samples/printf/strings.xstdout
+++ b/samples/printf/strings.xstdout
@@ -1,0 +1,5 @@
+## no_args
+Hello
+## literal_str_arg
+Hello strings.
+PASSED!

--- a/samples/printf/strings.xstdout
+++ b/samples/printf/strings.xstdout
@@ -1,5 +1,1 @@
-## no_args
-Hello
-## literal_str_arg
-Hello strings.
-PASSED!
+## no_args.*Hello.*## literal_str_arg.*Hello strings.*PASSED!

--- a/samples/printf/strings.xstdout
+++ b/samples/printf/strings.xstdout
@@ -1,1 +1,1 @@
-## no_args.*Hello.*## literal_str_arg.*Hello strings.*PASSED!
+## no_args.*Hello.*## literal_str_arg.*Hello strings.*## global_str_arg.*HELLO.* STRiNGS.*PASSED!

--- a/samples/printf/strings.xstdout
+++ b/samples/printf/strings.xstdout
@@ -2,4 +2,8 @@
 Hello
 ## literal_str_arg
 Hello strings.
+## global_str_arg
+HELLO
+ STRiNGS
+
 PASSED!

--- a/samples/printf/strings.xstdout
+++ b/samples/printf/strings.xstdout
@@ -2,8 +2,4 @@
 Hello
 ## literal_str_arg
 Hello strings.
-## global_str_arg
-HELLO
- STRiNGS
-
 PASSED!


### PR DESCRIPTION
Updates to the printf support with additional unit tests.

This is ready for a review to pull in to main, but please keep the following caveats in mind:
 * This needs an new patch to Clang that emits the literal strings to the global address space instead of the generic address space. @linehill is working on putting it to our default Clang branch and to the upstreaming queue.
 * Some of the tests fail on L0 which I suspect are issues with the Intel's compiler (yet to confirm). These pass with PoCL's spirv-fixes branch on a CPU device.
 * I haven't ran the new unit tests on AMD/HIP so the checks might need updating (I miss a AMD/HIP platform to test on).
 
