### PR TITLE
Attempt to fix #101

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -757,6 +757,14 @@ void CHIPDevice::addQueue(CHIPQueue *ChipQueue) {
   return;
 }
 
+void CHIPEvent::track() {
+  std::lock_guard<std::mutex> Lock(Mtx);
+  if (!TrackCalled_) {
+    trackImpl();
+    TrackCalled_ = true;
+  }
+}
+
 void CHIPEvent::trackImpl() {
   std::lock_guard<std::mutex> Lock(Backend->EventsMtx);
   Backend->Events.push_back(this);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -506,9 +506,8 @@ class CHIPContext;
 class CHIPDevice;
 
 class CHIPEvent {
-  public:
-  bool TrackCalled = false;
 protected:
+  bool TrackCalled_ = false;
   event_status_e EventStatus_;
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;
@@ -538,14 +537,7 @@ public:
     }
   }
   void trackImpl();
-  void track() {
-    std::lock_guard<std::mutex> Lock(Mtx);
-    //std::call_once(TrackCalled, &CHIPEvent::trackImpl, this);
-    if (!TrackCalled) {
-      trackImpl();
-      TrackCalled = true;
-    }
-  }
+  void track();
   CHIPEventFlags getFlags() { return Flags_; }
   std::mutex Mtx;
   std::string Msg;
@@ -556,11 +548,6 @@ public:
              (void *)this, Msg.c_str(), *Refc_, *Refc_ - 1, Reason);
     if (*Refc_ > 0) {
       (*Refc_)--;
-      if (*Refc_ == 0) {
-        Msg = "INVALID";
-        TrackCalled = false;
-        EventStatus_ = EVENT_STATUS_INIT;
-      }
     } else {
       logError("CHIPEvent::decreaseRefCount() called when refc == 0");
     }

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -506,8 +506,9 @@ class CHIPContext;
 class CHIPDevice;
 
 class CHIPEvent {
-protected:
+  public:
   bool TrackCalled = false;
+protected:
   event_status_e EventStatus_;
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -553,11 +553,6 @@ void CHIPStaleEventMonitorLevel0::monitor() {
           CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
         }
 
-        // Add the most course-grain lock here in case event destructor is not
-        // thread-safe
-        std::lock_guard Lock(Backend->Mtx);
-        if (!E->EventPool) // Delete event if not owned by an event pool.
-          delete E;
       }
 
     } // done collecting events to delete
@@ -1190,6 +1185,7 @@ CHIPEventLevel0 *LZEventPool::getEvent() {
   // reset event
   auto Status = zeEventHostReset(Event->get());
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
+  Event->TrackCalled = false;
 
   return Event;
 };

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -179,6 +179,14 @@ createSampler(CHIPDeviceLevel0 *ChipDev, const hipResourceDesc *PResDesc,
 // CHIPEventLevel0
 // ***********************************************************************
 
+void CHIPEventLevel0::reset() {
+  auto Status = zeEventHostReset(get());
+  CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
+  std::lock_guard<std::mutex> Lock(Mtx);
+  TrackCalled_ = false;
+  EventStatus_  = EVENT_STATUS_INIT;
+}
+
 ze_event_handle_t CHIPEventLevel0::peek() { return Event_; }
 
 ze_event_handle_t CHIPEventLevel0::get() {
@@ -1182,11 +1190,7 @@ CHIPEventLevel0 *LZEventPool::getEvent() {
   if (PoolIndex == -1)
     return nullptr;
   auto Event = Events_[PoolIndex];
-
-  // reset event
-  auto Status = zeEventHostReset(Event->get());
-  CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
-  Event->TrackCalled = false;
+  Event->reset();
 
   return Event;
 };

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -184,7 +184,7 @@ void CHIPEventLevel0::reset() {
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
   std::lock_guard<std::mutex> Lock(Mtx);
   TrackCalled_ = false;
-  EventStatus_  = EVENT_STATUS_INIT;
+  EventStatus_ = EVENT_STATUS_INIT;
 }
 
 ze_event_handle_t CHIPEventLevel0::peek() { return Event_; }
@@ -560,7 +560,6 @@ void CHIPStaleEventMonitorLevel0::monitor() {
           auto Status = zeCommandListDestroy(CommandList);
           CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
         }
-
       }
 
     } // done collecting events to delete

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -612,6 +612,7 @@ hipError_t CHIPKernelLevel0::getAttributes(hipFuncAttributes *Attr) {
   Attr->numRegs = 0;
   Attr->preferredShmemCarveout = 0;
   Attr->ptxVersion = 10;
+  return hipSuccess;
 }
 
 // CHIPQueueLevelZero

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -55,6 +55,8 @@ public:
 
   virtual void hostSignal() override;
 
+  void reset();
+
   ze_event_handle_t peek();
   ze_event_handle_t get();
 };


### PR DESCRIPTION
I saw that CHIPStaleEventMonitorLevel0::monitor() was not cleaning up
stale command list (aka. they are memory leaked) which I suspected to
be the cause for memory hogging in tests like FloydWarshall. Attempted
to fix the issue by:

* changing event call method get() -> peek() in
  CHIPQueueLevel0::executeCommandList to "fix" reference counting. I
  saw in the logs that reference counter was incremented two times but
  only ever decreased by one once.
* resetting event state when the reference count decresed to zero so
  they could be reused. Without this the recycled events were not put
  into Backend->Events lists so the monitor never picked them up.

Also, fixed CHIPStaleEventMonitorLevel0::monitor() not to delete used
events which are belonging to event pools. Apparently, LZEventPool
manages them.

With the fixes above, the memory hogging issues are cleared in the
FloydWarshall and BitonicSort test cases at least on my
machine. However, other problems pops out. I see following tests
failing occasionally:

* FastWalshTransform
* hip_async_binomial
* cuda-bandwidthTest
* cuda-FDTD3d

The failures seems to pop up more often when the tests are ran without
debug printing.