### PR TITLE
Fixes for LLVM 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ set(CHIP_SRC
 )
 
 set(CHIP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "CHIP-SPV source directory")
+set(CLANG_VERSION_LESS_14 FALSE CACHE INTERNAL "Clang version < 14.0")
+set(CLANG_VERSION_LESS_15 FALSE CACHE INTERNAL "Clang version < 15.0")
 
 set(CHIP_SPV_LINK_FLAGS "")
 set(CHIP_SPV_COMPILE_FLAGS "")
@@ -82,9 +84,6 @@ set(HIP_OFFLOAD_LINK_OPTIONS "" CACHE STRING "space separated list of compiler f
 
 ###############################################################################
 # CHIP-SPV CMAKE OPTIONS PARSING
-
-set(CLANG_VERSION_LESS_14 FALSE CACHE INTERNAL "Clang version < 14.0")
-set(CLANG_VERSION_LESS_15 FALSE CACHE INTERNAL "Clang version < 15.0")
 if((CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang") OR
    (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM"))
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0.0)
@@ -102,6 +101,20 @@ if((CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang") OR
   endif()
 else()
   message(FATAL_ERROR "this project must be compiled with clang. CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+set(DISABLE_OPAQUE_PTRS_OPT "")
+if (NOT CLANG_VERSION_LESS_15)
+  # LLVM 15 switches to opaque pointer mode by default which
+  # llvm-spirv currently does not support. Switch the mode off.
+  #
+  # NOTE: https://reviews.llvm.org/D130766 will disable the mode off
+  #       for SPIR-V targets but the patch has not yet landed on the
+  #       LLVM 15 branch.
+  #
+  # NOTE: Bitcode library must be compiled with the same opaque
+  #       pointer setting.
+  set(DISABLE_OPAQUE_PTRS_OPT -Xclang -no-opaque-pointers)
 endif()
 
 if(LLVM_USE_INTERGRATED_SPIRV)
@@ -182,6 +195,7 @@ find_package(Threads REQUIRED)
 set(PTHREAD_LIBRARY Threads::Threads)
 
 add_subdirectory(llvm_passes)
+add_subdirectory(bitcode)
 
 enable_testing()
 add_subdirectory(HIP/tests/catch catch)
@@ -219,20 +233,6 @@ target_include_directories(CHIP
 
 ###############################################################################
 # HIP OFFLOAD FLAGS
-set(DISABLE_OPAQUE_PTRS_OPT "")
-if (NOT CLANG_VERSION_LESS_15)
-  # LLVM 15 switches to opaque pointer mode by default which
-  # llvm-spirv currently does not support. Switch the mode off.
-  #
-  # NOTE: https://reviews.llvm.org/D130766 will disable the mode off
-  #       for SPIR-V targets but the patch has not yet landed on the
-  #       LLVM 15 branch.
-  #
-  # NOTE: Bitcode library must be compiled with the same opaque
-  #       pointer setting.
-  set(DISABLE_OPAQUE_PTRS_OPT -Xclang -no-opaque-pointers)
-endif()
-
 set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ -x hip --target=x86_64-linux-gnu
   ${SPIRV_EMITTER_OPTS} ${DISABLE_OPAQUE_PTRS_OPT})
 
@@ -246,8 +246,6 @@ if(NOT CLANG_VERSION_LESS_14)
       # excludes the wrappers.
       "-nohipwrapperinc")
 endif()
-
-add_subdirectory(bitcode)
 
 if(CLANG_VERSION_LESS_14 )
   set(HIP_LINK_DEVICELIB_BUILD --hip-device-lib-path=${CMAKE_BINARY_DIR}/share --hip-device-lib=devicelib.bc --hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ set(CHIP_SRC
 )
 
 set(CHIP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "CHIP-SPV source directory")
-set(CLANG_VERSION_LESS_14 FALSE CACHE INTERNAL "Clang version < 14.0")
 
 set(CHIP_SPV_LINK_FLAGS "")
 set(CHIP_SPV_COMPILE_FLAGS "")
@@ -83,9 +82,17 @@ set(HIP_OFFLOAD_LINK_OPTIONS "" CACHE STRING "space separated list of compiler f
 
 ###############################################################################
 # CHIP-SPV CMAKE OPTIONS PARSING
-if((CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang") OR(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM"))
+
+set(CLANG_VERSION_LESS_14 FALSE CACHE INTERNAL "Clang version < 14.0")
+set(CLANG_VERSION_LESS_15 FALSE CACHE INTERNAL "Clang version < 15.0")
+if((CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang") OR
+   (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM"))
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0.0)
     message(FATAL_ERROR "this project requires clang >= 8.0")
+  endif()
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0.0)
+    set(CLANG_VERSION_LESS_15 ON)
   endif()
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0.0)
@@ -175,7 +182,6 @@ find_package(Threads REQUIRED)
 set(PTHREAD_LIBRARY Threads::Threads)
 
 add_subdirectory(llvm_passes)
-add_subdirectory(bitcode)
 
 enable_testing()
 add_subdirectory(HIP/tests/catch catch)
@@ -213,7 +219,22 @@ target_include_directories(CHIP
 
 ###############################################################################
 # HIP OFFLOAD FLAGS
-set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ -x hip --target=x86_64-linux-gnu ${SPIRV_EMITTER_OPTS})
+set(DISABLE_OPAQUE_PTRS_OPT "")
+if (NOT CLANG_VERSION_LESS_15)
+  # LLVM 15 switches to opaque pointer mode by default which
+  # llvm-spirv currently does not support. Switch the mode off.
+  #
+  # NOTE: https://reviews.llvm.org/D130766 will disable the mode off
+  #       for SPIR-V targets but the patch has not yet landed on the
+  #       LLVM 15 branch.
+  #
+  # NOTE: Bitcode library must be compiled with the same opaque
+  #       pointer setting.
+  set(DISABLE_OPAQUE_PTRS_OPT -Xclang -no-opaque-pointers)
+endif()
+
+set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ -x hip --target=x86_64-linux-gnu
+  ${SPIRV_EMITTER_OPTS} ${DISABLE_OPAQUE_PTRS_OPT})
 
 # hipDeviceLink sample requires --offload=spirv64 flag at link time. Why? 
 if(NOT CLANG_VERSION_LESS_14)
@@ -225,6 +246,8 @@ if(NOT CLANG_VERSION_LESS_14)
       # excludes the wrappers.
       "-nohipwrapperinc")
 endif()
+
+add_subdirectory(bitcode)
 
 if(CLANG_VERSION_LESS_14 )
   set(HIP_LINK_DEVICELIB_BUILD --hip-device-lib-path=${CMAKE_BINARY_DIR}/share --hip-device-lib=devicelib.bc --hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes)

--- a/bitcode/CMakeLists.txt
+++ b/bitcode/CMakeLists.txt
@@ -25,12 +25,13 @@ else()
   set(BC_DESTINATION lib/hip-device-lib)
 endif()
 
+set(BITCODE_COMPILE_FLAGS "${CLANG_CL_NO_STDINC_FLAG}"
+  -Xclang -finclude-default-header -O2 -x cl -cl-std=CL2.0
+  --target=${BC_TRIPLE} -emit-llvm ${DISABLE_OPAQUE_PTRS_OPT})
+
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/devicelib.bc"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/devicelib.cl"
-  COMMAND "${CMAKE_CXX_COMPILER}"
-  "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
-  -O2 -x cl -cl-std=CL2.0
-  --target=${BC_TRIPLE} -emit-llvm
+  COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_COMPILE_FLAGS}
   -o "${CMAKE_CURRENT_BINARY_DIR}/BC/devicelib.bc"
   -c "${CMAKE_CURRENT_SOURCE_DIR}/devicelib.cl"
   COMMENT "Building devicelib.bc"
@@ -40,10 +41,7 @@ list(APPEND DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/devicelib.bc")
 # Support function(s) for printf().
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/_cl_print_str.cl"
-  COMMAND "${CMAKE_CXX_COMPILER}"
-  "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
-  -O2 -x cl -cl-std=CL2.0
-  --target=spir64-unknown-unknown -emit-llvm
+  COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_COMPILE_FLAGS}
   -o "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc"
   -c "${CMAKE_CURRENT_SOURCE_DIR}/_cl_print_str.cl"
   COMMENT "Building printf_support.bc"
@@ -52,10 +50,7 @@ list(APPEND DEPEND_LIST "${CMAKE_CURRENT_BINARY_DIR}/BC/printf_support.bc")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/texture.bc"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/texture.cl"
-  COMMAND "${CMAKE_CXX_COMPILER}"
-  "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
-  -O2 -x cl -cl-std=CL2.0
-  --target=${BC_TRIPLE} -emit-llvm
+  COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_COMPILE_FLAGS}
   -o "${CMAKE_CURRENT_BINARY_DIR}/BC/texture.bc"
   -c "${CMAKE_CURRENT_SOURCE_DIR}/texture.cl"
   COMMENT "Building texture.bc"
@@ -69,10 +64,7 @@ foreach(SOURCE IN LISTS SOURCES)
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/${SOURCE}.bc"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/OCML/${SOURCE}.cl"
-    COMMAND "${CMAKE_CXX_COMPILER}"
-    "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
-    -O2 -pthread -x cl -cl-std=CL2.0
-    --target=${BC_TRIPLE} -emit-llvm
+    COMMAND "${CMAKE_CXX_COMPILER}" ${BITCODE_COMPILE_FLAGS}
     -o "${CMAKE_CURRENT_BINARY_DIR}/BC/${SOURCE}.bc"
     -c "${CMAKE_CURRENT_SOURCE_DIR}/OCML/${SOURCE}.cl"
     COMMENT "Building ${SOURCE}.bc"


### PR DESCRIPTION
* Disable opaque pointers because llvm-spirv does not support them (yet).
* Fix HipPrintf pass triggered a LLVM assertion.
