### PR TITLE
Bring the texture support for OpenCL

### DIFF
--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2022 Henry Linjamäki / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef SRC_UTILS_HH
+#define SRC_UTILS_HH
+
+/// Clamps 'Val' to [0, INT_MAX] range.
+static inline int clampToInt(size_t Val) {
+  return std::min<size_t>(Val, std::numeric_limits<int>::max());
+}
+
+#endif

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1,4 +1,5 @@
 #include "CHIPBackendLevel0.hh"
+#include "Utils.hh"
 
 static ze_image_type_t getImageType(unsigned HipTextureID) {
   switch (HipTextureID) {
@@ -1143,13 +1144,9 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
 
   // Clamp texture dimensions to [0, INT_MAX] because the return value
   // of hipDeviceGetAttribute() is int type.
-  auto ClampToInt = [](size_t Val) -> int {
-    auto MaxInt = std::numeric_limits<int>::max();
-    return std::min<int>(Val, MaxInt);
-  };
-  auto MaxDim0 = ClampToInt(DeviceImageProps.maxImageDims1D);
-  auto MaxDim1 = ClampToInt(DeviceImageProps.maxImageDims2D);
-  auto MaxDim2 = ClampToInt(DeviceImageProps.maxImageDims3D);
+  auto MaxDim0 = clampToInt(DeviceImageProps.maxImageDims1D);
+  auto MaxDim1 = clampToInt(DeviceImageProps.maxImageDims2D);
+  auto MaxDim2 = clampToInt(DeviceImageProps.maxImageDims3D);
 
   HipDeviceProps_.maxTexture1DLinear = MaxDim0;
   HipDeviceProps_.maxTexture1D = MaxDim0;
@@ -1203,7 +1200,6 @@ CHIPTexture *CHIPDeviceLevel0::createTexture(
     // Checked in CHIPBindings already.
     CHIPASSERT(Array->data && "Invalid hipArray.");
     CHIPASSERT(!Array->isDrv && "Not supported/implemented yet.");
-    auto TexelByteSize = getChannelByteSize(Array->desc);
     size_t Width = Array->width;
     size_t Height = Array->height;
     size_t Depth = Array->depth;
@@ -1212,30 +1208,15 @@ CHIPTexture *CHIPDeviceLevel0::createTexture(
         allocateImage(Array->textureType, Array->desc, NormalizedFloat, Width,
                       Height, Depth));
 
-    auto *Tex = new CHIPTextureLevel0(*PResDesc, ImageHandle, SamplerHandle);
-    logTrace("Created texture: {}", (void *)Tex);
+    auto Tex = std::make_unique<CHIPTextureLevel0>(*PResDesc, ImageHandle,
+                                                   SamplerHandle);
+    logTrace("Created texture: {}", (void *)Tex.get());
 
-    CHIPRegionDesc SrcDesc;
-    // TODO: sink logic into CHIPRegionDesc::fromHipArray().
-    switch (Array->textureType) {
-    default:
-      CHIPASSERT(false && "Unkown texture type.");
-      return nullptr;
-    case hipTextureType1D:
-      SrcDesc = CHIPRegionDesc::get1DRegion(Width, TexelByteSize);
-      break;
-    case hipTextureType2D:
-      SrcDesc = CHIPRegionDesc::get2DRegion(Width, Height, TexelByteSize);
-      break;
-    case hipTextureType3D:
-      SrcDesc =
-          CHIPRegionDesc::get3DRegion(Width, Height, Depth, TexelByteSize);
-      break;
-    }
-    Q->memCopyToImage(ImageHandle, Array->data, SrcDesc);
+    CHIPRegionDesc SrcRegion = CHIPRegionDesc::from(*Array);
+    Q->memCopyToImage(ImageHandle, Array->data, SrcRegion);
     Q->finish(); // Finish for safety.
 
-    return Tex;
+    return Tex.release();
   }
 
   if (PResDesc->resType == hipResourceTypeLinear) {
@@ -1246,15 +1227,16 @@ CHIPTexture *CHIPDeviceLevel0::createTexture(
     ze_image_handle_t ImageHandle = reinterpret_cast<ze_image_handle_t>(
         allocateImage(hipTextureType1D, Res.desc, NormalizedFloat, Width));
 
-    auto *Tex = new CHIPTextureLevel0(*PResDesc, ImageHandle, SamplerHandle);
-    logTrace("Created texture: {}", (void *)Tex);
+    auto Tex = std::make_unique<CHIPTextureLevel0>(*PResDesc, ImageHandle,
+                                                   SamplerHandle);
+    logTrace("Created texture: {}", (void *)Tex.get());
 
     // Copy data to image.
     auto SrcDesc = CHIPRegionDesc::get1DRegion(Width, TexelByteSize);
     Q->memCopyToImage(ImageHandle, Res.devPtr, SrcDesc);
     Q->finish(); // Finish for safety.
 
-    return Tex;
+    return Tex.release();
   }
 
   if (PResDesc->resType == hipResourceTypePitch2D) {
@@ -1266,15 +1248,16 @@ CHIPTexture *CHIPDeviceLevel0::createTexture(
         allocateImage(hipTextureType2D, Res.desc, NormalizedFloat, Res.width,
                       Res.height));
 
-    auto *Tex = new CHIPTextureLevel0(*PResDesc, ImageHandle, SamplerHandle);
-    logTrace("Created texture: {}", (void *)Tex);
+    auto Tex = std::make_unique<CHIPTextureLevel0>(*PResDesc, ImageHandle,
+                                                   SamplerHandle);
+    logTrace("Created texture: {}", (void *)Tex.get());
 
     // Copy data to image.
     auto SrcDesc = CHIPRegionDesc::from(*PResDesc);
     Q->memCopyToImage(ImageHandle, Res.devPtr, SrcDesc);
     Q->finish(); // Finish for safety.
 
-    return Tex;
+    return Tex.release();
   }
 
   CHIPASSERT(false && "Unsupported/unimplemented texture resource type.");


### PR DESCRIPTION
A follow up patch for #32. This brings the texture support to the OpenCL backend to the same level as Level Zero.