### PR TITLE
Fix hipMemset behavior with host malloc'd pointers

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2267,16 +2267,17 @@ hipError_t hipMemset(void *Dst, int Value, size_t SizeBytes) {
     logDebug("Found associated alloc info");
 
     Backend->getActiveDevice()->getDefaultQueue()->memFill(Dst, SizeBytes,
-							   &CharVal, 1);
+                                                           &CharVal, 1);
     auto RegisterMemDst = AllocInfo->HostPtr;
     if (RegisterMemDst)
       memset(RegisterMemDst, Value, SizeBytes);
     RETURN(hipSuccess);
   } else {
     logDebug("Unregistered pointer");
-    // Unregistered pointer, so it's either not a device pointer or it's a Unified
-    // Memory pointer allocated with host malloc() which could be accessible directly
-    // by the device or not, depending on its UM capabilities.
+    // Unregistered pointer, so it's either not a device pointer or it's a
+    // Unified Memory pointer allocated with host malloc() which could be
+    // accessible directly by the device or not, depending on its UM
+    // capabilities.
     if (Backend->getActiveDevice()->getContext()->isAllocatedPtrMappedToVM(
             Dst)) {
       logDebug("Pointer mapped to VM.");

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2258,8 +2258,6 @@ hipError_t hipMemset(void *Dst, int Value, size_t SizeBytes) {
 
   char CharVal = Value;
   Backend->getActiveDevice()->initializeDeviceVariables();
-  Backend->getActiveDevice()->getDefaultQueue()->memFill(Dst, SizeBytes,
-                                                         &CharVal, 1);
 
   // Check if this pointer is registered
   auto AllocTracker = Backend->getActiveDevice()->AllocationTracker;
@@ -2267,12 +2265,29 @@ hipError_t hipMemset(void *Dst, int Value, size_t SizeBytes) {
 
   if (AllocInfo) {
     logDebug("Found associated alloc info");
+
+    Backend->getActiveDevice()->getDefaultQueue()->memFill(Dst, SizeBytes,
+							   &CharVal, 1);
     auto RegisterMemDst = AllocInfo->HostPtr;
     if (RegisterMemDst)
       memset(RegisterMemDst, Value, SizeBytes);
+    RETURN(hipSuccess);
+  } else {
+    logDebug("Unregistered pointer");
+    // Unregistered pointer, so it's either not a device pointer or it's a Unified
+    // Memory pointer allocated with host malloc() which could be accessible directly
+    // by the device or not, depending on its UM capabilities.
+    if (Backend->getActiveDevice()->getContext()->isAllocatedPtrMappedToVM(
+            Dst)) {
+      logDebug("Pointer mapped to VM.");
+      Backend->getActiveDevice()->getDefaultQueue()->memFill(Dst, SizeBytes,
+                                                             &CharVal, 1);
+      RETURN(hipSuccess);
+    } else {
+      RETURN(hipErrorInvalidValue);
+    }
   }
 
-  RETURN(hipSuccess);
   CHIP_CATCH
 }
 


### PR DESCRIPTION
AFAIU it should not just go and fill the memory as asked in that case, but return an error if it's not an UM-mapped pointer.

Fixes Unit_hipMemset_InvalidPtrTests for OpenCL.

@pvelesko  can you test with the Aurora envs and push this in if works and looks OK? Thanks!