### PR TITLE
OpenCL: Fix duplicate device reference in a context

### DIFF
--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -301,8 +301,6 @@ CHIPDeviceOpenCL::CHIPDeviceOpenCL(CHIPContextOpenCL *ChipCtx,
     : CHIPDevice(ChipCtx, Idx), ClDevice(DevIn), ClContext(ChipCtx->get()) {
   logTrace("CHIPDeviceOpenCL initialized via OpenCL device pointer and context "
            "pointer");
-
-  ChipCtx->addDevice(this);
 }
 
 void CHIPDeviceOpenCL::populateDevicePropertiesImpl() {


### PR DESCRIPTION
This fixes broken tests under samples/hipSymbol/.

The double addition of the CHIPDevice to a CHIPContext caused multiple
CHIPDeviceVar instances per global-scope device variable to be created
in a way that the host and kernels saw different device pointers. This
then caused the host and kernels not to see each other's writes to the
variables.