### PR TITLE
Fix a test failed after switching to C++-based hipcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,14 @@ enable_testing()
 add_subdirectory(HIP/tests/catch catch)
 add_subdirectory(tests/cuda)
 add_subdirectory(./samples samples)
+set(HIPCC_BUILD_PATH "${CMAKE_BINARY_DIR}/bin")
 add_subdirectory(HIPCC)
 # Make CHIP depend on devicelib_bc and LLVMHipPasses for
 # convenience. The CHIP module itself does not depend on these but
 # HIP program compilation does.
 add_dependencies(CHIP devicelib_bc LLVMHipPasses)
 add_dependencies(samples CHIP)
-add_dependencies(CHIP hipcc.bin)
+add_dependencies(CHIP hipcc.bin hipconfig.bin)
 
 add_subdirectory(bin)
 
@@ -499,9 +500,13 @@ file(WRITE "${PROJECT_BINARY_DIR}/share/.hipInfo" ${_hipInfo_build})
 install(FILES ${PROJECT_BINARY_DIR}/share/.hipInfo_install
   DESTINATION ${SHARE_INSTALL_DIR} RENAME .hipInfo)
 
+# Copy over includes for hipcc to work in the build dir
+file(COPY ${CMAKE_SOURCE_DIR}/include DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${CMAKE_SOURCE_DIR}/HIP/include/hip DESTINATION ${CMAKE_BINARY_DIR}/include)
+
 # Copy hipconfig, hipvars, etc to bin
-install(FILES ${CMAKE_BINARY_DIR}/HIPCC/hipcc.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipcc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)
-install(FILES ${CMAKE_BINARY_DIR}/HIPCC/hipconfig.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipconfig PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)
+install(FILES ${CMAKE_BINARY_DIR}/bin/hipcc.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipcc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)
+install(FILES ${CMAKE_BINARY_DIR}/bin/hipconfig.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipconfig PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)
 
 set(CHIP_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
 set(CHIP_CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})

--- a/bin/cuspvc-build.in
+++ b/bin/cuspvc-build.in
@@ -29,5 +29,6 @@
 #=============================================================================
 
 export HIP_PLATFORM=spirv
-export PATH=@CLANG_BIN_DIR@:@CMAKE_BINARY_DIR@/bin:$PATH
-hipcc @CHIP_INCLUDES@ "$@"
+export HIP_PATH=@CMAKE_BINARY_DIR@
+export PATH=@CLANG_BIN_DIR@:@CMAKE_BINARY_DIR@/bin:@CMAKE_BINARY_DIR@/HIPCC:$PATH
+hipcc.bin @CHIP_INCLUDES@ "$@"

--- a/bin/cuspvc-build.in
+++ b/bin/cuspvc-build.in
@@ -29,6 +29,6 @@
 #=============================================================================
 
 export HIP_PLATFORM=spirv
+export PATH=@CLANG_BIN_DIR@:@CMAKE_BINARY_DIR@/bin:$PATH
 export HIP_PATH=@CMAKE_BINARY_DIR@
-export PATH=@CLANG_BIN_DIR@:@CMAKE_BINARY_DIR@/bin:@CMAKE_BINARY_DIR@/HIPCC:$PATH
 hipcc.bin @CHIP_INCLUDES@ "$@"

--- a/bin/cuspvc-install.in
+++ b/bin/cuspvc-install.in
@@ -28,6 +28,7 @@
 #=============================================================================
 
 export HIP_PLATFORM=spirv
+export HIP_PATH=@CMAKE_INSTALL_PREFIX@
 # Set PATH for locating hipcc and clang.
 export PATH=@CLANG_BIN_DIR@:@CMAKE_INSTALL_PREFIX@/bin:$PATH
 hipcc -I@CMAKE_INSTALL_PREFIX@/include/cuspv "$@"

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -18,6 +18,8 @@ function(add_compile_test)
 endfunction()
 
 add_compile_test(NAME activemask SOURCES activemask.cu
-  COMPILE_OPTIONS -fsyntax-only)
+  # '-c' option is a kludge fix for C++ based hipcc. This test worked
+  # without the option with the previous perl-based hipcc.
+  COMPILE_OPTIONS "-fsyntax-only -c")
 set_tests_properties(activemask PROPERTIES
   PASS_REGULAR_EXPRESSION "error: '__activemask' is unavailable: unsupported in CHIP-SPV")


### PR DESCRIPTION
This fix requires HIPCC submodule to be updated with fixes from https://github.com/CHIP-SPV/HIPCC/pull/1.

