### PR TITLE
Adjust build dependences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,10 +179,11 @@ add_dependencies(UnitTests CHIP)
 set(CHIP_SAMPLE_BINDIR ${CMAKE_INSTALL_PREFIX}/bin/samples)
 add_subdirectory(./samples samples)
 
-
-add_dependencies(LLVMHipPasses kernellib_bc)
-add_dependencies(samples kernellib_bc)
-add_dependencies(CHIP kernellib_bc)
+# Make CHIP depend on kernellib_bc and LLVMHipPasses for
+# convenience. The CHIP module itself does not depend on these but
+# HIP program compilation does.
+add_dependencies(CHIP kernellib_bc LLVMHipPasses)
+add_dependencies(samples CHIP)
 
 set(CHIP_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
 set(CHIP_CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
* Make sure HIP LLVM passes are built before HIP programs are
  (samples, HIP tests).

* HIP LLVM passes do not depend on the kernel library. Remove the
  dependence.

* Make the CHIP module (the runtime) depend on kernel library and HIP
  LLVM passes for convenience. HIP compilation depend on all of the three.
  The runtime itself does not depend on the kernel library or the passes.