### PR TITLE
cuspvc: Add search directory for locating clang++

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,3 +1,7 @@
+
+# For telling cuspvc where to look for clang.
+get_filename_component(CLANG_BIN_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
+
 # Read includes, prepend each one with -I.
 set(prop "$<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>")
 set(CHIP_INCLUDES "$<$<BOOL:${prop}>:-I$<JOIN:${prop}, -I>>")

--- a/bin/cuspvc-build.in
+++ b/bin/cuspvc-build.in
@@ -6,5 +6,5 @@
 #
 # NOTE: this file is not meant only to be usable in CHIP-SPV build directory.
 export HIP_PLATFORM=spirv
-export PATH=@CMAKE_BINARY_DIR@/bin:$PATH
+export PATH=@CLANG_BIN_DIR@:@CMAKE_BINARY_DIR@/bin:$PATH
 hipcc @CHIP_INCLUDES@ "$@"

--- a/bin/cuspvc-install.in
+++ b/bin/cuspvc-install.in
@@ -4,6 +4,6 @@
 # CUDA sources are compiled in HIP mode with an include search path to
 # cuda_runtime.h wrapper which translates CUDA API to HIP API.
 export HIP_PLATFORM=spirv
-# Add path for locating hipcc.
-export PATH=@CMAKE_INSTALL_PREFIX@/bin:$PATH
+# Set PATH for locating hipcc and clang.
+export PATH=@CLANG_BIN_DIR@:@CMAKE_INSTALL_PREFIX@/bin:$PATH
 hipcc -I@CMAKE_INSTALL_PREFIX@/include/cuspv "$@"


### PR DESCRIPTION
This makes the cuspvc more convenient to use and fixes one test under tests/cuda/ (which was broken by 5be3db582a217a28c4017480957b9f03138bad4e).