### PR TITLE
HIP-SYCL Interoperability 

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -32,7 +32,8 @@ function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
              )
 
     set_tests_properties("${TEST_NAME}" PROPERTIES
-             PASS_REGULAR_EXPRESSION "${TEST_PASS}")
+             PASS_REGULAR_EXPRESSION "${TEST_PASS}"
+             LABELS internal)
 
 
 endfunction()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-#include(/home/pvelesko/CHIP-SPV/install/cmake/CHIP/CHIPTargets.cmake)
+# include(/home/pvelesko/CHIP-SPV/install/cmake/CHIP/CHIPTargets.cmake)
 option(SAVE_TEMPS "Save temporary compilation products" OFF)
 option(VERBOSE "Verbose compilation" OFF)
 
@@ -13,98 +12,92 @@ endif()
 
 # ARGN = test args
 function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
+  set(TEST_EXEC_ARGS ${ARGN})
+  set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CXX)
 
-    set(TEST_EXEC_ARGS ${ARGN})
-    set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CXX)
+  add_executable("${EXEC_NAME}" ${SOURCE})
 
-    add_executable("${EXEC_NAME}" ${SOURCE})
+  target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
+  set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
 
-    target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
-    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+  target_link_libraries("${EXEC_NAME}" CHIP)
+  target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
+  install(TARGETS "${EXEC_NAME}"
+    RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
 
-    target_link_libraries("${EXEC_NAME}" CHIP)
-    target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
-    install(TARGETS "${EXEC_NAME}"
-            RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
+  add_test(NAME "${TEST_NAME}"
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${TEST_EXEC_ARGS}
+  )
 
-    add_test(NAME "${TEST_NAME}"
-             COMMAND "${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}" ${TEST_EXEC_ARGS}
-             )
-
-    set_tests_properties("${TEST_NAME}" PROPERTIES
-             PASS_REGULAR_EXPRESSION "${TEST_PASS}"
-             LABELS internal)
-
-
+  set_tests_properties("${TEST_NAME}" PROPERTIES
+    PASS_REGULAR_EXPRESSION "${TEST_PASS}"
+    LABELS internal)
 endfunction()
-
 
 # ARGN = sources
 function(add_chip_binary EXEC_NAME)
+  set(SOURCES ${ARGN})
+  set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
 
-    set(SOURCES ${ARGN})
-    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
+  add_executable("${EXEC_NAME}" ${SOURCES})
 
-    add_executable("${EXEC_NAME}" ${SOURCES})
+  target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
+  set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+  target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
+  target_link_libraries("${EXEC_NAME}" CHIP)
 
-    target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
-    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
-    target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
-    target_link_libraries("${EXEC_NAME}" CHIP)
-
-    install(TARGETS "${EXEC_NAME}"
-            RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
-
+  install(TARGETS "${EXEC_NAME}"
+    RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
 endfunction()
 
 function(add_chip_library EXEC_NAME)
+  set(SOURCES ${ARGN})
+  set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
 
-    set(SOURCES ${ARGN})
-    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
+  add_library("${EXEC_NAME}" STATIC ${SOURCES})
 
-    add_library("${EXEC_NAME}" STATIC ${SOURCES})
+  target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
+  set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
 
-    target_compile_options("${EXEC_NAME}" PRIVATE ${OFFLOAD_ARCH_STR})
-    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
-
-    target_link_libraries("${EXEC_NAME}" CHIP)
-    target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
-
+  target_link_libraries("${EXEC_NAME}" CHIP)
+  target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
 endfunction()
 
 set(SAMPLES
-    abort
-    hipmath
-    hiptest
-    bit_extract
-    hcc_dialects
-    fp16
-    0_MatrixTranspose
-    0_MatrixMultiply
-    1_hipEvent
-    2_vecadd
-    3_shared_memory
-    4_shfl
-    5_2dshfl
-    6_dynamic_shared
-    7_streams
-    9_unroll
-    10_memcpy3D
-    11_device
-    hipStreamSemantics
-    hipKernelLaunchIsNonBlocking
-    #hipMultiThreadAddCallback
-    hipInfo
-    hipSymbol
-    hip-cuda
-    printf
-    texture
-    hipDeviceLink # must be last in this list due to how hacky using multiple compilers with CMake is
+  abort
+  hipmath
+  hiptest
+  bit_extract
+  hcc_dialects
+  fp16
+  0_MatrixTranspose
+  0_MatrixMultiply
+  1_hipEvent
+  2_vecadd
+  3_shared_memory
+  4_shfl
+  5_2dshfl
+  6_dynamic_shared
+  7_streams
+  9_unroll
+  10_memcpy3D
+  11_device
+  hipStreamSemantics
+  hipKernelLaunchIsNonBlocking
+
+  # hipMultiThreadAddCallback
+  hipInfo
+  hipSymbol
+  hip-cuda
+  printf
+  texture
+  hipDeviceLink # must be last in this list due to how hacky using multiple compilers with CMake is
 )
 
 # Add samples that depend on Intel's oneAPI compiler - if available.
 find_program(ICPX_EXECUTABLE NAMES icpx)
-if (ICPX_EXECUTABLE)
+
+if(ICPX_EXECUTABLE)
   list(APPEND SAMPLES
     sycl_hip_interop
     hip_sycl_interop
@@ -114,8 +107,9 @@ else()
 endif()
 
 add_custom_target(samples DEPENDS ${SAMPLES})
-foreach (SAMPLE ${SAMPLES})
+
+foreach(SAMPLE ${SAMPLES})
   add_subdirectory(${SAMPLE})
 endforeach()
 
-#add_subdirectory(hip-cuda)
+# add_subdirectory(hip-cuda)

--- a/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
+++ b/samples/hipKernelLaunchIsNonBlocking/hipKernelLaunchIsNonBlocking.cc
@@ -53,8 +53,8 @@ int main() {
   CHECK(hipMalloc((void **)&A_d, NUM * sizeof(int)));
   CHECK(hipMalloc((void **)&C_d, NUM * sizeof(int)));
   printf("info: copy Host2Device\n");
-  CHECK(hipMemcpy(A_d, A_d, NUM * sizeof(int), hipMemcpyHostToDevice));
-  CHECK(hipMemcpy(C_d, C_d, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(A_d, A_h, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(C_d, C_h, NUM * sizeof(int), hipMemcpyHostToDevice));
 
   hipStream_t q;
   uint32_t flags = hipStreamNonBlocking;

--- a/samples/hipStreamSemantics/hipStreamSemantics.cc
+++ b/samples/hipStreamSemantics/hipStreamSemantics.cc
@@ -36,7 +36,7 @@ __global__ void addCountReverse(const T *A_d, T *C_d, int64_t NELEM,
 }
 
 int main() {
-  int numBlocks = 5120000;
+  int numBlocks = 512000;
   int dimBlocks = 32;
   const size_t NUM = numBlocks * dimBlocks;
   int *A_h, *A_d, *Ref;
@@ -53,8 +53,8 @@ int main() {
   CHECK(hipMalloc((void **)&A_d, NUM * sizeof(int)));
   CHECK(hipMalloc((void **)&C_d, NUM * sizeof(int)));
   printf("info: copy Host2Device\n");
-  CHECK(hipMemcpy(A_d, A_d, NUM * sizeof(int), hipMemcpyHostToDevice));
-  CHECK(hipMemcpy(C_d, C_d, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(A_d, A_h, NUM * sizeof(int), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(C_d, C_h, NUM * sizeof(int), hipMemcpyHostToDevice));
 
   hipStream_t q;
   uint32_t flags = hipStreamNonBlocking;

--- a/samples/hip_sycl_interop/CMakeLists.txt
+++ b/samples/hip_sycl_interop/CMakeLists.txt
@@ -3,12 +3,13 @@ add_subdirectory(onemkl_gemm_wrapper)
 add_chip_binary(hip_sycl_interop hip_sycl_interop.cpp)
 add_dependencies(build_tests_standalone hip_sycl_interop)
 target_link_libraries(hip_sycl_interop onemkl_gemm_wrapper)
+target_include_directories(hip_sycl_interop PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
 
 add_test(NAME "hip_sycl_interop"
-         COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop" 
-         )
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop"
+)
 
 set_tests_properties("hip_sycl_interop" PROPERTIES
-         PASS_REGULAR_EXPRESSION "${TEST_PASS}"
-         TIMEOUT 60
-         )
+    PASS_REGULAR_EXPRESSION "${TEST_PASS}"
+    TIMEOUT 60
+)

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -8,6 +8,11 @@
 
 #include "hip_sycl_interop.h"
 
+// must declare this here since it's not part of the standard HIP API
+extern "C" hipError_t hipGetBackendNativeHandles(hipStream_t Stream,
+                                                 uintptr_t *NativeHandles,
+                                                 int *NumHandles);
+
 using namespace std;
 
 const int WIDTH = 10;

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -89,9 +89,9 @@ int main() {
 
   assert(stream != nullptr);
 
-  unsigned long nativeHandlers[4];
-  int numItems = 0;
-  error = hipStreamGetBackendHandles(stream, nativeHandlers, &numItems);
+  uintptr_t nativeHandlers[4];
+  int numItems = 4;
+  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
   CHECK(error);
 
   // Invoke oneMKL GEEM

--- a/samples/hip_sycl_interop/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop/hip_sycl_interop.h
@@ -2,9 +2,10 @@
 #define __HIPLZ_SYCL_INTEROP_H__
 
 extern "C" {
-  // Run GEMM test via oneMKL
-  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
-		     int ldA, int ldB, int ldC, float alpha, float beta);
+// Run GEMM test via oneMKL
+int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A, float *B, float *C,
+                   int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
+                   float beta);
 }
 
 #endif

--- a/samples/hip_sycl_interop/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop/hip_sycl_interop.h
@@ -3,7 +3,7 @@
 
 extern "C" {
   // Run GEMM test via oneMKL
-  int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
+  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
 		     int ldA, int ldB, int ldC, float alpha, float beta);
 }
 

--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -53,7 +53,7 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C,
+int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C,
                    int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
                    float beta) {
   // Extract the native information

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -1,12 +1,16 @@
-#include "hip/hip_runtime.h"
-
 // STL classes
 #include <exception>
 #include <iostream>
 
+#include "hip/hip_runtime.h"
 #include <vector>
-
+#include <cmath>
 #include "hip_sycl_interop.h"
+
+// must declare this here since it's not part of the standard HIP API
+extern "C" hipError_t hipGetBackendNativeHandles(hipStream_t Stream,
+                                                 uintptr_t *NativeHandles,
+                                                 int *NumHandles);
 
 using namespace std;
 
@@ -62,8 +66,8 @@ int main() {
 
   uintptr_t nativeHandlers[4];
   int numItems = 4;
-  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
-  CHECK(error);
+  auto error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
+  assert(error == hipSuccess);
 
   // allocate memory
   hipMalloc(&d_A, WIDTH * WIDTH * sizeof(float));

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -60,9 +60,10 @@ int main() {
   hipStream_t stream = nullptr;
   hipStreamCreate(&stream);
 
-  unsigned long nativeHandlers[4];
-  int numItems = 0;
-  hipStreamGetBackendHandles(stream, nativeHandlers, &numItems);
+  uintptr_t nativeHandlers[4];
+  int numItems = 4;
+  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
+  CHECK(error);
 
   // allocate memory
   hipMalloc(&d_A, WIDTH * WIDTH * sizeof(float));

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.h
@@ -3,7 +3,7 @@
 
 extern "C" {
   // Run GEMM test via oneMKL
-  int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
+  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
 		     int ldA, int ldB, int ldC, float alpha, float beta);
 }
 

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -50,7 +50,7 @@ int onemkl_gemm(sycl::queue& my_queue, float* A, float* B, float* C, int m,
 }
 
 // Run GEMM test via oneMKL
-int oneMKLGemmTest(unsigned long* nativeHandlers, float* A, float* B, float* C,
+int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C,
                    int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
                    float beta) {
   // Extract the native information

--- a/samples/sycl_hip_interop/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_chip_interop.h
@@ -4,8 +4,7 @@
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-int hipInitFromOutside(void* driverPtr, void* deviePtr, void* contextPtr,
-                       void* queueptr);
+hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
 int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,

--- a/samples/sycl_hip_interop/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_chip_interop.h
@@ -1,17 +1,18 @@
 #ifndef __sycl_chip_interop_H__
 #define __sycl_chip_interop_H__
+#include <cstdint>
 
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
+int hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
-int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,
+int hipMatrixMultiplicationUSMTest(const float *A, const float *B, float *C,
                                    int M, int N);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend
-int hipMatrixMultiplicationTest(const float* A, const float* B, float* C, int M,
+int hipMatrixMultiplicationTest(const float *A, const float *B, float *C, int M,
                                 int N);
 }
 

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
@@ -3,8 +3,10 @@ set(CMAKE_CXX_FLAGS "")
 
 add_executable(sycl_chip_interop sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader -Wl,-rpath=${CHIP_DIR_}/build ${CHIP_CMAKE_INSTALL_LIBDIR})
-target_link_libraries(sycl_chip_interop PRIVATE ${CHIP_DIR_}/build/samples/sycl_hip_interop/libhipMatrixMul.a -L${CHIP_DIR_}/build -lCHIP -lOpenCL -pthread)
+
+# Warning the use of manual linking here using -lCHIP is on purpose due to conflicting opencl headers that get loaded otherwise.
+target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}/../../.. ${CHIP_CMAKE_INSTALL_LIBDIR})
+target_link_libraries(sycl_chip_interop PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../libhipMatrixMul.a -L${CMAKE_CURRENT_BINARY_DIR}/../../.. -lCHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop PRIVATE -fsycl -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
@@ -21,8 +23,10 @@ set_tests_properties("sycl_chip_interop" PROPERTIES
 
 add_executable(sycl_chip_interop_usm sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop_usm CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader -Wl,-rpath=${CHIP_DIR_}/build ${CHIP_CMAKE_INSTALL_LIBDIR})
-target_link_libraries(sycl_chip_interop_usm PRIVATE -L${CHIP_DIR_}/build/samples/sycl_hip_interop -lhipMatrixMul -L${CHIP_DIR_}/build -lCHIP -lOpenCL -pthread)
+
+# Warning the use of manual linking here using -lCHIP is on purpose due to conflicting opencl headers that get loaded otherwise.
+target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}/../../.. ${CHIP_CMAKE_INSTALL_LIBDIR})
+target_link_libraries(sycl_chip_interop_usm PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../libhipMatrixMul.a -L${CMAKE_CURRENT_BINARY_DIR}/../../.. -lCHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop_usm PRIVATE -fsycl -DUSM -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop_usm
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -73,11 +73,13 @@ int main() {
   if (Devs.size() >= 1) {
     // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
     // information
-    hipInitFromOutside(
-        Plt.template get_native<sycl::backend::level_zero>(),
-        Devs[0].template get_native<sycl::backend::level_zero>(),
-        Ctx.template get_native<sycl::backend::level_zero>(),
-        myQueue.template get_native<sycl::backend::level_zero>());
+    uintptr_t Args[] = {
+        (uintptr_t)Plt.template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)Devs[0].template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)Ctx.template get_native<sycl::backend::level_zero>(),
+        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()
+      };
+    hipInitFromNativeHandles(Args, 4);
 
 #ifdef USM
     // Run GEMM test via CHIP-SPV Level-Zero Backend and USM data transfer

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -1,5 +1,4 @@
 #include <stdint.h>
-
 #include "level_zero/ze_api.h"
 #include <CL/sycl.hpp>
 #include <CL/sycl/stl.hpp>
@@ -77,8 +76,7 @@ int main() {
         (uintptr_t)Plt.template get_native<sycl::backend::level_zero>(),
         (uintptr_t)Devs[0].template get_native<sycl::backend::level_zero>(),
         (uintptr_t)Ctx.template get_native<sycl::backend::level_zero>(),
-        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()
-      };
+        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()};
     hipInitFromNativeHandles(Args, 4);
 
 #ifdef USM

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
@@ -2,17 +2,15 @@
 #define __sycl_chip_interop_H__
 
 extern "C" {
-// Initialize CHIP-SPV Level-Zero Backend via providing native runtime
-// information
-hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
+// must declare this here since it's not part of the standard HIP API
+int hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
-int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,
+int hipMatrixMultiplicationUSMTest(const float *A, const float *B, float *C,
                                    int M, int N);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend
-int hipMatrixMultiplicationTest(const float* A, const float* B, float* C, int M,
+int hipMatrixMultiplicationTest(const float *A, const float *B, float *C, int M,
                                 int N);
 }
-
 #endif

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
@@ -4,8 +4,7 @@
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-int hipInitFromOutside(void* driverPtr, void* deviePtr, void* contextPtr,
-                       void* queueptr);
+hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
 int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -823,6 +823,16 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(unsigned int Flags,
   return ChipQueue;
 }
 
+CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
+                                              int NumHandles) {
+  std::lock_guard<std::mutex> Lock(Mtx_);
+  auto ChipQueue = addQueueImpl(NativeHandles, NumHandles);
+  addQueue(ChipQueue);
+  return ChipQueue;
+}
+
+
+
 std::vector<CHIPQueue *> &CHIPDevice::getQueues() { return ChipQueues_; }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -888,7 +888,12 @@ bool CHIPDevice::hasPCIBusId(int PciDomainID, int PciBusID, int PciDeviceID) {
   return (T1 && T2 && T3);
 }
 
-CHIPQueue *CHIPDevice::getActiveQueue() { return ChipQueues_[0]; }
+CHIPQueue *CHIPDevice::getActiveQueue() {
+    if (ChipQueues_.size() > 0)
+        return ChipQueues_[ActiveQueueId_];
+    else
+        return nullptr;
+}
 
 hipError_t CHIPDevice::allocateDeviceVariables() {
   std::lock_guard<std::mutex> Lock(Mtx_);

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -970,22 +970,10 @@ std::vector<CHIPDevice *> &CHIPContext::getDevices() {
   return ChipDevices_;
 }
 
-std::vector<CHIPQueue *> &CHIPContext::getQueues() {
-  if (ChipQueues_.size() == 0) {
-    std::string Msg = "No queus in this context";
-    CHIPERR_LOG_AND_THROW(Msg, hipErrorUnknown);
-  }
-  return ChipQueues_;
-}
-
-void CHIPContext::finishAll() {
-  for (CHIPQueue *Queue : ChipQueues_)
-    Queue->finish();
-}
-
 void *CHIPContext::allocate(size_t Size, hipMemoryType MemType) {
   return allocate(Size, 0, MemType, CHIPHostAllocFlags());
 }
+
 void *CHIPContext::allocate(size_t Size, size_t Alignment,
                             hipMemoryType MemType) {
   return allocate(Size, Alignment, MemType, CHIPHostAllocFlags());

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -137,8 +137,9 @@ void CHIPAllocationTracker::recordAllocation(void *DevPtr, void *HostPtr,
   if (HostPtr)
     PtrToAllocInfo_[HostPtr] = AllocInfo;
 
-  logDebug("CHIPAllocationTracker::recordAllocation size: {} HOST {} DEV {} TYPE {}",
-           Size, HostPtr, DevPtr, (unsigned)MemoryType);
+  logDebug(
+      "CHIPAllocationTracker::recordAllocation size: {} HOST {} DEV {} TYPE {}",
+      Size, HostPtr, DevPtr, (unsigned)MemoryType);
   return;
 }
 
@@ -742,6 +743,10 @@ int CHIPDevice::getAttr(hipDeviceAttribute_t Attr) {
 
 size_t CHIPDevice::getGlobalMemSize() { return HipDeviceProps_.totalGlobalMem; }
 
+void CHIPDevice::addModule(const std::string *ModuleStr, CHIPModule *Module) {
+  this->ChipModules[ModuleStr] = Module;
+}
+
 void CHIPDevice::registerFunctionAsKernel(std::string *ModuleStr,
                                           const void *HostFPtr,
                                           const char *HostFName) {
@@ -831,8 +836,6 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
   return ChipQueue;
 }
 
-
-
 std::vector<CHIPQueue *> &CHIPDevice::getQueues() { return ChipQueues_; }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,
@@ -899,10 +902,10 @@ bool CHIPDevice::hasPCIBusId(int PciDomainID, int PciBusID, int PciDeviceID) {
 }
 
 CHIPQueue *CHIPDevice::getActiveQueue() {
-    if (ChipQueues_.size() > 0)
-        return ChipQueues_[ActiveQueueId_];
-    else
-        return nullptr;
+  if (ChipQueues_.size() > 0)
+    return ChipQueues_[ActiveQueueId_];
+  else
+    return nullptr;
 }
 
 hipError_t CHIPDevice::allocateDeviceVariables() {

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1027,7 +1027,8 @@ public:
    */
   CHIPQueue *createQueueAndRegister(unsigned int Flags, int Priority);
 
-  CHIPQueue *createQueueAndRegister(const uintptr_t *NativeHandles, int NumHandles);
+  CHIPQueue *createQueueAndRegister(const uintptr_t *NativeHandles,
+                                    int NumHandles);
 
   size_t getMaxMallocSize() {
     if (MaxMallocSize_ < 1)
@@ -1116,7 +1117,8 @@ public:
    * in chip_queues vector)
    */
   virtual CHIPQueue *addQueueImpl(unsigned int Flags, int Priority) = 0;
-  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles, int NumHandles) = 0;
+  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles,
+                                  int NumHandles) = 0;
 
   /**
    * @brief Add a queue to this device
@@ -1299,6 +1301,7 @@ public:
                               const char *Name, size_t Size);
 
   virtual CHIPModule *addModule(std::string *ModuleStr) = 0;
+  void addModule(const std::string *ModuleStr, CHIPModule *Module);
 
   virtual CHIPTexture *
   createTexture(const hipResourceDesc *ResDesc, const hipTextureDesc *TexDesc,
@@ -1426,7 +1429,7 @@ public:
    * @return true/false
    */
 
-  virtual bool isAllocatedPtrUSM(void* Ptr) = 0;
+  virtual bool isAllocatedPtrUSM(void *Ptr) = 0;
 
   /**
    * @brief Free memory
@@ -1584,7 +1587,8 @@ public:
    * @param device_type_str
    * @param device_ids_str
    */
-  virtual void initializeFromNative(const uintptr_t *NativeHandles, int NumHandles) = 0;
+  virtual void initializeFromNative(const uintptr_t *NativeHandles,
+                                    int NumHandles) = 0;
 
   /**
    * @brief
@@ -1770,8 +1774,8 @@ public:
   virtual CHIPEventMonitor *createStaleEventMonitor() = 0;
 
   /* event interop */
-  virtual hipEvent_t getHipEvent(void* NativeEvent) = 0;
-  virtual void* getNativeEvent(hipEvent_t HipEvent) = 0;
+  virtual hipEvent_t getHipEvent(void *NativeEvent) = 0;
+  virtual void *getNativeEvent(hipEvent_t HipEvent) = 0;
 };
 
 /**
@@ -2053,10 +2057,13 @@ public:
    *
    * @param NativeHandles storage for handles
    * @param NumHandles variable to hold number of returned handles
-   * @return for Level0 backend, returns { ze_driver_handle_t, ze_device_handle_t, ze_context_handle_t, ze_command_queue_handle_t }
-   * @return for OpenCL backend, returns { cl_platform_id, cl_device_id, cl_context, cl_command_queue }
+   * @return for Level0 backend, returns { ze_driver_handle_t,
+   * ze_device_handle_t, ze_context_handle_t, ze_command_queue_handle_t }
+   * @return for OpenCL backend, returns { cl_platform_id, cl_device_id,
+   * cl_context, cl_command_queue }
    */
-  virtual hipError_t getBackendHandles(uintptr_t *NativeHandles, int *NumHandles) = 0;
+  virtual hipError_t getBackendHandles(uintptr_t *NativeHandles,
+                                       int *NumHandles) = 0;
 
   CHIPContext *getContext() { return ChipContext_; }
 };

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1415,6 +1415,17 @@ public:
                CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) = 0;
 
   /**
+   * @brief Returns true if the pointer is USM (unified shared memory).
+   * Some backends (like OpenCL) always return USM independently of which
+   * hipMemoryType is requested in allocation
+   *
+   * @param Ptr pointer to memory allocated by allocate()
+   * @return true/false
+   */
+
+  virtual bool isAllocatedPtrUSM(void* Ptr) = 0;
+
+  /**
    * @brief Free memory
    *
    * @param ptr pointer to the memory location to be deallocated. Internally

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1324,7 +1324,6 @@ protected:
 class CHIPContext {
 protected:
   std::vector<CHIPDevice *> ChipDevices_;
-  std::vector<CHIPQueue *> ChipQueues_;
   std::vector<void *> AllocatedPtrs_;
 
   unsigned int Flags_;
@@ -1360,13 +1359,6 @@ public:
    * @return std::vector<CHIPDevice*>&
    */
   std::vector<CHIPDevice *> &getDevices();
-
-  /**
-   * @brief Get the this contexts CHIPQueues
-   *
-   * @return std::vector<CHIPQueue*>&
-   */
-  std::vector<CHIPQueue *> &getQueues();
 
   /**
    * @brief Allocate data.
@@ -1441,12 +1433,6 @@ public:
    * @return false
    */
   virtual void freeImpl(void *Ptr) = 0;
-
-  /**
-   * @brief Finish all the queues in this context
-   *
-   */
-  void finishAll();
 
   /**
    * @brief Get the flags set on this context

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -3164,38 +3164,6 @@ hipError_t hipSetupArgument(const void *Arg, size_t Size, size_t Offset) {
   CHIP_CATCH
 }
 
-// TODO make generic with Size and pointer
-extern "C" hipError_t hipInitFromOutside(void *DriverPtr, void *DevicePtr,
-                                         void *ContexPtr, void *QueuePtr) {
-  logDebug("hipInitFromOutside");
-  auto Modules = std::move(Backend->getDevices()[0]->getModules());
-  {
-    std::lock_guard<std::mutex> LockCallbacks(Backend->CallbackQueueMtx);
-    std::lock_guard<std::mutex> LockEvents(Backend->EventsMtx);
-    delete Backend;
-  }
-  logDebug("deleting Backend object.");
-  Backend = new CHIPBackendLevel0();
-
-  ze_context_handle_t Ctx = (ze_context_handle_t)ContexPtr;
-  ze_driver_handle_t Driver = (ze_driver_handle_t)DriverPtr;
-  CHIPContextLevel0 *ChipCtx = new CHIPContextLevel0(Driver, Ctx);
-  Backend->addContext(ChipCtx);
-
-  ze_device_handle_t Dev = (ze_device_handle_t)DevicePtr;
-  auto Idx = 0; // All devices should have been deleted
-  CHIPDeviceLevel0 *ChipDev = new CHIPDeviceLevel0(&Dev, ChipCtx, Idx);
-  ChipDev->ChipModules = Modules;
-  Backend->ChipContexts[0]->getDevices().push_back(ChipDev);
-  Backend->addDevice(ChipDev);
-
-  // ze_command_queue_handle_t q = (ze_command_queue_handle_t)queuePtr;
-  ChipDev->createQueueAndRegister(0, 0);
-  Backend->setActiveDevice(ChipDev);
-
-  RETURN(hipSuccess);
-}
-
 extern "C" void
 __hipRegisterVar(void **Data,
                  void *Var,        // The shadow variable in host code
@@ -3321,15 +3289,54 @@ hipError_t hipGetDeviceFlags(unsigned int *Flags) {
   CHIP_CATCH
 }
 
-/**
- * Query the hip Stream related native informtions
- */
-hipError_t hipStreamGetBackendHandles(hipStream_t Stream,
-                                      unsigned long *NativeInfo, int *Size) {
-  logDebug("hipStreamGetBackendHandles");
-  ERROR_IF((Stream == nullptr), hipErrorInvalidValue);
-  Stream->getBackendHandles(NativeInfo, Size);
+/************************************************************
+ ************************************************************
+ ************************************************************/
 
-  return hipSuccess;
+extern "C" hipError_t hipGetBackendNativeHandles(hipStream_t Stream,
+                                      uintptr_t *NativeHandles, int *NumHandles) {
+  logDebug("hipGetBackendNativeHandles");
+  ERROR_IF((Stream == nullptr), hipErrorInvalidValue);
+  return Stream->getBackendHandles(NativeHandles, NumHandles);
 }
+
+extern "C" hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles) {
+    CHIP_TRY
+    logDebug("hipInitFromNativeHandles");
+    RETURN(CHIPReinitialize(NativeHandles, NumHandles));
+    CHIP_CATCH
+}
+
+extern "C" void* hipGetNativeEventFromHipEvent(hipEvent_t Event)
+{
+    logDebug("hipGetNativeEventFromHipEvent");
+    void *e = nullptr;
+    CHIP_TRY
+    CHIPInitialize();
+
+    if (Event == NULL)
+        return NULL;
+
+    e = Backend->getNativeEvent(Event);
+    CHIP_CATCH_NO_RETURN
+    return e;
+}
+
+extern "C" hipEvent_t hipGetHipEventFromNativeEvent(void* Event)
+{
+    logDebug("hipGetHipEventFromNativeEvent");
+    hipEvent_t e = nullptr;
+    CHIP_TRY
+    CHIPInitialize();
+
+    if (Event == NULL)
+        return NULL;
+
+    e = Backend->getHipEvent(Event);
+    CHIP_CATCH_NO_RETURN
+    return e;
+}
+
+
+
 #endif

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -3308,8 +3308,6 @@ extern "C" int hipInitFromNativeHandles(const uintptr_t *NativeHandles,
                                         int NumHandles) {
   CHIP_TRY
   logDebug("hipInitFromNativeHandles");
-  // TODO fix this
-  // RETURN(CHIPReinitialize(NativeHandles, NumHandles));
   auto Err = CHIPReinitialize(NativeHandles, NumHandles);
   if (Err == hipSuccess)
     return 0;

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -112,3 +112,41 @@ void CHIPUninitializeCallOnce() {
 extern void CHIPUninitialize() {
   std::call_once(Uninitialized, &CHIPUninitializeCallOnce);
 }
+
+extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles, int NumHandles) {
+    CHIPReadEnvVars();
+    logDebug("CHIPDriver REInitialize");
+
+    if (Backend)
+    {
+      logDebug("uninitializing existing Backend object.");
+      Backend->uninitialize();
+      delete Backend;
+    }
+
+    // TODO Check configuration for what backends are configured
+    if (!CHIPBackendType.compare("opencl")) {
+      if (UsingDefaultBackend)
+        logWarn("CHIP_BE was not set. Defaulting to OPENCL");
+      logDebug("CHIPBE=OPENCL... Initializing OpenCL Backend");
+      Backend = new CHIPBackendOpenCL();
+    } else if (!CHIPBackendType.compare("level0")) {
+      logDebug("CHIPBE=LEVEL0... Initializing Level0 Backend");
+      Backend = new CHIPBackendLevel0();
+    } else {
+      CHIPERR_LOG_AND_THROW(
+          "Invalid CHIP-SPV Backend Selected. Accepted values : level0, opencl.",
+          hipErrorInitializationError);
+    }
+
+    int RequiredHandles = Backend->ReqNumHandles();
+    if (RequiredHandles != NumHandles)  {
+        delete Backend;
+        CHIPERR_LOG_AND_THROW(
+            "Invalid number of native handles",
+            hipErrorInitializationError);
+    }
+
+    Backend->initializeFromNative(NativeHandles, NumHandles);
+    return hipSuccess;
+}

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -56,6 +56,5 @@ void CHIPInitializeCallOnce(std::string BackendStr = "");
 void CHIPUninitializeCallOnce();
 
 std::string read_env_var(std::string EnvVar, bool Lower);
-std::string read_backend_selection();
 
 #endif

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -55,6 +55,9 @@ void CHIPInitializeCallOnce(std::string BackendStr = "");
  */
 void CHIPUninitializeCallOnce();
 
+
+extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles, int NumHandles);
+
 std::string read_env_var(std::string EnvVar, bool Lower);
 
 #endif

--- a/src/CHIPDriver.hh
+++ b/src/CHIPDriver.hh
@@ -55,8 +55,8 @@ void CHIPInitializeCallOnce(std::string BackendStr = "");
  */
 void CHIPUninitializeCallOnce();
 
-
-extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles, int NumHandles);
+extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
+                                   int NumHandles);
 
 std::string read_env_var(std::string EnvVar, bool Lower);
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1124,7 +1124,7 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
       ChipL0Dev->populateDeviceProperties();
       ChipL0Ctx->addDevice(ChipL0Dev);
 
-      ChipL0Dev->createQueueAndRegister(0, 0);
+      ChipL0Dev->createQueueAndRegister((int)0, (int)0);
 
       Backend->addDevice(ChipL0Dev);
       break; // For now don't add more than one device

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -237,6 +237,11 @@ CHIPEventLevel0::CHIPEventLevel0(CHIPContextLevel0 *ChipCtx,
                               "Level Zero Event_ creation fail! ");
 }
 
+CHIPEventLevel0::CHIPEventLevel0(CHIPContextLevel0 *ChipCtx,
+                                 ze_event_handle_t NativeEvent)
+    : CHIPEvent((CHIPContext *)(ChipCtx)),
+      Event_(NativeEvent), EventPool_(nullptr), Timestamp_(0) {}
+
 void CHIPEventLevel0::takeOver(CHIPEvent *OtherIn) {
   // Take over target queues Event_
   CHIPEventLevel0 *Other = (CHIPEventLevel0 *)OtherIn;
@@ -590,6 +595,53 @@ CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, unsigned int Flags)
 CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev)
     : CHIPQueueLevel0(ChipDev, 0, 0) {}
 
+void CHIPQueueLevel0::initializeEventPool(CHIPDeviceLevel0 *ChipDev) {
+    ze_result_t Status;
+    auto ChipContextLz = (CHIPContextLevel0 *)ChipDev->getContext();
+
+    // Initialize the internal Event_ pool and finish Event_
+    ze_event_pool_desc_t EpDesc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr,
+                                   ZE_EVENT_POOL_FLAG_HOST_VISIBLE,
+                                   1 /* Count */};
+
+    ze_event_desc_t EvDesc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr,
+                              0, /* Index */
+                              ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
+    uint32_t NumDevices = 1;
+    Status = zeEventPoolCreate(ZeCtx_, &EpDesc, NumDevices, &ZeDev_, &EventPool_);
+
+    CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd,
+                                "zeEventPoolCreate FAILED");
+
+    Status = zeEventCreate(EventPool_, &EvDesc, &FinishEvent_);
+    CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd,
+                                "zeEventCreate FAILED with return code");
+
+    // Initialize the shared memory buffer
+    // TODO This does not record the buffer allocation in device allocation
+    // tracker
+    SharedBuf_ =
+        ChipContextLz->allocateImpl(32, 8, hipMemoryType::hipMemoryTypeUnified);
+
+    // Initialize the uint64_t part as 0
+    *(uint64_t *)this->SharedBuf_ = 0;
+    /**
+     * queues should always have lastEvent. Can't do this in the constuctor
+     * because enqueueMarker is virtual and calling overriden virtual methods
+     * from constructors is undefined behavior.
+     *
+     * Also, must call implementation method enqueueMarker_ as opposed to
+     * wrapped one (enqueueMarker) because the wrapped method enforces queue
+     * semantics which require LastEvent to be initialized.
+     *
+     */
+    std::lock_guard<std::mutex> LockEvents(Backend->EventsMtx);
+    auto Ev = enqueueMarker();
+    Ev->Msg = "InitialMarker";
+}
+
+
+
 CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, unsigned int Flags,
                                  int Priority)
     : CHIPQueue(ChipDev, Flags, Priority) {
@@ -601,8 +653,7 @@ CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, unsigned int Flags,
   ZeCtx_ = ChipContextLz->get();
   ZeDev_ = ChipDevLz->get();
 
-  logTrace("CHIPQueueLevel0 constructor called via CHIPContextLevel0 and "
-           "CHIPDeviceLevel0");
+  logTrace("CHIPQueueLevel0 constructor called via Flags and Priority");
 
   // Discover all command queue groups
   uint32_t CmdqueueGroupCount = 0;
@@ -712,46 +763,38 @@ CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, unsigned int Flags,
 #else
 #endif
 
-  // Initialize the internal Event_ pool and finish Event_
-  ze_event_pool_desc_t EpDesc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr,
-                                 ZE_EVENT_POOL_FLAG_HOST_VISIBLE,
-                                 1 /* Count */};
-
-  ze_event_desc_t EvDesc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr,
-                            0, /* Index */
-                            ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
-  uint32_t NumDevices = 1;
-  Status = zeEventPoolCreate(ZeCtx_, &EpDesc, NumDevices, &ZeDev_, &EventPool_);
-
-  CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd,
-                              "zeEventPoolCreate FAILED");
-
-  Status = zeEventCreate(EventPool_, &EvDesc, &FinishEvent_);
-  CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd,
-                              "zeEventCreate FAILED with return code");
-
-  // Initialize the shared memory buffer
-  // TODO This does not record the buffer allocation in device allocation
-  // tracker
-  SharedBuf_ =
-      ChipContextLz->allocateImpl(32, 8, hipMemoryType::hipMemoryTypeUnified);
-
-  // Initialize the uint64_t part as 0
-  *(uint64_t *)this->SharedBuf_ = 0;
-  /**
-   * queues should always have lastEvent. Can't do this in the constuctor
-   * because enqueueMarker is virtual and calling overriden virtual methods
-   * from constructors is undefined behavior.
-   *
-   * Also, must call implementation method enqueueMarker_ as opposed to
-   * wrapped one (enqueueMarker) because the wrapped method enforces queue
-   * semantics which require LastEvent to be initialized.
-   *
-   */
-  std::lock_guard<std::mutex> LockEvents(Backend->EventsMtx);
-  auto Ev = enqueueMarker();
-  Ev->Msg = "InitialMarker";
+  initializeEventPool(ChipDev);
 }
+
+CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev,
+                                 ze_command_queue_handle_t ZeQue)
+    : CHIPQueue(ChipDev, 0, 0) {
+    auto ChipDevLz = ChipDev;
+    auto Ctx = ChipDevLz->getContext();
+    auto ChipContextLz = (CHIPContextLevel0 *)Ctx;
+
+    ZeCtx_ = ChipContextLz->get();
+    ZeDev_ = ChipDevLz->get();
+
+    ZeCmdQ_ = ZeQue;
+#ifdef L0_IMM_QUEUES
+    // Create an immediate command list
+    Status = zeCommandListCreateImmediate(
+        ZeCtx_, ZeDev_, &CommandQueueComputeDesc, &ZeCmdListComputeImm_);
+    CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS,
+                                hipErrorInitializationError);
+    logTrace("Created an immediate compute list");
+    // Create an immediate command list for copy engine
+    Status = zeCommandListCreateImmediate(ZeCtx_, ZeDev_, &CommandQueueCopyDesc,
+                                          &ZeCmdListCopyImm_);
+    CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS,
+                                hipErrorInitializationError);
+    logTrace("Created an immediate copy list");
+#else
+#endif
+    initializeEventPool(ChipDev);
+}
+
 
 CHIPEvent *CHIPQueueLevel0::launchImpl(CHIPExecItem *ExecItem) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
@@ -894,23 +937,28 @@ CHIPEvent *CHIPQueueLevel0::memCopyToImage(ze_image_handle_t Image,
   return Ev;
 };
 
-void CHIPQueueLevel0::getBackendHandles(unsigned long *NativeInfo, int *Size) {
+hipError_t CHIPQueueLevel0::getBackendHandles(uintptr_t *NativeInfo, int *NumHandles) {
   logTrace("CHIPQueueLevel0::getBackendHandles");
-  *Size = 4;
+  if (*NumHandles < 4) {
+       logError("getBackendHandles requires space for 4 handles");
+       return hipErrorInvalidValue;
+  }
+  *NumHandles = 4;
 
   // Get queue handler
-  NativeInfo[3] = (unsigned long)ZeCmdQ_;
+  NativeInfo[3] = (uintptr_t)ZeCmdQ_;
 
   // Get context handler
   CHIPContextLevel0 *Ctx = (CHIPContextLevel0 *)ChipContext_;
-  NativeInfo[2] = (unsigned long)Ctx->get();
+  NativeInfo[2] = (uintptr_t)Ctx->get();
 
   // Get device handler
   CHIPDeviceLevel0 *Dev = (CHIPDeviceLevel0 *)ChipDevice_;
-  NativeInfo[1] = (unsigned long)Dev->get();
+  NativeInfo[1] = (uintptr_t)Dev->get();
 
   // Get driver handler
-  NativeInfo[0] = (unsigned long)Ctx->ZeDriver;
+  NativeInfo[0] = (uintptr_t)Ctx->ZeDriver;
+  return hipSuccess;
 }
 
 CHIPEvent *CHIPQueueLevel0::enqueueMarkerImpl() {
@@ -1134,6 +1182,41 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
   StaleEventMonitor =
       (CHIPStaleEventMonitorLevel0 *)Backend->createStaleEventMonitor();
 }
+
+
+void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles, int NumHandles) {
+    logTrace("CHIPBackendLevel0 InitializeNative");
+
+    ze_driver_handle_t Drv = (ze_driver_handle_t)NativeHandles[0];
+    ze_device_handle_t Dev = (ze_device_handle_t)NativeHandles[1];
+    ze_context_handle_t Ctx = (ze_context_handle_t)NativeHandles[2];
+
+    CHIPContextLevel0 *ChipCtx = new CHIPContextLevel0(Drv, Ctx);
+    addContext(ChipCtx);
+
+    CHIPDeviceLevel0 *ChipDev = new CHIPDeviceLevel0(&Dev, ChipCtx, 0);
+    ChipCtx->addDevice(ChipDev);
+    addDevice(ChipDev);
+
+    ChipDev->createQueueAndRegister(NativeHandles, NumHandles);
+
+    setActiveDevice(ChipDev);
+}
+
+hipEvent_t CHIPBackendLevel0::getHipEvent(void* NativeEvent) {
+    ze_event_handle_t E = (ze_event_handle_t)NativeEvent;
+    // TODO should we make refc == 2 ?
+    CHIPEventLevel0 *NewEvent =
+        new CHIPEventLevel0((CHIPContextLevel0 *)ActiveCtx_, E);
+    return NewEvent;
+}
+
+void* CHIPBackendLevel0::getNativeEvent(hipEvent_t HipEvent) {
+    CHIPEventLevel0 *E = (CHIPEventLevel0 *)HipEvent;
+    // TODO should we retain here?
+    return (void*)E->get();
+}
+
 
 // CHIPContextLevelZero
 // ***********************************************************************
@@ -1393,6 +1476,14 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
 
 CHIPQueue *CHIPDeviceLevel0::addQueueImpl(unsigned int Flags, int Priority) {
   CHIPQueueLevel0 *NewQ = new CHIPQueueLevel0(this, Flags, Priority);
+  return NewQ;
+}
+
+CHIPQueue *CHIPDeviceLevel0::addQueueImpl(const uintptr_t *NativeHandles,
+                                          int NumHandles) {
+  ze_command_queue_handle_t CmdQ = (ze_command_queue_handle_t)NativeHandles[3];
+
+  CHIPQueueLevel0 *NewQ = new CHIPQueueLevel0(this, CmdQ);
   return NewQ;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -215,6 +215,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemTy,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
+  bool isAllocatedPtrUSM(void* Ptr) override { return false; } // TODO
   void freeImpl(void *Ptr) override{}; // TODO
   ze_context_handle_t &get() { return ZeCtx; }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1029,7 +1029,9 @@ int CHIPExecItemOpenCL::setupAllArgs(CHIPKernelOpenCL *Kernel) {
     for (size_t InArgIdx = 0, OutArgIdx = 0;
          OutArgIdx < FuncInfo->ArgTypeInfo.size(); ++OutArgIdx, ++InArgIdx) {
       OCLArgTypeInfo &Ai = FuncInfo->ArgTypeInfo[OutArgIdx];
-      if (Ai.Type == OCLType::Pointer && Ai.Space != OCLSpace::Local) {
+      if (Ai.Type == OCLType::Pointer) {
+        if (Ai.Space == OCLSpace::Local)
+            continue;
         logTrace("clSetKernelArgSVMPointer {} SIZE {} to {}\n", OutArgIdx,
                  Ai.Size, ArgsPointer_[InArgIdx]);
         CHIPASSERT(Ai.Size == sizeof(void *));

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -118,6 +118,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemType,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
+  bool isAllocatedPtrUSM(void* Ptr) override { return true; }
   virtual void freeImpl(void *Ptr) override;
   cl::Context *get();
 };

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -19,7 +19,10 @@
 
 #include <CL/cl_ext_intel.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-braces"
 #include <CL/opencl.hpp>
+#pragma GCC diagnostic pop
 
 #include "../../CHIPBackend.hh"
 #include "exceptions.hh"

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -121,7 +121,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemType,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
-  bool isAllocatedPtrUSM(void* Ptr) override { return true; }
+  bool isAllocatedPtrUSM(void *Ptr) override { return true; }
   virtual void freeImpl(void *Ptr) override;
   cl::Context *get();
 };
@@ -137,7 +137,8 @@ public:
   virtual void resetImpl() override;
   virtual CHIPModuleOpenCL *addModule(std::string *ModuleStr) override;
   virtual CHIPQueue *addQueueImpl(unsigned int Flags, int Priority) override;
-  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles, int NumHandles) override;
+  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles,
+                                  int NumHandles) override;
 
   virtual CHIPTexture *
   createTexture(const hipResourceDesc *ResDesc, const hipTextureDesc *TexDesc,
@@ -178,7 +179,8 @@ public:
                                         size_t Width, size_t Height,
                                         size_t Depth) override;
 
-  virtual hipError_t getBackendHandles(uintptr_t *NativeInfo, int *NumHandles) override;
+  virtual hipError_t getBackendHandles(uintptr_t *NativeInfo,
+                                       int *NumHandles) override;
   virtual CHIPEvent *
   enqueueBarrierImpl(std::vector<CHIPEvent *> *EventsToWaitFor) override;
   virtual CHIPEvent *enqueueMarkerImpl() override;
@@ -219,7 +221,8 @@ public:
   virtual void initializeImpl(std::string CHIPPlatformStr,
                               std::string CHIPDeviceTypeStr,
                               std::string CHIPDeviceStr) override;
-  virtual void initializeFromNative(const uintptr_t *NativeHandles, int NumHandles) override;
+  virtual void initializeFromNative(const uintptr_t *NativeHandles,
+                                    int NumHandles) override;
 
   virtual std::string getDefaultJitFlags() override;
 
@@ -235,9 +238,8 @@ public:
   virtual CHIPEventMonitor *createCallbackEventMonitor() override;
   virtual CHIPEventMonitor *createStaleEventMonitor() override;
 
-  virtual hipEvent_t getHipEvent(void* NativeEvent) override;
-  virtual void* getNativeEvent(hipEvent_t HipEvent) override;
-
+  virtual hipEvent_t getHipEvent(void *NativeEvent) override;
+  virtual void *getNativeEvent(hipEvent_t HipEvent) override;
 };
 
 class CHIPTextureOpenCL : public CHIPTexture {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -86,7 +86,7 @@ protected:
 public:
   CHIPModuleOpenCL(std::string *ModuleStr);
   virtual void compile(CHIPDevice *ChipDevice) override;
-  cl::Program &get();
+  cl::Program *get();
 };
 
 class SVMemoryRegion {
@@ -146,8 +146,6 @@ public:
 class CHIPQueueOpenCL : public CHIPQueue {
 protected:
   // Any reason to make these private/protected?
-  cl::Context *ClContext_;
-  cl::Device *ClDevice_;
   cl::CommandQueue *ClQueue_;
 
 public:
@@ -194,7 +192,7 @@ public:
                    OCLFuncInfo *FuncInfo, CHIPModuleOpenCL *Parent);
   OCLFuncInfo *getFuncInfo() const;
   std::string getName();
-  cl::Kernel get() const;
+  cl::Kernel *get();
   size_t getTotalArgSize() const;
 
   CHIPModuleOpenCL *getModule() override { return Module; }


### PR DESCRIPTION
Creating this PR since I needed to make changes and test things but I don't have access to Parmance github. Since Parmance is a fork of this repo, I am also unable to make a PR to merge changes into your branch. 



changes some existing APIs, adds new, implemented for both backends

hipInitFromNativeHandles() replaces hipInitFromOutside()
hipGetBackendNativeHandles() replaces hipStreamGetBackendHandles()
implement them both for OpenCL & Level0
two new APIs, hipGetNativeEventFromHipEvent & hipGetHipEventFromNativeEvent
to make async interop possible (implemented for OpenCL & Level0)
plus some minor bugfixes. I will add some tests for the async interop soon. Running ctest with OpenCL backend on Intel Skylake results in 87% tests passed, 51 tests failed out of 379.

