### PR TITLE
hipDeviceReset(): Clear device global variables.

### DIFF
--- a/samples/hipSymbol/CMakeLists.txt
+++ b/samples/hipSymbol/CMakeLists.txt
@@ -4,4 +4,6 @@ add_chip_test(hipTestDeviceSymbol hipTestDeviceSymbol PASSED
   hipTestDeviceSymbol.cpp)
 add_chip_test(hipTestConstantDeviceSymbol hipConstantTestDeviceSymbol PASSED
   hipTestConstantDeviceSymbol.cpp)
+add_chip_test(hipTestSymbolReset hipTestSymbolReset PASSED
+  hipTestSymbolReset.cc)
 

--- a/samples/hipSymbol/hipTestSymbolReset.cc
+++ b/samples/hipSymbol/hipTestSymbolReset.cc
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2022 Henry Linjamäki / Parmance for Argonne National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Check global device variables are reset to their initialization
+// value after hipDeviceReset() call.
+
+#include <hip/hip_runtime.h>
+#include "test_common.h"
+
+__device__ int A = 123;
+__constant__ int B = 321;
+
+__global__ void ReadAB(int *Out) {
+  Out[0] = A;
+  Out[1] = B;
+}
+
+int main() {
+  int AData = 1;
+  int BData = 2;
+  HIPCHECK(hipMemcpyToSymbol(A, &AData, sizeof(int)));
+  HIPCHECK(hipMemcpyToSymbol(B, &BData, sizeof(int)));
+
+  int *OutD;
+  HIPCHECK(hipMalloc(&OutD, 2 * sizeof(int)));
+  hipLaunchKernelGGL(ReadAB, dim3(1), dim3(1), 0, 0, OutD);
+
+  int OutH[2];
+  HIPCHECK(hipMemcpy(&OutH, OutD, 2 * sizeof(int), hipMemcpyDeviceToHost));
+  HIPASSERT(OutH[0] == 1);
+  HIPASSERT(OutH[1] == 2);
+
+  HIPCHECK(hipDeviceReset());
+
+  HIPCHECK(hipMemcpyFromSymbol(&OutH[0], A, sizeof(int)));
+  HIPCHECK(hipMemcpyFromSymbol(&OutH[1], B, sizeof(int)));
+  HIPASSERT(OutH[0] == 123);
+  HIPASSERT(OutH[1] == 321);
+
+  HIPCHECK(hipFree(OutD));
+  passed();
+}

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -972,6 +972,9 @@ void CHIPContext::reset() {
         Dev->AllocationTracker->TotalMemSize);
   AllocatedPtrs_.clear();
 
+  for (auto *Dev : ChipDevices_)
+    Dev->reset();
+
   // TODO Is all the state reset?
 }
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -912,7 +912,10 @@ public:
    the current process.
    *
    */
-  virtual void reset() = 0;
+  void reset() {
+    invalidateDeviceVariables();
+    resetImpl();
+  }
 
   /**
    * @brief Query for a specific device attribute. Implementation copied from
@@ -1054,6 +1057,12 @@ public:
   void initializeDeviceVariables();
   void invalidateDeviceVariables();
   void deallocateDeviceVariables();
+
+protected:
+  /**
+   * @brief The backend hook for reset().
+   */
+  virtual void resetImpl() = 0;
 };
 
 /**

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -799,7 +799,7 @@ CHIPDeviceLevel0::CHIPDeviceLevel0(ze_device_handle_t &&ZeDev,
   assert(Ctx_ != nullptr);
 }
 
-void CHIPDeviceLevel0::reset() { UNIMPLEMENTED(); }
+void CHIPDeviceLevel0::resetImpl() { UNIMPLEMENTED(); }
 
 void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
   ze_result_t Status = ZE_RESULT_SUCCESS;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -267,7 +267,7 @@ public:
   virtual void populateDevicePropertiesImpl() override;
   ze_device_handle_t &get() { return ZeDev_; }
 
-  virtual void reset() override;
+  virtual void resetImpl() override;
   virtual CHIPModuleLevel0 *addModule(std::string *ModuleStr) override {
     logTrace("CHIPModuleLevel0::addModule()");
     CHIPModuleLevel0 *Mod = new CHIPModuleLevel0(ModuleStr);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -148,7 +148,7 @@ void CHIPDeviceOpenCL::populateDevicePropertiesImpl() {
   HipDeviceProps_.maxSharedMemoryPerMultiProcessor = 0;
 }
 
-void CHIPDeviceOpenCL::reset() { UNIMPLEMENTED(); }
+void CHIPDeviceOpenCL::resetImpl() { UNIMPLEMENTED(); }
 // CHIPEventOpenCL
 // ************************************************************************
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -129,7 +129,7 @@ public:
                    int Idx);
   cl::Device *get();
   virtual void populateDevicePropertiesImpl() override;
-  virtual void reset() override;
+  virtual void resetImpl() override;
   virtual CHIPModuleOpenCL *addModule(std::string *ModuleStr) override;
   virtual CHIPQueue *addQueueImpl(unsigned int Flags, int Priority) override;
   virtual CHIPTexture *


### PR DESCRIPTION
When hipDeviceReset() is called, reset all global device variables to their initialization value.