### PR TITLE
Implement hiprtc API for basic runtime compilation cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,16 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 set(PTHREAD_LIBRARY Threads::Threads)
 
+include(CheckIncludeFileCXX)
+check_include_file_cxx("filesystem" HAS_FILESYSTEM)
+if(NOT HAS_FILESYSTEM)
+  check_include_file_cxx("experimental/filesystem" HAS_EXPERIMENTAL_FILESYSTEM)
+endif()
+
+if(NOT HAS_FILESYSTEM AND NOT HAS_EXPERIMENTAL_FILESYSTEM)
+  message(FATAL_ERROR "<filesystem> was not found.")
+endif()
+
 # CHIP-SPV CMAKE DEPENDENCIES
 ###############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(CHIP_SRC
   src/CHIPBackend.cc
   src/CHIPBindings.cc
   src/logging.cc
+  src/Utils.cc
 )
 
 if(OpenCL_LIBRARY)
@@ -331,6 +332,7 @@ target_include_directories(CHIP
   PRIVATE
   "${CMAKE_SOURCE_DIR}/src"
   "${CMAKE_SOURCE_DIR}/include"
+  "${CMAKE_BINARY_DIR}"
 )
 # CHIP-SPV COMPILATION SETUP
 ###############################################################################
@@ -414,6 +416,18 @@ target_link_libraries(device INTERFACE CHIP)
 add_library(host INTERFACE)
 target_link_libraries(host INTERFACE device)
 # HIP OFFLOAD FLAGS
+###############################################################################
+
+###############################################################################
+# PROJECT CONFIGURATION HEADER
+
+set(CHIP_SOURCE_DIR ${CMAKE_SOURCE_DIR})
+set(CHIP_BUILD_DIR ${CMAKE_BINARY_DIR})
+set(CHIP_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
+set(CHIP_CLANG_PATH ${CLANG_BIN_PATH})
+configure_file(Config.hh.in Config.hh @ONLY)
+
+# PROJECT CONFIGURATION HEADER
 ###############################################################################
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,6 @@ Unit_hipGraphAddMemcpyNode_Functional$|\
 Unit_hipGraph_BasicFunctional$|\
 Unit_hipGraph_SimpleGraphWithKernel$|\
 Unit_hipHostMalloc_Coherent$|\
-Unit_hiprtc_saxpy$|\
 Unit_hipHostMalloc_NonCoherent$|\
 Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread - |\
 Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream - |\

--- a/Config.hh.in
+++ b/Config.hh.in
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef CHIP_CONFIG_H
+#define CHIP_CONFIG_H
+
+#cmakedefine CHIP_SOURCE_DIR "@CHIP_SOURCE_DIR@"
+
+#cmakedefine CHIP_BUILD_DIR "@CHIP_BUILD_DIR@"
+
+#cmakedefine CHIP_INSTALL_DIR "@CHIP_INSTALL_DIR@"
+
+#cmakedefine CHIP_CLANG_PATH "@CHIP_CLANG_PATH@"
+
+#endif

--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -39,8 +39,8 @@ THE SOFTWARE.
 typedef _Float16 _hip_f16;
 typedef _Float16 _hip_f16_2 __attribute__((ext_vector_type(2)));
 #else
-typedef api_half _hip_f16;
-typedef api_half2 _hip_f16_2;
+typedef short _hip_f16;
+typedef short _hip_f16_2 __attribute__((ext_vector_type(2)));
 #endif
 
 struct __half_raw {

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 add_definitions(${LLVM_DEFINITIONS})
 
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${LLVM_INCLUDE_DIRS} ${CMAKE_BINARY_DIR})
 
 if(NOT LLVM_ENABLE_RTTI)
   add_compile_options("-fno-rtti")

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1451,17 +1451,6 @@ CHIPQueue *CHIPBackend::findQueue(CHIPQueue *ChipQueue) {
   return *QueueFound;
 }
 
-bool CHIPBackend::eraseProgram(const CHIPProgram *ToErase) {
-  auto ErasePos =
-      std::remove_if(ChipPrograms_.begin(), ChipPrograms_.end(),
-                     [&](const std::unique_ptr<CHIPProgram> &Prog) -> bool {
-                       return Prog.get() == ToErase;
-                     });
-  bool WasErased = ErasePos != ChipPrograms_.end();
-  ChipPrograms_.erase(ErasePos, ChipPrograms_.end());
-  return WasErased;
-}
-
 // CHIPQueue
 //*************************************************************************************
 CHIPQueue::CHIPQueue(CHIPDevice *ChipDevice, CHIPQueueFlags Flags, int Priority)

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -51,7 +51,7 @@ static void queueVariableInfoShadowKernel(CHIPQueue *Q, CHIPModule *M,
                                           const CHIPDeviceVar *Var,
                                           void *InfoBuffer) {
   assert(M && Var && InfoBuffer);
-  auto *K = M->getKernel(std::string(ChipVarInfoPrefix) + Var->getName());
+  auto *K = M->getKernelByName(std::string(ChipVarInfoPrefix) + Var->getName());
   assert(K && "Module is missing a shadow kernel?");
   void *Args[] = {&InfoBuffer};
   queueKernel(Q, K, Args);
@@ -62,7 +62,7 @@ static void queueVariableBindShadowKernel(CHIPQueue *Q, CHIPModule *M,
   assert(M && Var);
   auto *DevPtr = Var->getDevAddr();
   assert(DevPtr && "Space has not be allocated for a variable.");
-  auto *K = M->getKernel(std::string(ChipVarBindPrefix) + Var->getName());
+  auto *K = M->getKernelByName(std::string(ChipVarBindPrefix) + Var->getName());
   assert(K && "Module is missing a shadow kernel?");
   void *Args[] = {&DevPtr};
   queueKernel(Q, K, Args);
@@ -71,7 +71,7 @@ static void queueVariableBindShadowKernel(CHIPQueue *Q, CHIPModule *M,
 static void queueVariableInitShadowKernel(CHIPQueue *Q, CHIPModule *M,
                                           const CHIPDeviceVar *Var) {
   assert(M && Var);
-  auto *K = M->getKernel(std::string(ChipVarInitPrefix) + Var->getName());
+  auto *K = M->getKernelByName(std::string(ChipVarInitPrefix) + Var->getName());
   assert(K && "Module is missing a shadow kernel?");
   queueKernel(Q, K);
 }
@@ -235,7 +235,7 @@ CHIPKernel *CHIPModule::findKernel(const std::string &Name) {
   return KernelFound == ChipKernels_.end() ? nullptr : *KernelFound;
 }
 
-CHIPKernel *CHIPModule::getKernel(std::string Name) {
+CHIPKernel *CHIPModule::getKernelByName(const std::string &Name) {
   auto *Kernel = findKernel(Name);
   if (!Kernel) {
     std::string Msg = "Failed to find kernel via kernel name: " + Name;
@@ -748,7 +748,7 @@ void CHIPDevice::registerFunctionAsKernel(std::string *ModuleStr,
     Module->compileOnce(this);
   }
 
-  CHIPKernel *Kernel = Module->getKernel(std::string(HostFName));
+  CHIPKernel *Kernel = Module->getKernelByName(HostFName);
   if (!Kernel) {
     std::string Msg = "Device " + getName() +
                       " tried to register host function " + HostFName +
@@ -1445,6 +1445,17 @@ CHIPQueue *CHIPBackend::findQueue(CHIPQueue *ChipQueue) {
   return *QueueFound;
 }
 
+bool CHIPBackend::eraseProgram(const CHIPProgram *ToErase) {
+  auto ErasePos =
+      std::remove_if(ChipPrograms_.begin(), ChipPrograms_.end(),
+                     [&](const std::unique_ptr<CHIPProgram> &Prog) -> bool {
+                       return Prog.get() == ToErase;
+                     });
+  bool WasErased = ErasePos != ChipPrograms_.end();
+  ChipPrograms_.erase(ErasePos, ChipPrograms_.end());
+  return WasErased;
+}
+
 // CHIPQueue
 //*************************************************************************************
 CHIPQueue::CHIPQueue(CHIPDevice *ChipDevice, CHIPQueueFlags Flags, int Priority)
@@ -1718,29 +1729,13 @@ void CHIPQueue::memPrefetch(const void *Ptr, size_t Count) {
   ChipEvent->track();
 }
 
-void CHIPQueue::launchHostFunc(const void *HostFunction, dim3 NumBlocks,
-                               dim3 DimBlocks, void **Args,
-                               size_t SharedMemBytes) {
+void CHIPQueue::launchKernel(CHIPKernel *ChipKernel, dim3 NumBlocks,
+                             dim3 DimBlocks, void **Args,
+                             size_t SharedMemBytes) {
   CHIPExecItem ExecItem(NumBlocks, DimBlocks, SharedMemBytes, this);
-
-  CHIPDevice *ChipDev = getDevice();
-  CHIPKernel *ChipKernel = ChipDev->findKernelByHostPtr(HostFunction);
-
   ExecItem.setArgPointer(Args);
   ExecItem.setKernel(ChipKernel);
   launch(&ExecItem);
-}
-
-void CHIPQueue::launchWithKernelParams(dim3 Grid, dim3 Block,
-                                       unsigned int SharedMemBytes, void **Args,
-                                       CHIPKernel *Kernel) {
-  UNIMPLEMENTED();
-}
-
-void CHIPQueue::launchWithExtraParams(dim3 Grid, dim3 Block,
-                                      unsigned int SharedMemBytes, void **Extra,
-                                      CHIPKernel *Kernel) {
-  UNIMPLEMENTED();
 }
 
 ///////// End Enqueue Operations //////////

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -194,8 +194,8 @@ CHIPEvent::CHIPEvent(CHIPContext *Ctx, CHIPEventFlags Flags)
 // CHIPModuleflags_
 //*************************************************************************************
 void CHIPModule::consumeSPIRV() {
-  FuncIL_ = (uint8_t *)Src_.data();
-  IlSize_ = Src_.length();
+  FuncIL_ = (uint8_t *)Src_->data();
+  IlSize_ = Src_->length();
 
   // Parse the SPIR-V fat binary to retrieve kernel function
   size_t NumWords = IlSize_ / 4;
@@ -210,13 +210,10 @@ void CHIPModule::consumeSPIRV() {
 }
 
 CHIPModule::CHIPModule(std::string *ModuleStr) {
-  Src_ = *ModuleStr;
-  consumeSPIRV();
-}
-CHIPModule::CHIPModule(std::string &&ModuleStr) {
   Src_ = ModuleStr;
   consumeSPIRV();
 }
+
 CHIPModule::~CHIPModule() {}
 
 void CHIPModule::addKernel(CHIPKernel *Kernel) {
@@ -735,6 +732,15 @@ size_t CHIPDevice::getGlobalMemSize() { return HipDeviceProps_.totalGlobalMem; }
 
 void CHIPDevice::addModule(const std::string *ModuleStr, CHIPModule *Module) {
   this->ChipModules[ModuleStr] = Module;
+}
+
+void CHIPDevice::eraseModule(CHIPModule *Module) {
+  std::lock_guard<std::mutex> Lock(Backend->BackendMtx);
+  auto *ModSrc = Module->getModuleSource();
+  if (auto It = ChipModules.find(ModSrc); It != ChipModules.end()) {
+    delete It->second;
+    ChipModules.erase(It);
+  }
 }
 
 void CHIPDevice::registerFunctionAsKernel(std::string *ModuleStr,

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -754,8 +754,8 @@ protected:
   std::vector<CHIPDeviceVar *> ChipVars_;
   // Kernels
   std::vector<CHIPKernel *> ChipKernels_;
-  /// Binary representation extracted from FatBinary
-  std::string Src_;
+  /// Binary representation extracted from FatBinary.
+  std::string *Src_;
   // Kernel JIT compilation can be lazy
   std::once_flag Compiled_;
 
@@ -783,12 +783,6 @@ public:
    * @param module_str string prepresenting the binary extracted from FatBinary
    */
   CHIPModule(std::string *ModuleStr);
-  /**
-   * @brief Construct a new CHIPModule object using move semantics
-   *
-   * @param module_str string from which to move resources
-   */
-  CHIPModule(std::string &&ModuleStr);
 
   /**
    * @brief Add a CHIPKernel to this module.
@@ -889,6 +883,8 @@ public:
   void deallocateDeviceVariablesNoLock(CHIPDevice *Device);
 
   OCLFuncInfo *findFunctionInfo(const std::string &FName);
+
+  const std::string *getModuleSource() const { return Src_; }
 };
 
 /**
@@ -1404,6 +1400,7 @@ public:
 
   virtual CHIPModule *addModule(std::string *ModuleStr) = 0;
   void addModule(const std::string *ModuleStr, CHIPModule *Module);
+  void eraseModule(CHIPModule *Module);
 
   virtual CHIPTexture *
   createTexture(const hipResourceDesc *ResDesc, const hipTextureDesc *TexDesc,

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1597,9 +1597,6 @@ protected:
   CHIPContext *ActiveCtx_;
   CHIPDevice *ActiveDev_;
 
-  // Programs created with hiprtcCreateProgram().
-  std::vector<std::unique_ptr<CHIPProgram>> ChipPrograms_;
-
 public:
   std::mutex SetActiveMtx;
   std::mutex QueueCreateDestroyMtx;
@@ -1886,12 +1883,6 @@ public:
   /* event interop */
   virtual hipEvent_t getHipEvent(void *NativeEvent) = 0;
   virtual void *getNativeEvent(hipEvent_t HipEvent) = 0;
-
-  void addProgram(std::unique_ptr<CHIPProgram> Program) {
-    ChipPrograms_.push_back(std::move(Program));
-  }
-
-  bool eraseProgram(const CHIPProgram *Program);
 };
 
 /**

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2057,8 +2057,7 @@ hipError_t hipMemcpyAsync(void *Dst, const void *Src, size_t SizeBytes,
                           hipMemcpyKind Kind, hipStream_t Stream) {
   CHIP_TRY
   CHIPInitialize();
-  NULLCHECK(Dst);
-  CHECK(Src);
+  NULLCHECK(Dst, Src);
 
   if (SizeBytes == 0)
     RETURN(hipSuccess);
@@ -2094,8 +2093,7 @@ hipError_t hipMemcpy(void *Dst, const void *Src, size_t SizeBytes,
                      hipMemcpyKind Kind) {
   CHIP_TRY
   CHIPInitialize();
-  NULLCHECK(Dst);
-  CHECK(Src);
+  NULLCHECK(Dst, Src);
 
   if (SizeBytes == 0)
     RETURN(hipSuccess);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2839,15 +2839,18 @@ hipError_t hipModuleLoadData(hipModule_t *ModuleHandle, const void *Image) {
     RETURN(hipErrorTbd);
   }
 
-  std::string FilteredModule;
-  if (!filterSPIRV(Module.data(), Module.size(), FilteredModule)) {
+  auto FilteredModule = std::make_unique<std::string>();
+  if (!filterSPIRV(Module.data(), Module.size(), *FilteredModule)) {
     logDebug("Encountered error in SPIR-V filtering.");
     RETURN(hipErrorTbd);
   }
 
-  auto *ChipModule = Backend->getActiveDevice()->addModule(&FilteredModule);
+  auto *ChipModule =
+      Backend->getActiveDevice()->addModule(FilteredModule.get());
   ChipModule->compileOnce(Backend->getActiveDevice());
   *ModuleHandle = ChipModule;
+
+  Backend->registerModuleStr(FilteredModule.release());
 
   RETURN(hipSuccess);
   CHIP_CATCH
@@ -3043,7 +3046,7 @@ hipError_t hipModuleUnload(hipModule_t Module) {
   CHIPInitialize();
   NULLCHECK(Module);
 
-  // TODO: Backend->getActiveDevice()->eraseModule((CHIPModule *)Module));
+  Backend->getActiveDevice()->eraseModule((CHIPModule *)Module);
 
   RETURN(hipSuccess);
   CHIP_CATCH

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -3124,6 +3124,53 @@ hipError_t hipModuleLaunchKernel(hipFunction_t Kernel, unsigned int GridDimX,
   CHIP_CATCH
 }
 
+hipError_t hipExtModuleLaunchKernel(
+    hipFunction_t Kernel,
+    // NOTE: Grid units are threads/work-items instead of blocks/workgroups.
+    uint32_t GlobalWorkSizeX, uint32_t GlobalWorkSizeY,
+    uint32_t GlobalWorkSizeZ, uint32_t LocalWorkSizeX, uint32_t LocalWorkSizeY,
+    uint32_t LocalWorkSizeZ, size_t SharedMemBytes, hipStream_t Stream,
+    void **KernelParams, void **Extra, hipEvent_t StartEvent,
+    hipEvent_t StopEvent, uint32_t Flags) {
+
+  CHIP_TRY
+  NULLCHECK(Kernel);
+  // Null checks on the KernelParams and Extra arguments are performed by
+  // hipModuleLaunchKernel().
+  CHIPInitialize();
+
+  // TODO: Process flags (hipExtAnyOrderLaunch).
+
+  // Check local sizes divide grids.
+  if (GlobalWorkSizeX % LocalWorkSizeX != 0 ||
+      GlobalWorkSizeY % LocalWorkSizeY != 0 ||
+      GlobalWorkSizeZ % LocalWorkSizeZ != 0)
+    RETURN(hipErrorInvalidValue);
+
+  auto GridBlocksX = GlobalWorkSizeX / LocalWorkSizeX;
+  auto GridBlocksY = GlobalWorkSizeY / LocalWorkSizeY;
+  auto GridBlocksZ = GlobalWorkSizeZ / LocalWorkSizeZ;
+
+  hipError_t Result = hipSuccess;
+
+  if (StartEvent)
+    Result = hipEventRecord(StartEvent, Stream);
+  if (Result != hipSuccess)
+    RETURN(Result);
+
+  Result = hipModuleLaunchKernel(Kernel, GridBlocksX, GridBlocksY, GridBlocksZ,
+                                 LocalWorkSizeX, LocalWorkSizeY, LocalWorkSizeZ,
+                                 SharedMemBytes, Stream, KernelParams, Extra);
+  if (Result != hipSuccess)
+    RETURN(Result);
+
+  if (StopEvent)
+    Result = hipEventRecord(StopEvent, Stream);
+
+  RETURN(Result);
+  CHIP_CATCH
+}
+
 //*****************************************************************************
 //*****************************************************************************
 //*****************************************************************************

--- a/src/Filesystem.hh
+++ b/src/Filesystem.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 CHIP-SPV developers
+ * Copyright (c) 2022 Henry Linjamäki / Parmance for Argonne National Laboratory
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,19 +20,25 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef CHIP_CONFIG_H
-#define CHIP_CONFIG_H
+// Provides a namespace alias (fs) over std::filesystem-like module.
 
-#cmakedefine CHIP_SOURCE_DIR "@CHIP_SOURCE_DIR@"
+#ifndef SRC_FILESYSTEM_HH
+#define SRC_FILESYSTEM_HH
 
-#cmakedefine CHIP_BUILD_DIR "@CHIP_BUILD_DIR@"
+#include "Config.hh"
 
-#cmakedefine CHIP_INSTALL_DIR "@CHIP_INSTALL_DIR@"
+#if defined(HAS_FILESYSTEM) && HAS_FILESYSTEM == 1
 
-#cmakedefine CHIP_CLANG_PATH "@CHIP_CLANG_PATH@"
+#include <filesystem>
+namespace fs = std::filesystem;
 
-#cmakedefine HAS_FILESYSTEM @HAS_FILESYSTEM@
+#elif defined(HAS_EXPERIMENTAL_FILESYSTEM) && HAS_EXPERIMENTAL_FILESYSTEM == 1
 
-#cmakedefine HAS_EXPERIMENTAL_FILESYSTEM @HAS_EXPERIMENTAL_FILESYSTEM@
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+#else
+#error filesystem is not available!
+#endif
 
 #endif

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -95,16 +95,13 @@ std::optional<std::string> readFromFile(const fs::path Path) {
 }
 
 std::optional<std::filesystem::path> getHIPCCPath() {
-  static const std::vector<fs::path> SearchLocs = {
-      fs::path(CHIP_INSTALL_DIR) / "bin",
-      fs::path(CHIP_BUILD_DIR) / "bin",
-  };
-
-  for (const auto &SearchLoc : SearchLocs) {
-    auto ExeCand = SearchLoc / "hipcc";
+  // TODO: Probably should detect if we are using a built or an
+  //       installed CHIP library. Mixing the installed and the built
+  //       resources could lead to obscure issues.
+  for (const auto &ExeCand : {fs::path(CHIP_INSTALL_DIR) / "bin/hipcc",
+                              fs::path(CHIP_BUILD_DIR) / "HIPCC/hipcc.bin"})
     if (canExecute(ExeCand))
       return ExeCand;
-  }
 
   return std::nullopt;
 }

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -99,7 +99,8 @@ std::optional<std::filesystem::path> getHIPCCPath() {
   //       installed CHIP library. Mixing the installed and the built
   //       resources could lead to obscure issues.
   for (const auto &ExeCand : {fs::path(CHIP_INSTALL_DIR) / "bin/hipcc",
-                              fs::path(CHIP_BUILD_DIR) / "HIPCC/hipcc.bin"})
+                              fs::path(CHIP_BUILD_DIR) / "bin/hipcc",
+                              fs::path(CHIP_BUILD_DIR) / "bin/hipcc.bin"})
     if (canExecute(ExeCand))
       return ExeCand;
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2022 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Utils.hh"
+
+#include "logging.hh"
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+
+namespace fs = std::filesystem;
+
+template <class T>
+static T copyAs(const void *BaseAddr, size_t ByteOffset = 0) {
+  T Res;
+  std::memcpy(&Res, (const char *)BaseAddr + ByteOffset, sizeof(T));
+  return Res;
+}
+
+/// Returns true if the file can be executed.
+static bool canExecute(const fs::path &Path) {
+  if (!fs::exists(Path))
+    return false;
+
+  const auto &Perms = fs::status(Path).permissions();
+
+  // Only considering file to be executable if it has others_exec bit
+  // set on. For owner_exec and group_exec bits we need to check
+  // user's file access privileges.
+  return (Perms & fs::perms::others_exec) != fs::perms::none;
+}
+
+std::string getRandomString(size_t Length) {
+  constexpr std::string_view CharacterSet =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  std::random_device RandomDevice;
+  std::mt19937 Generator(RandomDevice());
+  std::uniform_int_distribution<> Distribution(0, CharacterSet.size() - 1);
+
+  std::string Result(Length, '\0');
+  for (auto &C : Result)
+    C = CharacterSet[Distribution(Generator)];
+  return Result;
+}
+
+std::optional<fs::path> createTemporaryDirectory() {
+  const auto Prefix = fs::temp_directory_path() / "chip-temp-";
+  for (unsigned Tries = 100; Tries; Tries--) {
+    auto TempDir = Prefix;
+    TempDir += getRandomString(8);
+    // fs::create_directories returning false means that somebody else
+    // has already created the directory and is using it. Try to
+    // create a directory for exclusive use.
+    if (fs::create_directories(TempDir))
+      return TempDir;
+  }
+
+  return std::nullopt;
+}
+
+bool writeToFile(const fs::path Path, const std::string &Data) {
+  std::ofstream File(Path);
+  File << Data;
+  return File.good();
+}
+
+std::optional<std::string> readFromFile(const fs::path Path) {
+  if (auto File = std::ifstream(Path)) {
+    std::stringstream Buffer;
+    Buffer << File.rdbuf();
+    return Buffer.str();
+  }
+  return std::nullopt;
+}
+
+std::optional<std::filesystem::path> getHIPCCPath() {
+  static const std::vector<fs::path> SearchLocs = {
+      fs::path(CHIP_INSTALL_DIR) / "bin",
+      fs::path(CHIP_BUILD_DIR) / "bin",
+  };
+
+  for (const auto &SearchLoc : SearchLocs) {
+    auto ExeCand = SearchLoc / "hipcc";
+    if (canExecute(ExeCand))
+      return ExeCand;
+  }
+
+  return std::nullopt;
+}
+
+std::string_view extractSPIRVModule(const void *Bundle, std::string &ErrorMsg) {
+  // NOTE: This method is designed to read from possibly misaligned buffer.
+
+  std::string Magic(reinterpret_cast<const char *>(Bundle),
+                    sizeof(CLANG_OFFLOAD_BUNDLER_MAGIC) - 1);
+  if (Magic != CLANG_OFFLOAD_BUNDLER_MAGIC) {
+    ErrorMsg = "The bundled binaries are not Clang bundled "
+               "(CLANG_OFFLOAD_BUNDLER_MAGIC is missing)";
+    return std::string_view();
+  }
+
+  using HeaderT = __ClangOffloadBundleHeader;
+  using EntryT = __ClangOffloadBundleDesc;
+  const auto *Header = (const char *)Bundle;
+  auto NumBundles = copyAs<uint64_t>(Header, offsetof(HeaderT, numBundles));
+
+  const char *Desc = Header + offsetof(HeaderT, desc);
+  for (size_t i = 0; i < NumBundles; i++) {
+    auto Offset = copyAs<uint64_t>(Desc, offsetof(EntryT, offset));
+    auto Size = copyAs<uint64_t>(Desc, offsetof(EntryT, size));
+    auto TripleSize = copyAs<uint64_t>(Desc, offsetof(EntryT, tripleSize));
+    const char *Triple = Desc + offsetof(EntryT, triple);
+    std::string_view EntryID(Triple, TripleSize);
+
+    logDebug("Bundle entry ID {} is: '{}'\n", i, EntryID);
+
+    // SPIR-V bundle entry ID for HIP-Clang 14+. Additional components
+    // are ignored for now.
+    std::string_view SPIRVBundleID = "hip-spirv64";
+    if (EntryID.substr(0, SPIRVBundleID.size()) == SPIRVBundleID ||
+        // Legacy entry ID used during early development.
+        EntryID == "hip-spir64-unknown-unknown")
+      return std::string_view(Header + Offset, Size);
+
+    logDebug("Not a SPIR-V triple, ignoring\n");
+    Desc = Triple + TripleSize; // Next bundle entry.
+  }
+
+  ErrorMsg = "Couldn't find SPIR-V binary in the bundle!";
+  return std::string_view();
+}
+
+std::vector<void *>
+convertExtraArgsToPointerArray(void *ExtraArgBuf, const OCLFuncInfo &FuncInfo) {
+  auto *BaseAddr = (uint8_t *)ExtraArgBuf;
+  std::vector<void *> PointerArray;
+  PointerArray.reserve(FuncInfo.ArgTypeInfo.size());
+  unsigned Offset = 0;
+  unsigned i = 0;
+  for (const auto &ArgInfo : FuncInfo.ArgTypeInfo) {
+    // Default argument size and alignment.
+    size_t Size = ArgInfo.Size;
+    size_t Alignment = roundUpToPowerOfTwo(Size);
+    switch (ArgInfo.Type) {
+    default:
+      assert(false && "Unknown OpenCL type!");
+      // FALLTHROUGH.
+    case OCLType::Pointer:
+      if (ArgInfo.Space == OCLSpace::Local)
+        // Not passed by the client. The parameter is created when
+        // there is dynamic shared memory references in the kernel.
+        continue;
+      // FALLTHROUGH.
+    case OCLType::POD:
+      break; // Use default size & alignment.
+
+    case OCLType::Sampler:
+      // Not passed by the client. HipTextureLoweringPass creates these.
+      continue;
+
+    case OCLType::Image:
+      // In device code texture objects are presented as image types.
+      Size = Alignment = 8; // Texture objects are pointers.
+      break;
+    }
+
+    assert(Size && Alignment && "Couldn't determine arg size or alignment!");
+    Offset = roundUp(Offset, Alignment);
+    logDebug("Extra arg {} offset: {}", i++, Offset);
+    PointerArray.push_back(BaseAddr + Offset);
+    Offset += Size;
+  }
+  return PointerArray;
+}

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -28,8 +28,6 @@
 #include <fstream>
 #include <random>
 
-namespace fs = std::filesystem;
-
 template <class T>
 static T copyAs(const void *BaseAddr, size_t ByteOffset = 0) {
   T Res;

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -24,9 +24,56 @@
 #ifndef SRC_UTILS_HH
 #define SRC_UTILS_HH
 
+#include "common.hh"
+
+#include "hip/hip_fatbin.h"
+
+#include <filesystem>
+#include <optional>
+
 /// Clamps 'Val' to [0, INT_MAX] range.
 static inline int clampToInt(size_t Val) {
   return std::min<size_t>(Val, std::numeric_limits<int>::max());
 }
+
+// Round a value up to next power of two - e.g. 13 -> 16, 8 -> 8.
+static inline size_t roundUpToPowerOfTwo(size_t Val) {
+  size_t Pow = 1;
+  while (Pow < Val)
+    Pow *= 2;
+  return Pow;
+}
+
+/// Round a value up e.g. roundUp(9, 8) -> 16.
+static inline size_t roundUp(size_t Val, size_t Rounding) {
+  return ((Val + Rounding - 1) / Rounding) * Rounding;
+}
+
+/// Return a random 'N' length string.
+std::string getRandomString(size_t N);
+
+/// Return a unique directory for temporary use.
+std::optional<std::filesystem::path> createTemporaryDirectory();
+
+/// Write 'Data' into 'Path' file. If the file exists, its content is
+/// overwriten. Return false on errors.
+bool writeToFile(const std::filesystem::path Path, const std::string &Data);
+
+/// Reads contents of file from 'Path' into a std::string.
+std::optional<std::string> readFromFile(const std::filesystem::path Path);
+
+/// Locate hipcc tool. Return an absolute path to it if found.
+std::optional<std::filesystem::path> getHIPCCPath();
+
+/// Returns a span (string_view) over SPIR-V module in the given clang
+/// offload bundle.  Returns empty span if an error was encountered
+/// and 'ErrorMsg' is set to describe the encountered error.
+std::string_view extractSPIRVModule(const void *ClangOffloadBundle,
+                                    std::string &ErrorMsg);
+
+/// Convert "extra" kernel argument passing style to pointer array
+/// style (an array of pointers to the arguments).
+std::vector<void *> convertExtraArgsToPointerArray(void *ExtraArgBuf,
+                                                   const OCLFuncInfo &FuncInfo);
 
 #endif

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -25,10 +25,9 @@
 #define SRC_UTILS_HH
 
 #include "common.hh"
-
+#include "Filesystem.hh"
 #include "hip/hip_fatbin.h"
 
-#include <filesystem>
 #include <optional>
 
 /// Clamps 'Val' to [0, INT_MAX] range.
@@ -53,17 +52,17 @@ static inline size_t roundUp(size_t Val, size_t Rounding) {
 std::string getRandomString(size_t N);
 
 /// Return a unique directory for temporary use.
-std::optional<std::filesystem::path> createTemporaryDirectory();
+std::optional<fs::path> createTemporaryDirectory();
 
 /// Write 'Data' into 'Path' file. If the file exists, its content is
 /// overwriten. Return false on errors.
-bool writeToFile(const std::filesystem::path Path, const std::string &Data);
+bool writeToFile(const fs::path Path, const std::string &Data);
 
 /// Reads contents of file from 'Path' into a std::string.
-std::optional<std::string> readFromFile(const std::filesystem::path Path);
+std::optional<std::string> readFromFile(const fs::path Path);
 
 /// Locate hipcc tool. Return an absolute path to it if found.
-std::optional<std::filesystem::path> getHIPCCPath();
+std::optional<fs::path> getHIPCCPath();
 
 /// Returns a span (string_view) over SPIR-V module in the given clang
 /// offload bundle.  Returns empty span if an error was encountered

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -304,11 +304,16 @@ class CHIPModuleLevel0 : public CHIPModule {
 
 public:
   CHIPModuleLevel0(std::string *ModuleStr) : CHIPModule(ModuleStr) {}
-  virtual ~CHIPModuleLevel0() { logTrace("CHIPModuleLevel0 DEST"); }
-  //   auto Status = zeModuleDestroy(ZeModule_);
-  //   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
-  // Also delete all kernels
-  // }
+
+  virtual ~CHIPModuleLevel0() {
+    logTrace("destroy CHIPModuleLevel0 {}", (void *)this);
+    for (auto *K : ChipKernels_) // Kernels must be destroyed before the module.
+      delete K;
+    ChipKernels_.clear();
+    auto Result = zeModuleDestroy(ZeModule_);
+    assert(Result == ZE_RESULT_SUCCESS && "Double free?");
+  }
+
   /**
    * @brief Compile this module.
    * Extracts kernels, sets the ze_module
@@ -337,7 +342,13 @@ protected:
 
 public:
   CHIPKernelLevel0();
-  virtual ~CHIPKernelLevel0() { logTrace("CHIPKernelLevel0 DEST"); }
+
+  virtual ~CHIPKernelLevel0() {
+    logTrace("destroy CHIPKernelLevel0 {}", (void *)this);
+    auto Result = zeKernelDestroy(ZeKernel_);
+    assert(Result == ZE_RESULT_SUCCESS && "Double free?");
+  }
+
   CHIPKernelLevel0(ze_kernel_handle_t ZeKernel, CHIPDeviceLevel0 *Dev,
                    std::string FuncName, OCLFuncInfo *FuncInfo,
                    CHIPModuleLevel0 *Parent);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -645,7 +645,7 @@ void CHIPModuleOpenCL::compile(CHIPDevice *ChipDev) {
       (CHIPContextOpenCL *)(ChipDevOcl->getContext());
 
   int Err;
-  std::vector<char> BinaryVec(Src_.begin(), Src_.end());
+  std::vector<char> BinaryVec(Src_->begin(), Src_->end());
   auto Program = cl::Program(*(ChipCtxOcl->get()), BinaryVec, false, &Err);
   CHIPERR_CHECK_LOG_AND_THROW(Err, CL_SUCCESS, hipErrorInitializationError);
 

--- a/src/common.hh
+++ b/src/common.hh
@@ -23,6 +23,8 @@
 #ifndef HIP_COMMON_H
 #define HIP_COMMON_H
 
+#include "Config.hh"
+
 #include <map>
 #include <vector>
 #include <stdint.h>

--- a/src/spirv.cc
+++ b/src/spirv.cc
@@ -497,7 +497,7 @@ bool filterSPIRV(const char *Bytes, size_t NumBytes, std::string &Dst) {
   for (size_t I = 0; I < NumWords; I += InsnSize) {
     SPIRVinst Insn(WordsPtr + I);
     InsnSize = Insn.size();
-    assert(InsnSize && "Invalis instruction size, will loop forever!");
+    assert(InsnSize && "Invalid instruction size, will loop forever!");
 
     // A workaround for https://github.com/CHIP-SPV/chip-spv/issues/48.
     //

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022 CHIP-SPV developers.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +24,149 @@ THE SOFTWARE.
 #include <hip/hiprtc.h>
 #include "macros.hh"
 #include "logging.hh"
+#include "CHIPBackend.hh"
+#include "Utils.hh"
+
+#include <filesystem>
+#include <cstdlib>
+#include <regex>
+#include <set>
+
+namespace fs = std::filesystem;
+
+/// Checks the name is valid string for #include (both the "" and <>
+/// forms) and is sensible name for shells as is (doesn't need escaping).
+static bool checkIncludeName(std::string_view Name) {
+  // TODO: capture more valid cases (e.g. foo/bar.h).
+  static const auto RegEx = std::regex("[.\\w][\\-.\\w]*");
+  return std::regex_match(Name.begin(), Name.end(), RegEx);
+}
+
+static bool createHeaderFiles(const CHIPProgram &Program,
+                              const fs::path &DestDir) {
+  for (auto &Header : Program.getHeaders())
+    if (!writeToFile(DestDir / Header.first, Header.second))
+      return false;
+  return true;
+}
+
+static bool createSourceFile(const CHIPProgram &Program,
+                             const fs::path OutputFile) {
+  return writeToFile(OutputFile, Program.getSource());
+}
+
+static bool createCompileCommand(const fs::path &WorkingDirectory,
+                                 const fs::path &SourceFile,
+                                 const fs::path &OutputFile,
+                                 const fs::path &CompileLogFile,
+                                 std::string &CompileCommandRet) {
+
+  CompileCommandRet.clear();
+
+  auto Append = [&](const std::string Str) -> void {
+    if (CompileCommandRet.size())
+      CompileCommandRet += " ";
+    CompileCommandRet += Str;
+  };
+
+  Append("sh -c '");
+
+#ifdef CHIP_CLANG_PATH
+  // For convenience, add the clang (needed by hipcc) found during
+  // project configuration into the PATH in case it's not there
+  // already. The path is appended to the back so we don't override
+  // search paths the client has possibly set.
+  CompileCommandRet +=
+      std::string("export PATH=$PATH:") + CHIP_CLANG_PATH + ";";
+#endif
+
+  // Get path to hipcc tool. If not found use "hipcc" and hope it's
+  // found in PATH.
+  Append(getHIPCCPath().value_or("hipcc"));
+
+  // Emit device code only. Resulting output file is a clang offload bundle.
+  Append("--cuda-device-only");
+
+#ifdef CHIP_SOURCE_DIR
+  // For making the compilation work in the build directory.
+  //
+  // TODO: Could we detect if we are using installed CHIP-SPV and omit
+  //       these options?
+  Append(std::string("-I") + CHIP_SOURCE_DIR + "/HIP/include");
+  Append(std::string("-I") + CHIP_SOURCE_DIR + "/include/hip");
+  Append(std::string("-I") + CHIP_SOURCE_DIR + "/include");
+#endif
+
+  // For locating headers added by hiprtcCreateProgram().
+  Append("-I" + WorkingDirectory.string());
+
+  // Clients don't need to include hip_runtime.h by themselves.
+  Append("--include=hip/hip_runtime.h");
+
+  // By default optimizations are on (-dopt).
+  Append("-O2 -c");
+
+  Append(SourceFile.string());
+  Append("-o " + OutputFile.string());
+  Append(">" + CompileLogFile.string() + " 2>&1");
+
+  CompileCommandRet += "'";
+
+  return true;
+}
+
+static bool executeCommand(const std::string &Command) {
+  logDebug("Executing shell command '{}'", Command);
+  int ReturnCode = std::system(Command.c_str());
+  logDebug("Return code: {}", ReturnCode);
+  return ReturnCode == 0;
+}
+
+// Compiles sources stored in 'Program'. Uses 'WorkingDirectory' for
+// temporary compilation I/O.
+static hiprtcResult compile(CHIPProgram &Program, fs::path WorkingDirectory) {
+  // Create source and header files.
+  auto SourceFile = WorkingDirectory / "program.hip";
+  auto OutputFile = WorkingDirectory / "program.o";
+  auto CompileLogFile = WorkingDirectory / "compile.log";
+
+  if (!createHeaderFiles(Program, WorkingDirectory)) {
+    logError("hiprtc: could not create user header files.");
+    return HIPRTC_ERROR_COMPILATION;
+  }
+
+  if (!createSourceFile(Program, SourceFile)) {
+    logError("hiprtc: could not create user source file.");
+    return HIPRTC_ERROR_COMPILATION;
+  }
+
+  std::string CompileCommand;
+  if (!createCompileCommand(WorkingDirectory, SourceFile, OutputFile,
+                            CompileLogFile, CompileCommand)) {
+    logError("hiprtc: Could not create compilation command.");
+    return HIPRTC_ERROR_COMPILATION;
+  }
+
+  bool ExecSuccess = executeCommand(CompileCommand);
+
+  if (auto Log = readFromFile(CompileLogFile))
+    Program.appendToLog(*Log);
+  else
+    logError("Could not read logfile (unknown reason).");
+
+  if (!ExecSuccess)
+    return HIPRTC_ERROR_COMPILATION;
+
+  auto Bundle = readFromFile(OutputFile);
+  if (!Bundle) {
+    logError("Could not read compilation output '{}' (unknown reason).",
+             OutputFile.string());
+    return HIPRTC_ERROR_COMPILATION;
+  }
+
+  Program.addCode(*Bundle);
+  return HIPRTC_SUCCESS;
+}
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,11 +179,39 @@ extern "C" {
 #endif
 
 const char *hiprtcGetErrorString(hiprtcResult Result) {
-  UNIMPLEMENTED(nullptr);
+#define HANDLE_CASE(E)                                                         \
+  case E:                                                                      \
+    return #E
+
+  switch (Result) {
+  default:
+    logError("Invalid hiprtc error code: {}.", Result);
+    return nullptr;
+
+    HANDLE_CASE(HIPRTC_SUCCESS);
+    HANDLE_CASE(HIPRTC_ERROR_OUT_OF_MEMORY);
+    HANDLE_CASE(HIPRTC_ERROR_PROGRAM_CREATION_FAILURE);
+    HANDLE_CASE(HIPRTC_ERROR_INVALID_INPUT);
+    HANDLE_CASE(HIPRTC_ERROR_INVALID_PROGRAM);
+    HANDLE_CASE(HIPRTC_ERROR_INVALID_OPTION);
+    HANDLE_CASE(HIPRTC_ERROR_COMPILATION);
+    HANDLE_CASE(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+    HANDLE_CASE(HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION);
+    HANDLE_CASE(HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION);
+    HANDLE_CASE(HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID);
+    HANDLE_CASE(HIPRTC_ERROR_INTERNAL_ERROR);
+  }
+#undef HANDLE_CASE
 }
 
 hiprtcResult hiprtcVersion(int *Major, int *Minor) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Major || !Minor)
+    return HIPRTC_ERROR_INVALID_INPUT;
+
+  // TODO: Choose a version to return. Returning dummy version values for now.
+  *Major = 1;
+  *Minor = 0;
+  return HIPRTC_SUCCESS;
 }
 
 hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
@@ -49,18 +221,113 @@ hiprtcResult hiprtcAddNameExpression(hiprtcProgram Prog,
 
 hiprtcResult hiprtcCompileProgram(hiprtcProgram Prog, int NumOptions,
                                   const char **Options) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  logTrace("{}", __func__);
+
+  if (NumOptions < 0)
+    return HIPRTC_ERROR_INVALID_INPUT;
+
+  if (NumOptions)
+    logWarn("hiprtc: compile options are ignored (not supported yet).");
+
+  for (int OptIdx = 0; OptIdx < NumOptions; OptIdx++) {
+    const auto *Option = Options[OptIdx];
+    if (!Option)
+      return HIPRTC_ERROR_INVALID_INPUT;
+    logDebug("hiprtc: option: '{}'", Option);
+  }
+
+  if (!Prog)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  try {
+    auto &Program = *(CHIPProgram *)Prog;
+
+    // Create temporary directory for compilation I/O.
+    auto TmpDir = createTemporaryDirectory();
+    if (!TmpDir) {
+      logError(
+          "hiprtc: Failed to create a temporary directory for compilation.");
+      return HIPRTC_ERROR_COMPILATION;
+    }
+
+    logDebug("hiprtc: Temp directory: '{}'", TmpDir->string());
+    hiprtcResult Result = compile(Program, *TmpDir);
+
+    // TODO: Add a debug option for preserving the directory.
+    assert(!TmpDir->empty() && *TmpDir != TmpDir->root_path() &&
+           "Attempted to delete a root directory!");
+
+    logDebug("Removing '{}'", TmpDir->string());
+    std::error_code IgnoreErrors;
+    fs::remove_all(*TmpDir, IgnoreErrors);
+
+    return Result;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcCreateProgram(hiprtcProgram *Prog, const char *Src,
                                  const char *Name, int NumHeaders,
                                  const char **Headers,
                                  const char **IncludeNames) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  if (!Src)
+    return HIPRTC_ERROR_INVALID_INPUT;
+
+  try {
+    // From NVRTC: 'CUDA program name. name can be NULL;
+    // "default_program" is used when name is NULL or "". '.
+    auto Program =
+        std::make_unique<CHIPProgram>(Name ? Name : "default_program");
+    Program->setSource(Src);
+
+    for (int i = 0; i < NumHeaders; i++) {
+      auto *IncludeNamePtr = IncludeNames[i];
+      auto *HeaderPtr = Headers[i];
+
+      if (!IncludeNamePtr) {
+        logError("Include name must not be null.");
+        return HIPRTC_ERROR_INVALID_INPUT;
+      }
+      if (!HeaderPtr) {
+        logError("Include contents buffer must not be null.");
+        return HIPRTC_ERROR_INVALID_INPUT;
+      }
+
+      std::string_view IncludeName(IncludeNamePtr);
+      if (IncludeName.empty()) // Nameless headers can't be included.
+        continue;
+
+      if (!checkIncludeName(IncludeNamePtr)) {
+        logError("Invalid include name.");
+        return HIPRTC_ERROR_INVALID_INPUT;
+      }
+
+      Program->addHeader(IncludeName, HeaderPtr);
+    }
+
+    *Prog = (hiprtcProgram)Program.get();
+    Backend->addProgram(std::move(Program));
+    return HIPRTC_SUCCESS;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcDestroyProgram(hiprtcProgram *Prog) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog || !*Prog)
+    return HIPRTC_ERROR_INVALID_PROGRAM;
+  try {
+    return Backend->eraseProgram((CHIPProgram *)*Prog)
+               ? HIPRTC_SUCCESS
+               : HIPRTC_ERROR_INVALID_PROGRAM;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcGetLoweredName(hiprtcProgram Prog,
@@ -70,19 +337,57 @@ hiprtcResult hiprtcGetLoweredName(hiprtcProgram Prog,
 }
 
 hiprtcResult hiprtcGetProgramLog(hiprtcProgram Prog, char *Log) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog || !Log)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  try {
+    const auto &LogSrc = ((CHIPProgram *)Prog)->getProgramLog();
+    std::memcpy(Log, LogSrc.c_str(), LogSrc.size());
+    return HIPRTC_SUCCESS;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcGetProgramLogSize(hiprtcProgram Prog, size_t *LogSizeRet) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog || !LogSizeRet)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  try {
+    *LogSizeRet = ((CHIPProgram *)Prog)->getProgramLog().size();
+    return HIPRTC_SUCCESS;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcGetCode(hiprtcProgram Prog, char *Code) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog)
+    return HIPRTC_ERROR_INVALID_PROGRAM;
+  if (!Code)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  try {
+    auto &SavedCode = ((CHIPProgram *)Prog)->getCode();
+    std::memcpy(Code, SavedCode.c_str(), SavedCode.size());
+    return HIPRTC_SUCCESS;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 hiprtcResult hiprtcGetCodeSize(hiprtcProgram Prog, size_t *CodeSizeRet) {
-  UNIMPLEMENTED(HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE);
+  if (!Prog)
+    return HIPRTC_ERROR_INVALID_PROGRAM;
+  if (!CodeSizeRet)
+    return HIPRTC_ERROR_INVALID_INPUT;
+  try {
+    *CodeSizeRet = ((CHIPProgram *)Prog)->getCode().size();
+    return HIPRTC_SUCCESS;
+  } catch (...) {
+    logDebug("Caught an unknown exception\n");
+    return HIPRTC_ERROR_INTERNAL_ERROR;
+  }
 }
 
 #if !defined(_WIN32)

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -305,8 +305,7 @@ hiprtcResult hiprtcCreateProgram(hiprtcProgram *Prog, const char *Src,
       Program->addHeader(IncludeName, HeaderPtr);
     }
 
-    *Prog = (hiprtcProgram)Program.get();
-    Backend->addProgram(std::move(Program));
+    *Prog = (hiprtcProgram)Program.release();
     return HIPRTC_SUCCESS;
   } catch (...) {
     logDebug("Caught an unknown exception\n");
@@ -318,13 +317,13 @@ hiprtcResult hiprtcDestroyProgram(hiprtcProgram *Prog) {
   if (!Prog || !*Prog)
     return HIPRTC_ERROR_INVALID_PROGRAM;
   try {
-    return Backend->eraseProgram((CHIPProgram *)*Prog)
-               ? HIPRTC_SUCCESS
-               : HIPRTC_ERROR_INVALID_PROGRAM;
+    delete (CHIPProgram *)*Prog;
+    *Prog = nullptr;
   } catch (...) {
     logDebug("Caught an unknown exception\n");
     return HIPRTC_ERROR_INTERNAL_ERROR;
   }
+  return HIPRTC_SUCCESS;
 }
 
 hiprtcResult hiprtcGetLoweredName(hiprtcProgram Prog,

--- a/src/spirv_hiprtc.cc
+++ b/src/spirv_hiprtc.cc
@@ -27,12 +27,9 @@ THE SOFTWARE.
 #include "CHIPBackend.hh"
 #include "Utils.hh"
 
-#include <filesystem>
 #include <cstdlib>
 #include <regex>
 #include <set>
-
-namespace fs = std::filesystem;
 
 /// Checks the name is valid string for #include (both the "" and <>
 /// forms) and is sensible name for shells as is (doesn't need escaping).


### PR DESCRIPTION
Implement hiprtc API for basic runtime compilation cases

Supported:

* Invoking extern "C" `__global__` kernels.

Unsupported or missing features:

* Compile options (currently ignored).
* Invoking non-extern "C" `__global__` kernels (required `hiprtcAddNameExpression()` and `hiprtcGetLoweredName()` functions are not implemented yet).