### PR TITLE
Fixes and documentation updates for Release 0.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "HIP"]
+	path = HIP
+	url = https://github.com/CHIP-SPV/HIP.git
 [submodule "Catch2"]
 	path = Catch2
 	url = https://github.com/catchorg/Catch2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "HIP"]
-	path = HIP
-	url = https://github.com/CHIP-SPV/HIP.git
 [submodule "Catch2"]
 	path = Catch2
 	url = https://github.com/catchorg/Catch2.git

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-1.0-pre   September 2022
+0.9    September 2022
 =====================
 
 Initial release of CHIP-SPV
@@ -6,4 +6,4 @@ Initial release of CHIP-SPV
 - support for OpenCL and Level0 backends
 - support for Clang 14 & 15
 - most of the HIP API supported
-- ability to compile CUDA 8.0 sources directly
+- ability to compile some CUDA 8.0 based applications directly

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # CHIP-SPV
 
-CHIP-SPV is a HIP implementation that abstracts HIP API, providing a
-set of base classes that can be derived from to implement an
-additional, SPIR-V capable backend on which to execute HIP
-calls.
-
-Currently CHIP-SPV supports OpenCL and Level Zero as backend alternatives.
+CHIP-SPV that aims to make HIP and CUDA portable to platforms which support
+SPIR-V as the device intermediate representation. Currently CHIP-SPV supports
+OpenCL and Level Zero as the low-level runtime alternatives.
 
 This project is an integration of [HIPCL](https://github.com/cpc/hipcl) and
 [HIPLZ](https://github.com/jz10/anl-gt-gpu/) projects.
@@ -26,13 +23,12 @@ For a list of (un)supported features in CHIP-SPV, read [this.](docs/Features.md)
   * [Intel Compute Runtime](https://github.com/intel/compute-runtime) and
   * [oneAPI Level Zero Loader](https://github.com/oneapi-src/level-zero/releases)
 * For OpenCL Backend
-  * OpenCL implementation with Shared Virtual Memory and SPIR-V
-    support.
+  * OpenCL 2.0 or 3.0 implementation with coarse grained Shared Virtual Memory and SPIR-V input supported.
 
 ## Downloading Sources
 
 ```bash
-git clone https://github.com/CHIP-SPV/chip-spv.git
+git clone https://github.com/CHIP-SPV/chip-spv.git -b Release-0.9
 cd chip-spv
 git submodule update --init --recursive
 ```
@@ -47,15 +43,27 @@ cmake .. \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_INSTALL_PREFIX=<install location>
- # optional: -DCMAKE_BUILD_TYPE=<Debug(default), Release, RelWithDebInfo>
- # optional: to provide a path to separately built SPIRV-LLVM translator, use -DLLVM_SPIRV_BINARY=/path
+
 make
 make install
 ```
 
-Be sure you refer to the clang++ and clang binaries you want to build against in
-the above command. For example, the LLVM debian packages might install binaries with
-a version suffix in the names: 'clang++-15' and 'clang-15'.
+Note: At the moment the build assumes it finds the following LLVM project binaries
+with the given names 'clang++', 'clang' and 'llvm-link'. Thus, make sure you have
+symlinks setup to the correct versions before building chip-spv. See [Issue 133](https://github.com/CHIP-SPV/chip-spv/issues/133)).
+
+Useful options:
+ * -DCMAKE_BUILD_TYPE=<Debug(default), Release, RelWithDebInfo>
+ * to provide a path to separately built SPIRV-LLVM translator, use -DLLVM_SPIRV_BINARY=/path
+
+The documentation will be placed in `doxygen/html`.
+
+## Building & Running Unit Tests
+
+```bash
+make build_tests_standalone
+make check # runs only tests that are expected to work
+```
 
 ## Building documentation
 

--- a/docs/release_notes/release-0.9.txt
+++ b/docs/release_notes/release-0.9.txt
@@ -6,26 +6,23 @@ devices which support SPIR-V's OpenCL profile as the input intermediate
 language. It supports OpenCL and Intel oneAPI Level Zero as the low-level
 runtime options.
 
-This is the first preview release of the project, thus bumps the road.
-However, we have tested it somewhat and shaved off the most apparent
-issues with a bunch of tests and small application cases.
+This is the first preview release of the project, thus please tolerate some
+bumps the road. However, we have tested it in the past weeks and shaved off
+the most dramatic issues with a bunch of tests and small application cases.
 
 Testers and especially contributing developers are welcomed to join the
-effort.
+effort!
 
 Release Highlights
 ------------------
 
-* The compilation toolchain works with upstream Clang/LLVM 14 and 15.
+* The compilation toolchain works with upstream Clang/LLVM 15.
 * Over 600 unit tests and various small applications pass.
 * See the Features document for the current HIP/CUDA feature coverage.
-* Tested with Intel Level Zero on multiple GPU devices [list].
-* Tested with Intel OpenCL for CPUs and GPUs on various devices [list]
+* Tested with Intel Level Zero on multiple GPU devices.
+* Tested with Intel OpenCL for CPUs and GPUs.
 
 Links
 -----
 
-Release web page: https://github.com/CHIP-SPV/chip-spv/[FILL]
-This announcement: https://github.com/CHIP-SPV/chip-spv/[FILL]
-Change log: https://github.com/CHIP-SPV/chip-spv/blob/Release-0.9/CHANGES
-Download: https://github.com/CHIP-SPV/chip-spv/[FILL]
+Release web page: [tbd]

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -992,8 +992,11 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
   if (TargetQueue == DefaultQueue) {
     for (auto &q : QueuesToSyncWith) {
       auto Ev = q->getLastEvent();
-      if (Ev)
-        EventsToWaitOn.push_back(Ev);
+      if (Ev && Ev->getCHIPRefc() > 0) {
+        Ev->updateFinishStatus(false);
+        if (!Ev->isFinished())
+          EventsToWaitOn.push_back(Ev);
+      }
     }
     std::lock_guard<std::mutex> LockQueue(TargetQueue->QueueMtx);
     SyncQueuesEvent = TargetQueue->enqueueBarrierImpl(&EventsToWaitOn);
@@ -1001,8 +1004,12 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
     TargetQueue->updateLastEvent(SyncQueuesEvent);
   } else { // blocking stream must wait until default stream is done
     auto Ev = DefaultQueue->getLastEvent();
-    if (Ev)
-      EventsToWaitOn.push_back(Ev);
+    if (Ev) {
+      std::lock_guard<std::mutex> LockEvent(Ev->EventMtx);
+      Ev->updateFinishStatus(false);
+      if (!Ev->isFinished())
+        EventsToWaitOn.push_back(Ev);
+    }
     std::lock_guard<std::mutex> LockQueue(TargetQueue->QueueMtx);
     SyncQueuesEvent = TargetQueue->enqueueBarrierImpl(&EventsToWaitOn);
     SyncQueuesEvent->Msg = "barrierSyncQueue";
@@ -1052,12 +1059,13 @@ void *CHIPContext::allocate(size_t Size, size_t Alignment,
 
   CHIPDevice *ChipDev = Backend->getActiveDevice();
 
-    if (Size > ChipDev->getMaxMallocSize()) {
+  if (Size > ChipDev->getMaxMallocSize()) {
     logCritical("Requested allocation of {} exceeds the maximum size of a "
                 "single allocation of {}",
                 Size, ChipDev->getMaxMallocSize());
-    CHIPERR_LOG_AND_THROW("Allocation size exceeds limits for a single allocation",
-                          hipErrorOutOfMemory);
+    CHIPERR_LOG_AND_THROW(
+        "Allocation size exceeds limits for a single allocation",
+        hipErrorOutOfMemory);
   }
   assert(ChipDev->getContext() == this);
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1056,8 +1056,8 @@ void *CHIPContext::allocate(size_t Size, size_t Alignment,
     logCritical("Requested allocation of {} exceeds the maximum size of a "
                 "single allocation of {}",
                 Size, ChipDev->getMaxMallocSize());
-    CHIPERR_LOG_AND_THROW("Allocation size exceeds limits",
-                          hipErrorInvalidValue);
+    CHIPERR_LOG_AND_THROW("Allocation size exceeds limits for a single allocation",
+                          hipErrorOutOfMemory);
   }
   assert(ChipDev->getContext() == this);
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1068,7 +1068,7 @@ void *CHIPContext::allocate(size_t Size, size_t Alignment,
   if (AllocatedPtr == nullptr)
     ChipDev->AllocationTracker->releaseMemReservation(Size);
 
-  if (MemType == hipMemoryTypeUnified || isAllocatedPtrUSM(AllocatedPtr)) {
+  if (MemType == hipMemoryTypeUnified || isAllocatedPtrMappedToVM(AllocatedPtr)) {
     HostPtr = AllocatedPtr;
     MemType = hipMemoryTypeUnified;
   }

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -530,6 +530,7 @@ class CHIPDevice;
 
 class CHIPEvent {
 protected:
+  bool UserEvent_ = false;
   bool TrackCalled_ = false;
   event_status_e EventStatus_;
   CHIPEventFlags Flags_;
@@ -552,6 +553,7 @@ protected:
   CHIPEvent() = default;
 
 public:
+  bool isUserEvent() { return UserEvent_; }
   void addDependency(CHIPEvent *Event) { DependsOnList.push_back(Event); }
   void releaseDependencies() {
     for (auto Event : DependsOnList) {
@@ -2131,6 +2133,7 @@ public:
                                        int *NumHandles) = 0;
 
   CHIPContext *getContext() { return ChipContext_; }
+  void setFlags(CHIPQueueFlags TheFlags) { QueueFlags_ = TheFlags; }
 };
 
 #endif

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1479,15 +1479,14 @@ public:
                CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) = 0;
 
   /**
-   * @brief Returns true if the pointer is USM (unified shared memory).
-   * Some backends (like OpenCL) always return USM independently of which
-   * hipMemoryType is requested in allocation
+   * @brief Returns true if the pointer is mapped to virtual memory with
+   * updates synchronized to it automatically at synchronization points.
    *
-   * @param Ptr pointer to memory allocated by allocate()
+   * @param Ptr pointer to memory allocated by allocate().
    * @return true/false
    */
 
-  virtual bool isAllocatedPtrUSM(void *Ptr) = 0;
+  virtual bool isAllocatedPtrMappedToVM(void *Ptr) = 0;
 
   /**
    * @brief Free memory

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1360,7 +1360,7 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
   ze_result_t Status;
   Status = zeInit(0);
   if (Status != ZE_RESULT_SUCCESS) {
-    logError("zeInit failed ");
+    logError("zeInit failed with code {}", Status);
     std::abort();
   }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -292,7 +292,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemTy,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
-  bool isAllocatedPtrUSM(void *Ptr) override { return false; } // TODO
+  bool isAllocatedPtrMappedToVM(void *Ptr) override { return false; } // TODO
   void freeImpl(void *Ptr) override{};                         // TODO
   ze_context_handle_t &get() { return ZeCtx; }
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -147,7 +147,7 @@ public:
   void *allocateImpl(size_t Size, size_t Alignment, hipMemoryType MemType,
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
-  bool isAllocatedPtrUSM(void *Ptr) override { return true; }
+  bool isAllocatedPtrMappedToVM(void *Ptr) override { return false; } // TODO
   virtual void freeImpl(void *Ptr) override;
   cl::Context *get();
 };

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -91,7 +91,7 @@ public:
 
 public:
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext, cl_event ClEvent,
-                  CHIPEventFlags Flags = CHIPEventFlags());
+                  CHIPEventFlags Flags = CHIPEventFlags(), bool UserEvent = false);
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext,
                   CHIPEventFlags Flags = CHIPEventFlags());
   virtual ~CHIPEventOpenCL() override;
@@ -101,10 +101,13 @@ public:
   float getElapsedTime(CHIPEvent *Other) override;
   virtual void hostSignal() override;
   virtual bool updateFinishStatus(bool ThrowErrorIfNotReady = true) override;
-  cl_event peek();
-  cl_event get();
+  cl_event* getNativePtr() {return &ClEvent;}
+  cl_event& getNativeRef() {return ClEvent;}
   uint64_t getFinishTime();
   size_t getRefCount();
+
+  virtual void increaseRefCount(std::string Reason) override;
+  virtual void decreaseRefCount(std::string Reason) override;
 };
 
 class CHIPModuleOpenCL : public CHIPModule {


### PR DESCRIPTION
With these, the #142 status goes to:

```
97% tests passed, 23 tests failed out of 671

Label Time Summary:
cuda        =  63.34 sec*proc (27 tests)
internal    =  84.68 sec*proc (80 tests)

Total Test time (real) = 665.05 sec

The following tests did not run:
	641 - sycl_chip_interop (Skipped)
	642 - sycl_chip_interop_usm (Skipped)

The following tests FAILED:
	100 - Unit_hipMemcpy_HalfMemCopy (Failed)
	127 - Unit_hipMemset_InvalidPtrTests (Failed)
	205 - Unit_hipMemcpyAsync_KernelLaunch - int (Failed)
	206 - Unit_hipMemcpyAsync_KernelLaunch - float (Failed)
	207 - Unit_hipMemcpyAsync_KernelLaunch - double (Failed)
	500 - Unit_hipStreamGetFlags_BasicFunctionalities (Failed)
	508 - Unit_hipMultiStream_sameDevice (SEGFAULT)
	519 - Unit_hipStreamCreate_MultistreamBasicFunctionalities (Failed)
	545 - Unit_hipDeviceSynchronize_Functional (Failed)
	562 - Unit_hipStreamPerThread_Basic (Failed)
	571 - Unit_hipStreamPerThread_MultiThread (SEGFAULT)
	572 - Unit_hipStreamPerThread_DeviceReset_1 (SEGFAULT)
	579 - Stress_hipMalloc (Failed)
	581 - Stress_hipMemcpy_multiDevice-AllAPIs - int (Timeout)
	582 - Stress_hipMemcpy_multiDevice-AllAPIs - size_t (Timeout)
	583 - Stress_hipMemcpy_multiDevice-AllAPIs - long double (Failed)
	585 - activemask (Failed)
	592 - fp16 (Subprocess aborted)
	601 - 2d_shuffle (Failed)
	609 - hipStreamSemantics (Failed)
	613 - hipConstantTestDeviceSymbol (Subprocess aborted)
	639 - hipAddressingModes (Failed)
	662 - cuda-blackscholes (Failed)
Errors while running CTest
```
With this race condition workaround patch for #152 

```C++
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2096,6 +2096,9 @@ hipError_t hipMemcpy(void *Dst, const void *Src, size_t SizeBytes,
   NULLCHECK(Dst);
   CHECK(Src);

+  // See https://github.com/CHIP-SPV/chip-spv/issues/152.
+  // Let's be safe first, and optimize the asynch behavior later.
+  hipDeviceSynchronize();
   if (SizeBytes == 0)
     RETURN(hipSuccess);
```

it goes down to
```
97% tests passed, 18 tests failed out of 671

Label Time Summary:
cuda        =  62.26 sec*proc (27 tests)
internal    =  83.08 sec*proc (80 tests)

Total Test time (real) = 392.48 sec

The following tests did not run:
	641 - sycl_chip_interop (Skipped)
	642 - sycl_chip_interop_usm (Skipped)

The following tests FAILED:
	127 - Unit_hipMemset_InvalidPtrTests (Failed)
	173 - Unit_hipMemcpyWithStream_MultiThread (SEGFAULT)
	205 - Unit_hipMemcpyAsync_KernelLaunch - int (Failed)
	206 - Unit_hipMemcpyAsync_KernelLaunch - float (Failed)
	207 - Unit_hipMemcpyAsync_KernelLaunch - double (Failed)
	500 - Unit_hipStreamGetFlags_BasicFunctionalities (Failed)
	508 - Unit_hipMultiStream_sameDevice (SEGFAULT)
	519 - Unit_hipStreamCreate_MultistreamBasicFunctionalities (Failed)
	545 - Unit_hipDeviceSynchronize_Functional (Failed)
	562 - Unit_hipStreamPerThread_Basic (Failed)
	571 - Unit_hipStreamPerThread_MultiThread (Subprocess aborted)
	572 - Unit_hipStreamPerThread_DeviceReset_1 (Subprocess aborted)
	579 - Stress_hipMalloc (Failed)
	601 - 2d_shuffle (Failed)
	609 - hipStreamSemantics (Failed)
	613 - hipConstantTestDeviceSymbol (Subprocess aborted)
	639 - hipAddressingModes (Failed)
	662 - cuda-blackscholes (Failed)
```
I didn't test with LZ, so someone with a functioning LZ config please test, review and pull in. Thanks!
