### PR TITLE
Fix host transfer

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1094,7 +1094,6 @@ hipError_t CHIPContext::free(void *Ptr) {
 void CHIPBackend::uninitialize() {
   logDebug("CHIPBackend::uninitialize()");
   {
-    // std::lock_guard<std::mutex> LockCallbacks(Backend->CallbackQueueMtx);
     std::lock_guard<std::mutex> Lock(Backend->EventsMtx);
     for (auto q : Backend->getQueues()) {
       auto Ev = q->getLastEvent();

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1094,6 +1094,7 @@ hipError_t CHIPContext::free(void *Ptr) {
 void CHIPBackend::uninitialize() {
   logDebug("CHIPBackend::uninitialize()");
   {
+    // std::lock_guard<std::mutex> LockCallbacks(Backend->CallbackQueueMtx);
     std::lock_guard<std::mutex> Lock(Backend->EventsMtx);
     for (auto q : Backend->getQueues()) {
       auto Ev = q->getLastEvent();
@@ -1589,6 +1590,10 @@ void CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
     //                       hipErrorTbd);
     void *HostPtr = AllocInfo->HostPtr;
 
+    // If this is a shared pointer then we don't need to transfer data back
+    if (AllocInfo->MemoryType == hipMemoryTypeUnified)
+      continue;
+
     if (HostPtr) {
       auto AllocInfo = AllocTracker->getAllocInfo(DevPtr);
 
@@ -1596,14 +1601,14 @@ void CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
         logDebug("A hipHostRegister argument was found. Appending a mem copy "
                  "Host -> Device {} -> {}",
                  DevPtr, HostPtr);
-        auto Ev = this->memCopyImpl(DevPtr, HostPtr, AllocInfo->Size);
+        auto Ev = this->memCopyAsyncImpl(DevPtr, HostPtr, AllocInfo->Size);
         Ev->Msg = "hipHostRegisterMemCpyHostToDev";
         updateLastEvent(Ev);
       } else {
         logDebug("A hipHostRegister argument was found. Appending a mem copy "
                  "back to the host {} -> {}",
                  DevPtr, HostPtr);
-        auto Ev = this->memCopyImpl(HostPtr, DevPtr, AllocInfo->Size);
+        auto Ev = this->memCopyAsyncImpl(HostPtr, DevPtr, AllocInfo->Size);
         Ev->Msg = "hipHostRegisterMemCpyDevToHost";
         updateLastEvent(Ev);
       }


### PR DESCRIPTION
`RegisteredVarCopy` is a function that takes care of variable transfers to/from host for variables that have been registered via `hipHostRegister`

* No longer block on the host once the transfer has been enqueued since kernel launches are asynchronous, you must manually sync with the host by calling `hipDeviceSyncronize()` or equivalent. This sync would also take care of waiting on these inserted transfers.
* If memory is shared do not perform any transfers. 