### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ if(NOT "${HIP_SPIRV_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}"
     message(FATAL_ERROR "Custom HIP_SPIRV_DIR=${HIP_SPIRV_DIR} was provided H that does not contain <HIP_SPIRV_DIR>/share/kernellib.bc")
 endif()
 
-set(CHIP_SPV_INCLUDE_FLAGS "" )
 set(CHIP_SPV_LINK_FLAGS "" )
 set(CHIP_SPV_COMPILE_FLAGS "" )
 
@@ -49,6 +48,11 @@ set(HIP_COMPILER clang)
 if(VERBOSE)
   set(CMAKE_VERBOSE_MAKEFILE ON)
   add_compile_options("-v")
+endif()
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  add_compile_options("-Wall")
 endif()
 
 if (ABORT_IF_NOT_IMPLEMENTED)
@@ -86,8 +90,6 @@ if((CMAKE_C_COMPILER_ID MATCHES "[Cc]lang") OR (CMAKE_C_COMPILER_ID MATCHES "Int
 else()
  message(FATAL_ERROR "this project must be compiled with clang. CMAKE_C_COMPILER_ID = ${CMAKE_C_COMPILER_ID}")
 endif()
-
-set(CHIP_SPV_INCLUDE_FLAGS ${CHIP_SPV_INCLUDE_FLAGS} src backend include . HIP/include ${OpenCL_INCLUDE_DIR})
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -166,11 +168,11 @@ target_include_directories(CHIP
         "${CMAKE_SOURCE_DIR}"
         "${CMAKE_SOURCE_DIR}/src"
         "${CMAKE_SOURCE_DIR}/include"
-        "${CMAKE_SOURCE_DIR}/HIP/include"
-        "${OpenCL_INCLUDE_DIR}"
 )
 
-
+target_include_directories(CHIP SYSTEM PRIVATE
+  "${CMAKE_SOURCE_DIR}/HIP/include"
+  "${OpenCL_INCLUDE_DIR}")
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/llvm_passes/HipPrintf.cpp
+++ b/llvm_passes/HipPrintf.cpp
@@ -48,7 +48,6 @@ Value* convertFormatString(Value *HipFmtStrArg, Instruction *Before,
 
   Module *M = Before->getParent()->getParent()->getParent();
 
-  Type *Int8Ty = IntegerType::get(M->getContext(), 8);
   ConstantExpr *CE = cast<ConstantExpr>(HipFmtStrArg);
 
   Value *FmtStrOpr = CE->getOperand(0);

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -300,7 +300,9 @@ hipError_t CHIPModule::allocateDeviceVariablesNoLock(CHIPDevice *Device,
   }
   auto Err =
       Queue->memCopyAsync(VarInfoBufH.get(), VarInfoBufD, VarInfoBufSize);
+  // There is no reason the copy would not succeed.
   assert(Err == hipSuccess);
+  (void)Err;
   Queue->finish();
 
   // Allocate storage for the device variables.
@@ -641,8 +643,7 @@ int CHIPDevice::getAttr(hipDeviceAttribute_t Attr) {
     break;
   case hipDeviceAttributeHdpMemFlushCntl:
   case hipDeviceAttributeHdpRegFlushCntl:
-    assert(false && "UNIMPLEMENTED");
-    return -1;
+    UNIMPLEMENTED(-1);
   case hipDeviceAttributeMaxPitch:
     return Prop.memPitch;
     break;
@@ -1470,7 +1471,7 @@ void CHIPQueue::launch(CHIPExecItem *ExecItem) {
       // there is no corresponding value in argument list.
       continue;
     void **k = reinterpret_cast<void **>(Args[InArgI++]);
-    assert(k);
+    assert(k); // Args list does not have nullpointers in it.
     void *DevPtr = reinterpret_cast<void *>(*k);
     void *HostPtr = AllocTracker->getAssociatedHostPtr(DevPtr);
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -438,7 +438,8 @@ size_t CHIPExecItem::getSharedMem() { return SharedMem_; }
 CHIPQueue *CHIPExecItem::getQueue() { return ChipQueue_; }
 // CHIPDevice
 //*************************************************************************************
-CHIPDevice::CHIPDevice(CHIPContext *Ctx) : Ctx_(Ctx) {}
+CHIPDevice::CHIPDevice(CHIPContext *Ctx, int DeviceIdx)
+    : Ctx_(Ctx), Idx_(DeviceIdx) {}
 
 CHIPDevice::CHIPDevice() {
   logDebug("Device {} is {}: name \"{}\" \n", Idx_, (void *)this,

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1082,7 +1082,7 @@ public:
    * @brief Destroy the CHIPContext object
    *
    */
-  ~CHIPContext();
+  virtual ~CHIPContext();
 
   virtual void syncQueues(CHIPQueue *TargetQueue);
 
@@ -1323,7 +1323,7 @@ public:
    * @brief Destroy the CHIPBackend objectk
    *
    */
-  ~CHIPBackend();
+  virtual ~CHIPBackend();
 
   /**
    * @brief Initialize this backend with given environment flags
@@ -1611,7 +1611,7 @@ public:
    * @brief Destroy the CHIPQueue object
    *
    */
-  ~CHIPQueue();
+  virtual ~CHIPQueue();
 
   CHIPQueueType getQueueType() { return QueueType_; }
   virtual void updateLastEvent(CHIPEvent *ChipEv) {

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -772,7 +772,7 @@ protected:
   /// Maps host-side shadow variables to the corresponding device variables.
   std::unordered_map<const void *, CHIPDeviceVar *> DeviceVarLookup_;
 
-  int Idx_;
+  int Idx_ = -1; // Initialized with a value indicating unset ID.
 
 public:
   size_t getMaxMallocSize() {
@@ -790,7 +790,7 @@ public:
    * @brief Construct a new CHIPDevice object
    *
    */
-  CHIPDevice(CHIPContext *Ctx);
+  CHIPDevice(CHIPContext *Ctx, int DeviceIdx);
 
   /**
    * @brief Construct a new CHIPDevice object

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -113,15 +113,13 @@ template <class T> std::string resultToString(T Err);
 
 enum class CHIPMemoryType : unsigned { Host = 0, Device = 1, Shared = 2 };
 class CHIPEventFlags {
-  bool Default_;
-  bool BlockingSync_;
-  bool DisableTiming_;
-  bool Interprocess_;
+  bool BlockingSync_ = false;
+  bool DisableTiming_ = false;
+  bool Interprocess_ = false;
 
 public:
+  CHIPEventFlags() = default;
   CHIPEventFlags(unsigned Flags) {
-    if (Flags & hipEventDefault)
-      Default_ = true;
     if (Flags & hipEventBlockingSync)
       BlockingSync_ = true;
     if (Flags & hipEventDisableTiming)
@@ -129,9 +127,10 @@ public:
     if (Flags & hipEventInterprocess)
       Interprocess_ = true;
   }
-  CHIPEventFlags() { CHIPEventFlags(hipEventDefault); }
 
-  bool isDefault() { return Default_; };
+  bool isDefault() {
+    return !BlockingSync_ && !DisableTiming_ && !Interprocess_;
+  };
   bool isBlockingSync() { return BlockingSync_; };
   bool isDisableTiming() { return DisableTiming_; };
   bool isInterprocess() { return Interprocess_; };

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1625,6 +1625,9 @@ hipError_t hipMemcpy2DFromArrayAsync(void *Dst, size_t DPitch,
   CHIPInitialize();
   NULLCHECK(Dst, Src);
 
+  if (!Width || !Height)
+    RETURN(hipSuccess);
+
   size_t ByteSize;
   if (Src) {
     switch (Src[0].desc.f) {

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1342,6 +1342,10 @@ hipError_t hipMemcpyAsync(void *Dst, const void *Src, size_t SizeBytes,
   CHIPInitialize();
   NULLCHECK(Dst);
   CHECK(Src);
+
+  if (SizeBytes == 0)
+    RETURN(hipSuccess);
+
   Stream = Backend->findQueue(Stream);
 
   // Stream->getDevice()->initializeDeviceVariables();
@@ -1374,6 +1378,9 @@ hipError_t hipMemcpy(void *Dst, const void *Src, size_t SizeBytes,
   CHIPInitialize();
   NULLCHECK(Dst);
   CHECK(Src);
+
+  if (SizeBytes == 0)
+    RETURN(hipSuccess);
 
   if (Kind == hipMemcpyHostToHost) {
     memcpy(Dst, Src, SizeBytes);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1123,7 +1123,9 @@ hipError_t hipHostRegister(void *HostPtr, size_t SizeBytes,
     }
 
   void *DevPtr;
-  hipMalloc(&DevPtr, SizeBytes);
+  auto Err = hipMalloc(&DevPtr, SizeBytes);
+  if (Err != hipSuccess)
+    RETURN(Err);
 
   // Associate the pointer
   auto Device = Backend->getActiveDevice();
@@ -1141,9 +1143,9 @@ hipError_t hipHostUnregister(void *HostPtr) {
 
   auto Device = Backend->getActiveDevice();
   auto AllocInfo = Device->AllocationTracker->getByHostPtr(HostPtr);
-  hipFree(AllocInfo->BasePtr);
+  auto Err = hipFree(AllocInfo->BasePtr);
   Device->AllocationTracker->unregsiterHostPointer(HostPtr);
-  RETURN(hipSuccess);
+  RETURN(Err);
 
   CHIP_CATCH
 }
@@ -1658,7 +1660,9 @@ hipError_t hipMemcpy2DFromArrayAsync(void *Dst, size_t DPitch,
   for (size_t Offset = 0; Offset < Height; ++Offset) {
     void *SrcP = ((unsigned char *)Src->data + Offset * SrcW);
     void *DstP = ((unsigned char *)Dst + Offset * DstW);
-    hipMemcpyAsync(DstP, SrcP, Width, Kind, Stream);
+    auto Err = hipMemcpyAsync(DstP, SrcP, Width, Kind, Stream);
+    if (Err != hipSuccess)
+      RETURN(Err);
   }
 
   RETURN(hipSuccess);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1124,8 +1124,7 @@ hipError_t hipHostRegister(void *HostPtr, size_t SizeBytes,
 
   void *DevPtr;
   auto Err = hipMalloc(&DevPtr, SizeBytes);
-  if (Err != hipSuccess)
-    RETURN(Err);
+  ERROR_IF(Err != hipSuccess, Err);
 
   // Associate the pointer
   auto Device = Backend->getActiveDevice();
@@ -1668,8 +1667,7 @@ hipError_t hipMemcpy2DFromArrayAsync(void *Dst, size_t DPitch,
     void *SrcP = ((unsigned char *)Src->data + Offset * SrcW);
     void *DstP = ((unsigned char *)Dst + Offset * DstW);
     auto Err = hipMemcpyAsync(DstP, SrcP, Width, Kind, Stream);
-    if (Err != hipSuccess)
-      RETURN(Err);
+    ERROR_IF(Err != hipSuccess, Err);
   }
 
   RETURN(hipSuccess);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -790,15 +790,13 @@ void *CHIPContextLevel0::allocateImpl(size_t Size, size_t Alignment,
 // ***********************************************************************
 CHIPDeviceLevel0::CHIPDeviceLevel0(ze_device_handle_t *ZeDev,
                                    CHIPContextLevel0 *ChipCtx, int Idx)
-    : CHIPDevice(ChipCtx), ZeDev_(*ZeDev), ZeCtx_(ChipCtx->get()) {
+    : CHIPDevice(ChipCtx, Idx), ZeDev_(*ZeDev), ZeCtx_(ChipCtx->get()) {
   assert(Ctx_ != nullptr);
-  Idx_ = Idx;
 }
 CHIPDeviceLevel0::CHIPDeviceLevel0(ze_device_handle_t &&ZeDev,
                                    CHIPContextLevel0 *ChipCtx, int Idx)
-    : CHIPDevice(ChipCtx), ZeDev_(ZeDev), ZeCtx_(ChipCtx->get()) {
+    : CHIPDevice(ChipCtx, Idx), ZeDev_(ZeDev), ZeCtx_(ChipCtx->get()) {
   assert(Ctx_ != nullptr);
-  Idx_ = Idx;
 }
 
 void CHIPDeviceLevel0::reset() { UNIMPLEMENTED(); }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -169,9 +169,9 @@ public:
   ze_context_handle_t ZeCtx;
   ze_driver_handle_t ZeDriver;
   CHIPContextLevel0(ze_driver_handle_t ZeDriver, ze_context_handle_t &&ZeCtx)
-      : ZeDriver(ZeDriver), ZeCtx(ZeCtx) {}
+      : ZeCtx(ZeCtx), ZeDriver(ZeDriver) {}
   CHIPContextLevel0(ze_driver_handle_t ZeDriver, ze_context_handle_t ZeCtx)
-      : ZeDriver(ZeDriver), ZeCtx(ZeCtx) {}
+      : ZeCtx(ZeCtx), ZeDriver(ZeDriver) {}
 
   void *allocateImpl(size_t Size, size_t Alignment,
                      CHIPMemoryType MemTy) override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -46,7 +46,7 @@ void CHIPDeviceOpenCL::destroyTexture(CHIPTexture *ChipTexture) {
 
 CHIPDeviceOpenCL::CHIPDeviceOpenCL(CHIPContextOpenCL *ChipCtx,
                                    cl::Device *DevIn, int Idx)
-    : CHIPDevice(ChipCtx), ClDevice(DevIn), ClContext(ChipCtx->get()) {
+    : CHIPDevice(ChipCtx, Idx), ClDevice(DevIn), ClContext(ChipCtx->get()) {
   logTrace("CHIPDeviceOpenCL initialized via OpenCL device pointer and context "
            "pointer");
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -5,15 +5,15 @@
 // CHIPCallbackDataLevel0
 // ************************************************************************
 
-CHIPCallbackDataOpenCL::CHIPCallbackDataOpenCL(hipStreamCallback_t CallbackF,
-                                               void *CallbackArgs,
+CHIPCallbackDataOpenCL::CHIPCallbackDataOpenCL(hipStreamCallback_t TheCallback,
+                                               void *TheCallbackArgs,
                                                CHIPQueue *ChipQueue)
     : ChipQueue((CHIPQueueOpenCL *)ChipQueue) {
-  if (CallbackArgs != nullptr)
-    CallbackArgs = CallbackArgs;
-  if (CallbackF == nullptr)
+  if (TheCallbackArgs != nullptr)
+    CallbackArgs = TheCallbackArgs;
+  if (TheCallback == nullptr)
     CHIPERR_LOG_AND_THROW("", hipErrorTbd);
-  CallbackF = CallbackF;
+  CallbackF = TheCallback;
 }
 
 // CHIPEventMonitorOpenCL
@@ -175,7 +175,6 @@ uint64_t CHIPEventOpenCL::getFinishTime() {
                                    sizeof(Ret), &Ret, NULL);
 
   if (Status != CL_SUCCESS) {
-    int UpdatedStatus;
     auto Status = clGetEventInfo(ClEvent, CL_EVENT_COMMAND_EXECUTION_STATUS,
                                  sizeof(int), &EventStatus_, NULL);
     CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
@@ -569,7 +568,6 @@ CHIPEvent *CHIPQueueOpenCL::launchImpl(CHIPExecItem *ExecItem) {
                                            Local, nullptr, &Ev);
 
   CHIPERR_CHECK_LOG_AND_THROW(Err, CL_SUCCESS, hipErrorTbd);
-  hipError_t Retval = hipSuccess;
 
   CHIPEventOpenCL *E =
       new CHIPEventOpenCL((CHIPContextOpenCL *)ChipContext_, Ev.get());


### PR DESCRIPTION
Fix issues introduced in #35 and other things:

* Fix failures due to uninitialized variables and missing checks.
* Add work around for kernels not working if `OptNoneINTEL` is present in the SPIR-V binary. Perhaps there is a bug in Level zero and Intel’s OpenCL?
* Add `-Wall` compilation option when the build mode is `Debug`.
* Fix compiler warnings.
