### PR TITLE
Fixes to HIP-SYCL Interop

### DIFF
--- a/samples/hip_sycl_interop/CMakeLists.txt
+++ b/samples/hip_sycl_interop/CMakeLists.txt
@@ -3,12 +3,13 @@ add_subdirectory(onemkl_gemm_wrapper)
 add_chip_binary(hip_sycl_interop hip_sycl_interop.cpp)
 add_dependencies(build_tests_standalone hip_sycl_interop)
 target_link_libraries(hip_sycl_interop onemkl_gemm_wrapper)
+target_include_directories(hip_sycl_interop PUBLIC ${CHIP_DIR_}/HIP/include ${CHIP_DIR_}/include)
 
 add_test(NAME "hip_sycl_interop"
-         COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop" 
-         )
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hip_sycl_interop"
+)
 
 set_tests_properties("hip_sycl_interop" PROPERTIES
-         PASS_REGULAR_EXPRESSION "${TEST_PASS}"
-         TIMEOUT 60
-         )
+    PASS_REGULAR_EXPRESSION "${TEST_PASS}"
+    TIMEOUT 60
+)

--- a/samples/hip_sycl_interop/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop/hip_sycl_interop.cpp
@@ -8,6 +8,11 @@
 
 #include "hip_sycl_interop.h"
 
+// must declare this here since it's not part of the standard HIP API
+extern "C" hipError_t hipGetBackendNativeHandles(hipStream_t Stream,
+                                                 uintptr_t *NativeHandles,
+                                                 int *NumHandles);
+
 using namespace std;
 
 const int WIDTH = 10;

--- a/samples/hip_sycl_interop/hip_sycl_interop.h
+++ b/samples/hip_sycl_interop/hip_sycl_interop.h
@@ -2,9 +2,10 @@
 #define __HIPLZ_SYCL_INTEROP_H__
 
 extern "C" {
-  // Run GEMM test via oneMKL
-  int oneMKLGemmTest(uintptr_t* nativeHandlers, float* A, float* B, float* C, int M, int N, int K,
-		     int ldA, int ldB, int ldC, float alpha, float beta);
+// Run GEMM test via oneMKL
+int oneMKLGemmTest(uintptr_t *nativeHandlers, float *A, float *B, float *C,
+                   int M, int N, int K, int ldA, int ldB, int ldC, float alpha,
+                   float beta);
 }
 
 #endif

--- a/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
+++ b/samples/hip_sycl_interop_no_buffers/hip_sycl_interop.cpp
@@ -1,12 +1,16 @@
-#include "hip/hip_runtime.h"
-
 // STL classes
 #include <exception>
 #include <iostream>
 
+#include "hip/hip_runtime.h"
 #include <vector>
-
+#include <cmath>
 #include "hip_sycl_interop.h"
+
+// must declare this here since it's not part of the standard HIP API
+extern "C" hipError_t hipGetBackendNativeHandles(hipStream_t Stream,
+                                                 uintptr_t *NativeHandles,
+                                                 int *NumHandles);
 
 using namespace std;
 
@@ -62,8 +66,8 @@ int main() {
 
   uintptr_t nativeHandlers[4];
   int numItems = 4;
-  error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
-  CHECK(error);
+  auto error = hipGetBackendNativeHandles(stream, nativeHandlers, &numItems);
+  assert(error == hipSuccess);
 
   // allocate memory
   hipMalloc(&d_A, WIDTH * WIDTH * sizeof(float));

--- a/samples/sycl_hip_interop/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_chip_interop.h
@@ -1,17 +1,18 @@
 #ifndef __sycl_chip_interop_H__
 #define __sycl_chip_interop_H__
+#include <cstdint>
 
 extern "C" {
 // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
 // information
-hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
+int hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
-int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,
+int hipMatrixMultiplicationUSMTest(const float *A, const float *B, float *C,
                                    int M, int N);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend
-int hipMatrixMultiplicationTest(const float* A, const float* B, float* C, int M,
+int hipMatrixMultiplicationTest(const float *A, const float *B, float *C, int M,
                                 int N);
 }
 

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
@@ -3,8 +3,8 @@ set(CMAKE_CXX_FLAGS "")
 
 add_executable(sycl_chip_interop sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader -Wl,-rpath=${CHIP_DIR_}/build ${CHIP_CMAKE_INSTALL_LIBDIR})
-target_link_libraries(sycl_chip_interop PRIVATE ${CHIP_DIR_}/build/samples/sycl_hip_interop/libhipMatrixMul.a -L${CHIP_DIR_}/build -lCHIP -lOpenCL -pthread)
+target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader)
+target_link_libraries(sycl_chip_interop PRIVATE hipMatrixMul CHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop PRIVATE -fsycl -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
@@ -21,8 +21,8 @@ set_tests_properties("sycl_chip_interop" PROPERTIES
 
 add_executable(sycl_chip_interop_usm sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop_usm CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader -Wl,-rpath=${CHIP_DIR_}/build ${CHIP_CMAKE_INSTALL_LIBDIR})
-target_link_libraries(sycl_chip_interop_usm PRIVATE -L${CHIP_DIR_}/build/samples/sycl_hip_interop -lhipMatrixMul -L${CHIP_DIR_}/build -lCHIP -lOpenCL -pthread)
+target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader)
+target_link_libraries(sycl_chip_interop PRIVATE hipMatrixMul CHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop_usm PRIVATE -fsycl -DUSM -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop_usm
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/CMakeLists.txt
@@ -3,8 +3,10 @@ set(CMAKE_CXX_FLAGS "")
 
 add_executable(sycl_chip_interop sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader)
-target_link_libraries(sycl_chip_interop PRIVATE hipMatrixMul CHIP -lOpenCL -pthread)
+
+# Warning the use of manual linking here using -lCHIP is on purpose due to conflicting opencl headers that get loaded otherwise.
+target_link_options(sycl_chip_interop PRIVATE -fsycl -lze_loader -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}/../../.. ${CHIP_CMAKE_INSTALL_LIBDIR})
+target_link_libraries(sycl_chip_interop PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../libhipMatrixMul.a -L${CMAKE_CURRENT_BINARY_DIR}/../../.. -lCHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop PRIVATE -fsycl -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
@@ -21,8 +23,10 @@ set_tests_properties("sycl_chip_interop" PROPERTIES
 
 add_executable(sycl_chip_interop_usm sycl_chip_interop.cpp)
 add_dependencies(sycl_chip_interop_usm CHIP hipMatrixMul)
-target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader)
-target_link_libraries(sycl_chip_interop PRIVATE hipMatrixMul CHIP -lOpenCL -pthread)
+
+# Warning the use of manual linking here using -lCHIP is on purpose due to conflicting opencl headers that get loaded otherwise.
+target_link_options(sycl_chip_interop_usm PRIVATE -fsycl -lze_loader -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}/../../.. ${CHIP_CMAKE_INSTALL_LIBDIR})
+target_link_libraries(sycl_chip_interop_usm PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../libhipMatrixMul.a -L${CMAKE_CURRENT_BINARY_DIR}/../../.. -lCHIP -lOpenCL -pthread)
 target_compile_options(sycl_chip_interop_usm PRIVATE -fsycl -DUSM -Wno-deprecated-declarations)
 install(TARGETS sycl_chip_interop_usm
     RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -1,5 +1,4 @@
 #include <stdint.h>
-
 #include "level_zero/ze_api.h"
 #include <CL/sycl.hpp>
 #include <CL/sycl/stl.hpp>
@@ -77,8 +76,7 @@ int main() {
         (uintptr_t)Plt.template get_native<sycl::backend::level_zero>(),
         (uintptr_t)Devs[0].template get_native<sycl::backend::level_zero>(),
         (uintptr_t)Ctx.template get_native<sycl::backend::level_zero>(),
-        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()
-      };
+        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()};
     hipInitFromNativeHandles(Args, 4);
 
 #ifdef USM

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.h
@@ -2,17 +2,15 @@
 #define __sycl_chip_interop_H__
 
 extern "C" {
-// Initialize CHIP-SPV Level-Zero Backend via providing native runtime
-// information
-hipError_t hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
+// must declare this here since it's not part of the standard HIP API
+int hipInitFromNativeHandles(const uintptr_t *NativeHandles, int NumHandles);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend via USM data transfer
-int hipMatrixMultiplicationUSMTest(const float* A, const float* B, float* C,
+int hipMatrixMultiplicationUSMTest(const float *A, const float *B, float *C,
                                    int M, int N);
 
 // Run GEMM test via CHIP-SPV Level-Zero Backend
-int hipMatrixMultiplicationTest(const float* A, const float* B, float* C, int M,
+int hipMatrixMultiplicationTest(const float *A, const float *B, float *C, int M,
                                 int N);
 }
-
 #endif

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -137,8 +137,9 @@ void CHIPAllocationTracker::recordAllocation(void *DevPtr, void *HostPtr,
   if (HostPtr)
     PtrToAllocInfo_[HostPtr] = AllocInfo;
 
-  logDebug("CHIPAllocationTracker::recordAllocation size: {} HOST {} DEV {} TYPE {}",
-           Size, HostPtr, DevPtr, (unsigned)MemoryType);
+  logDebug(
+      "CHIPAllocationTracker::recordAllocation size: {} HOST {} DEV {} TYPE {}",
+      Size, HostPtr, DevPtr, (unsigned)MemoryType);
   return;
 }
 
@@ -742,6 +743,10 @@ int CHIPDevice::getAttr(hipDeviceAttribute_t Attr) {
 
 size_t CHIPDevice::getGlobalMemSize() { return HipDeviceProps_.totalGlobalMem; }
 
+void CHIPDevice::addModule(const std::string *ModuleStr, CHIPModule *Module) {
+  this->ChipModules[ModuleStr] = Module;
+}
+
 void CHIPDevice::registerFunctionAsKernel(std::string *ModuleStr,
                                           const void *HostFPtr,
                                           const char *HostFName) {
@@ -831,8 +836,6 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
   return ChipQueue;
 }
 
-
-
 std::vector<CHIPQueue *> &CHIPDevice::getQueues() { return ChipQueues_; }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,
@@ -899,10 +902,10 @@ bool CHIPDevice::hasPCIBusId(int PciDomainID, int PciBusID, int PciDeviceID) {
 }
 
 CHIPQueue *CHIPDevice::getActiveQueue() {
-    if (ChipQueues_.size() > 0)
-        return ChipQueues_[ActiveQueueId_];
-    else
-        return nullptr;
+  if (ChipQueues_.size() > 0)
+    return ChipQueues_[ActiveQueueId_];
+  else
+    return nullptr;
 }
 
 hipError_t CHIPDevice::allocateDeviceVariables() {

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1027,7 +1027,8 @@ public:
    */
   CHIPQueue *createQueueAndRegister(unsigned int Flags, int Priority);
 
-  CHIPQueue *createQueueAndRegister(const uintptr_t *NativeHandles, int NumHandles);
+  CHIPQueue *createQueueAndRegister(const uintptr_t *NativeHandles,
+                                    int NumHandles);
 
   size_t getMaxMallocSize() {
     if (MaxMallocSize_ < 1)
@@ -1116,7 +1117,8 @@ public:
    * in chip_queues vector)
    */
   virtual CHIPQueue *addQueueImpl(unsigned int Flags, int Priority) = 0;
-  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles, int NumHandles) = 0;
+  virtual CHIPQueue *addQueueImpl(const uintptr_t *NativeHandles,
+                                  int NumHandles) = 0;
 
   /**
    * @brief Add a queue to this device
@@ -1299,6 +1301,7 @@ public:
                               const char *Name, size_t Size);
 
   virtual CHIPModule *addModule(std::string *ModuleStr) = 0;
+  void addModule(const std::string *ModuleStr, CHIPModule *Module);
 
   virtual CHIPTexture *
   createTexture(const hipResourceDesc *ResDesc, const hipTextureDesc *TexDesc,
@@ -1426,7 +1429,7 @@ public:
    * @return true/false
    */
 
-  virtual bool isAllocatedPtrUSM(void* Ptr) = 0;
+  virtual bool isAllocatedPtrUSM(void *Ptr) = 0;
 
   /**
    * @brief Free memory
@@ -1584,7 +1587,8 @@ public:
    * @param device_type_str
    * @param device_ids_str
    */
-  virtual void initializeFromNative(const uintptr_t *NativeHandles, int NumHandles) = 0;
+  virtual void initializeFromNative(const uintptr_t *NativeHandles,
+                                    int NumHandles) = 0;
 
   /**
    * @brief
@@ -1770,8 +1774,8 @@ public:
   virtual CHIPEventMonitor *createStaleEventMonitor() = 0;
 
   /* event interop */
-  virtual hipEvent_t getHipEvent(void* NativeEvent) = 0;
-  virtual void* getNativeEvent(hipEvent_t HipEvent) = 0;
+  virtual hipEvent_t getHipEvent(void *NativeEvent) = 0;
+  virtual void *getNativeEvent(hipEvent_t HipEvent) = 0;
 };
 
 /**
@@ -2053,10 +2057,13 @@ public:
    *
    * @param NativeHandles storage for handles
    * @param NumHandles variable to hold number of returned handles
-   * @return for Level0 backend, returns { ze_driver_handle_t, ze_device_handle_t, ze_context_handle_t, ze_command_queue_handle_t }
-   * @return for OpenCL backend, returns { cl_platform_id, cl_device_id, cl_context, cl_command_queue }
+   * @return for Level0 backend, returns { ze_driver_handle_t,
+   * ze_device_handle_t, ze_context_handle_t, ze_command_queue_handle_t }
+   * @return for OpenCL backend, returns { cl_platform_id, cl_device_id,
+   * cl_context, cl_command_queue }
    */
-  virtual hipError_t getBackendHandles(uintptr_t *NativeHandles, int *NumHandles) = 0;
+  virtual hipError_t getBackendHandles(uintptr_t *NativeHandles,
+                                       int *NumHandles) = 0;
 
   CHIPContext *getContext() { return ChipContext_; }
 };


### PR DESCRIPTION
Creating a separate PR with fixes to HIP-SYCL Interop

* Various compilation issues in the two samples
* One issue that needs to be addressed is SYCL calling HIP:
1. icpx compiler needs to be used to compile SYCL (at least the way that the sample is currently setup) and it is not compatible with HIP headers. Including "hip/hip_runtime.h" results in errors
2. `hipInitFromNativeHandles` Is not in the HIP API, so it must be declared in the sample itself
3. if `hipInitFromNativeHandles` returns `hipError_t` then we must include "hip/hip_runtime.h"

* A lot of formatting/linting issues.