### PR TITLE
Interoperability improvements

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -32,7 +32,8 @@ function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
              )
 
     set_tests_properties("${TEST_NAME}" PROPERTIES
-             PASS_REGULAR_EXPRESSION "${TEST_PASS}")
+             PASS_REGULAR_EXPRESSION "${TEST_PASS}"
+             LABELS internal)
 
 
 endfunction()

--- a/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
+++ b/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
@@ -53,8 +53,8 @@ int main() {
   CHECK(hipMalloc((void **)&A_d, NUM * sizeof(int)));
   CHECK(hipMalloc((void **)&C_d, NUM * sizeof(int)));
   printf("info: copy Host2Device\n");
-  CHECK(hipMemcpy(A_d, A_d, NUM * sizeof(int), hipMemcpyHostToDevice));
-  CHECK(hipMemcpy(C_d, C_d, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(A_d, A_h, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(C_d, C_h, NUM * sizeof(int), hipMemcpyHostToDevice));
 
   hipStream_t q;
   uint32_t flags = hipStreamNonBlocking;

--- a/samples/hipStreamSemantics/hipStreamSemantics.cc
+++ b/samples/hipStreamSemantics/hipStreamSemantics.cc
@@ -36,7 +36,7 @@ __global__ void addCountReverse(const T *A_d, T *C_d, int64_t NELEM,
 }
 
 int main() {
-  int numBlocks = 5120000;
+  int numBlocks = 512000;
   int dimBlocks = 32;
   const size_t NUM = numBlocks * dimBlocks;
   int *A_h, *A_d, *Ref;
@@ -53,8 +53,8 @@ int main() {
   CHECK(hipMalloc((void **)&A_d, NUM * sizeof(int)));
   CHECK(hipMalloc((void **)&C_d, NUM * sizeof(int)));
   printf("info: copy Host2Device\n");
-  CHECK(hipMemcpy(A_d, A_d, NUM * sizeof(int), hipMemcpyHostToDevice));
-  CHECK(hipMemcpy(C_d, C_d, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(A_d, A_h, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(C_d, C_h, NUM * sizeof(int), hipMemcpyHostToDevice));
 
   hipStream_t q;
   uint32_t flags = hipStreamNonBlocking;

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -89,9 +89,9 @@ int main() {
 
   assert(stream != nullptr);
 
-  unsigned long nativeHandlers[4];
-  int numItems = 0;
-  error = hipStreamGetBackendHandles(stream, nativeHandlers, &numItems);
+  uintptr_t nativeHandlers[4];
+  int numItems = 4;
+  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
   CHECK(error);
 
   // Invoke oneMKL GEEM

--- a/samples/hip_sycl_interop/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop/hip_sycl_interop.h
@@ -3,7 +3,7 @@
 
 extern "C" {
   // Run GEMM test via oneMKL
-  int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
+  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
 		     int ldA, int ldB, int ldC, float alpha, float beta);
 }
 

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -53,7 +53,7 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C,
+int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C,
                    int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
                    float beta) {
   // Extract the native information

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -60,9 +60,10 @@ int main() {
   hipStream_t stream = nullptr;
   hipStreamCreate(&stream);
 
-  unsigned long nativeHandlers[4];
-  int numItems = 0;
-  hipStreamGetBackendHandles(stream, nativeHandlers, &numItems);
+  uintptr_t nativeHandlers[4];
+  int numItems = 4;
+  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
+  CHECK(error);
 
   // allocate memory
   hipMalloc(&d_A, WIDTH * WIDTH * sizeof(float));

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
@@ -3,7 +3,7 @@
 
 extern "C" {
   // Run GEMM test via oneMKL
-  int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
+  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
 		     int ldA, int ldB, int ldC, float alpha, float beta);
 }
 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -50,7 +50,7 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C,
+int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C,
                    int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
                    float beta) {
   // Extract the native information

--- a/samples/sycl_hip_interop/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_chip_interop.h
@@ -4,8 +4,7 @@
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-int hipInitFromOutside(void* driverPtr, void* deviePtr, void* contextPtr,
-                       void* queueptr);
+hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
 int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -73,11 +73,13 @@ int main() {
   if (Devs.size() >= 1) {
     // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
     // information
-    hipInitFromOutside(
-        Plt.template get_native<sycl::backend::level_zero>(),
-        Devs[0].template get_native<sycl::backend::level_zero>(),
-        Ctx.template get_native<sycl::backend::level_zero>(),
-        myQueue.template get_native<sycl::backend::level_zero>());
+    uintptr_t Args[] = {
+        (uintptr_t)Plt.template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)Devs[0].template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)Ctx.template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()
+      };
+    hipInitFromNativeHandles(Args, 4);
 
 #ifdef USM
     // Run GEMM test via CHIP-SPV Level-Zero Backend and USM data transfer

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
@@ -4,8 +4,7 @@
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-int hipInitFromOutside(void* driverPtr, void* deviePtr, void* contextPtr,
-                       void* queueptr);
+hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
 int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -823,6 +823,16 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(unsigned int Flags,
   return ChipQueue;
 }
 
+CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
+                                              int NumHandles) {
+  std::lock_guard<std::mutex> Lock(Mtx_);
+  auto ChipQueue = addQueueImpl(NativeHandles, NumHandles);
+  addQueue(ChipQueue);
+  return ChipQueue;
+}
+
+
+
 std::vector<CHIPQueue *> &CHIPDevice::getQueues() { return ChipQueues_; }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -888,7 +888,12 @@ bool CHIPDevice::hasPCIBusId(int PciDomainID, int PciBusID, int PciDeviceID) {
   return (T1 && T2 && T3);
 }
 
-CHIPQueue *CHIPDevice::getActiveQueue() { return ChipQueues_[0]; }
+CHIPQueue *CHIPDevice::getActiveQueue() {
+    if (ChipQueues_.size() > 0)
+        return ChipQueues_[ActiveQueueId_];
+    else
+        return nullptr;
+}
 
 hipError_t CHIPDevice::allocateDeviceVariables() {
   std::lock_guard<std::mutex> Lock(Mtx_);

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -970,22 +970,10 @@ std::vector<CHIPDevice *> &CHIPContext::getDevices() {
   return ChipDevices_;
 }
 
-std::vector<CHIPQueue *> &CHIPContext::getQueues() {
-  if (ChipQueues_.size() == 0) {
-    std::string Msg = "No queus in this context";
-    CHIPERR_LOG_AND_THROW(Msg, hipErrorUnknown);
-  }
-  return ChipQueues_;
-}
-
-void CHIPContext::finishAll() {
-  for (CHIPQueue *Queue : ChipQueues_)
-    Queue->finish();
-}
-
 void *CHIPContext::allocate(size_t Size, hipMemoryType MemType) {
   return allocate(Size, 0, MemType, CHIPHostAllocFlags());
 }
+
 void *CHIPContext::allocate(size_t Size, size_t Alignment,
                             hipMemoryType MemType) {
   return allocate(Size, Alignment, MemType, CHIPHostAllocFlags());

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1415,6 +1415,17 @@ public:
                CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) = 0;
 
   /**
+   * @brief Returns true if the pointer is USM (unified shared memory).
+   * Some backends (like OpenCL) always return USM independently of which
+   * hipMemoryType is requested in allocation
+   *
+   * @param Ptr pointer to memory allocated by allocate()
+   * @return true/false
+   */
+
+  virtual bool isAllocatedPtrUSM(void* Ptr) = 0;
+
+  /**
    * @brief Free memory
    *
    * @param ptr pointer to the memory location to be deallocated. Internally

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1324,7 +1324,6 @@ protected:
 class CHIPContext {
 protected:
   std::vector<CHIPDevice *> ChipDevices_;
-  std::vector<CHIPQueue *> ChipQueues_;
   std::vector<void *> AllocatedPtrs_;
 
   unsigned int Flags_;
@@ -1360,13 +1359,6 @@ public:
    * @return std::vector<CHIPDevice*>&
    */
   std::vector<CHIPDevice *> &getDevices();
-
-  /**
-   * @brief Get the this contexts CHIPQueues
-   *
-   * @return std::vector<CHIPQueue*>&
-   */
-  std::vector<CHIPQueue *> &getQueues();
 
   /**
    * @brief Allocate data.
@@ -1441,12 +1433,6 @@ public:
    * @return false
    */
   virtual void freeImpl(void *Ptr) = 0;
-
-  /**
-   * @brief Finish all the queues in this context
-   *
-   */
-  void finishAll();
 
   /**
    * @brief Get the flags set on this context

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -112,3 +112,41 @@ void CHIPUninitializeCallOnce() {
 extern void CHIPUninitialize() {
   std::call_once(Uninitialized, &CHIPUninitializeCallOnce);
 }
+
+extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles, int NumHandles) {
+    CHIPReadEnvVars();
+    logDebug("CHIPDriver REInitialize");
+
+    if (Backend)
+    {
+      logDebug("uninitializing existing Backend object.");
+      Backend->uninitialize();
+      delete Backend;
+    }
+
+    // TODO Check configuration for what backends are configured
+    if (!CHIPBackendType.compare("opencl")) {
+      if (UsingDefaultBackend)
+        logWarn("CHIP_BE was not set. Defaulting to OPENCL");
+      logDebug("CHIPBE=OPENCL... Initializing OpenCL Backend");
+      Backend = new CHIPBackendOpenCL();
+    } else if (!CHIPBackendType.compare("level0")) {
+      logDebug("CHIPBE=LEVEL0... Initializing Level0 Backend");
+      Backend = new CHIPBackendLevel0();
+    } else {
+      CHIPERR_LOG_AND_THROW(
+          "Invalid CHIP-SPV Backend Selected. Accepted values : level0, opencl.",
+          hipErrorInitializationError);
+    }
+
+    int RequiredHandles = Backend->ReqNumHandles();
+    if (RequiredHandles != NumHandles)  {
+        delete Backend;
+        CHIPERR_LOG_AND_THROW(
+            "Invalid number of native handles",
+            hipErrorInitializationError);
+    }
+
+    Backend->initializeFromNative(NativeHandles, NumHandles);
+    return hipSuccess;
+}

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -56,6 +56,5 @@ void CHIPInitializeCallOnce(std::string BackendStr = "");
 void CHIPUninitializeCallOnce();
 
 std::string read_env_var(std::string EnvVar, bool Lower);
-std::string read_backend_selection();
 
 #endif

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -55,6 +55,9 @@ void CHIPInitializeCallOnce(std::string BackendStr = "");
  */
 void CHIPUninitializeCallOnce();
 
+
+extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles, int NumHandles);
+
 std::string read_env_var(std::string EnvVar, bool Lower);
 
 #endif

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1125,7 +1125,7 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
       ChipL0Dev->populateDeviceProperties();
       ChipL0Ctx->addDevice(ChipL0Dev);
 
-      ChipL0Dev->createQueueAndRegister(0, 0);
+      ChipL0Dev->createQueueAndRegister((int)0, (int)0);
 
       Backend->addDevice(ChipL0Dev);
       break; // For now don't add more than one device

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -215,6 +215,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemTy,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
+  bool isAllocatedPtrUSM(void* Ptr) override { return false; } // TODO
   void freeImpl(void *Ptr) override{}; // TODO
   ze_context_handle_t &get() { return ZeCtx; }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1029,7 +1029,9 @@ int CHIPExecItemOpenCL::setupAllArgs(CHIPKernelOpenCL *Kernel) {
     for (size_t InArgIdx = 0, OutArgIdx = 0;
          OutArgIdx < FuncInfo->ArgTypeInfo.size(); ++OutArgIdx, ++InArgIdx) {
       OCLArgTypeInfo &Ai = FuncInfo->ArgTypeInfo[OutArgIdx];
-      if (Ai.Type == OCLType::Pointer && Ai.Space != OCLSpace::Local) {
+      if (Ai.Type == OCLType::Pointer) {
+        if (Ai.Space == OCLSpace::Local)
+            continue;
         logTrace("clSetKernelArgSVMPointer {} SIZE {} to {}\n", OutArgIdx,
                  Ai.Size, ArgsPointer_[InArgIdx]);
         CHIPASSERT(Ai.Size == sizeof(void *));

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -118,6 +118,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemType,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
+  bool isAllocatedPtrUSM(void* Ptr) override { return true; }
   virtual void freeImpl(void *Ptr) override;
   cl::Context *get();
 };

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -19,7 +19,10 @@
 
 #include <CL/cl_ext_intel.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-braces"
 #include <CL/opencl.hpp>
+#pragma GCC diagnostic pop
 
 #include "../../CHIPBackend.hh"
 #include "exceptions.hh"

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -86,7 +86,7 @@ protected:
 public:
   CHIPModuleOpenCL(std::string *ModuleStr);
   virtual void compile(CHIPDevice *ChipDevice) override;
-  cl::Program &get();
+  cl::Program *get();
 };
 
 class SVMemoryRegion {
@@ -146,8 +146,6 @@ public:
 class CHIPQueueOpenCL : public CHIPQueue {
 protected:
   // Any reason to make these private/protected?
-  cl::Context *ClContext_;
-  cl::Device *ClDevice_;
   cl::CommandQueue *ClQueue_;
 
 public:
@@ -194,7 +192,7 @@ public:
                    OCLFuncInfo *FuncInfo, CHIPModuleOpenCL *Parent);
   OCLFuncInfo *getFuncInfo() const;
   std::string getName();
-  cl::Kernel get() const;
+  cl::Kernel *get();
   size_t getTotalArgSize() const;
 
   CHIPModuleOpenCL *getModule() override { return Module; }


### PR DESCRIPTION
changes some existing APIs, adds new, implemented for both backends

 - hipInitFromNativeHandles() replaces hipInitFromOutside()
 - hipGetBackendNativeHandles() replaces hipStreamGetBackendHandles()
 - implement them both for OpenCL & Level0
 - two new APIs, hipGetNativeEventFromHipEvent & hipGetHipEventFromNativeEvent
   to make async interop possible (implemented for OpenCL & Level0)

plus some minor bugfixes. I will add some tests for the async interop soon. Running ctest with OpenCL backend on Intel Skylake results in `87% tests passed, 51 tests failed out of 379`.