### PR TITLE
hiprtc: support C++ kernels and handle user options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ add_subdirectory(llvm_passes)
 add_subdirectory(bitcode)
 
 add_subdirectory(tests/cuda)
+add_subdirectory(tests/hiprtc)
 add_subdirectory(./samples samples)
 set(HIPCC_BUILD_PATH "${CMAKE_BINARY_DIR}/bin")
 add_subdirectory(HIPCC)

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -7,7 +7,6 @@ This is a (non-exhaustive) list of features currently (un)supported by CHIP-SPV.
 
 #### Unsupported / unimplemented APIs
 
-* hipRtc API
 * hipGraph API
 * hipIpc API
 * hipModuleOccupancy API
@@ -24,8 +23,10 @@ This is a (non-exhaustive) list of features currently (un)supported by CHIP-SPV.
   hipModuleLoadData, hipModuleUnload, hipModuleLaunchKernel
 
 #### partially supported
-  * Texture Objects of 1D/2D type are supported; 3D, LOD, Grad,
-    Cubemap, Gather and Mipmapped textures are not supported
+* Texture Objects of 1D/2D type are supported; 3D, LOD, Grad,
+  Cubemap, Gather and Mipmapped textures are not supported.
+* hiprtc: Referring global device variables, constants and texture
+  references in the name expressions are not supported.
 
 ### Device side
 
@@ -47,3 +48,13 @@ This is a (non-exhaustive) list of features currently (un)supported by CHIP-SPV.
 ### Known issues
 
 * warpSize might depend on the kernel instead of being a device constant
+
+* hiprtc: Valid name expressions with a function pointer cast
+  (e.g. '(void(*)(float *))akernel') fails with misleading
+  messages. For example: "error: address of overloaded function
+  'akernel' does not match required type ...". This issue prevents
+  disambiguation of overloaded kernels.
+
+* hiprtc: quoted strings are not preserved due to the way the hipcc
+  handles arguments currently.  E.g. -DGREETING="Hello, World!" is
+  treated as two argument ('-DGREETING=Hello,' and 'World!').

--- a/docs/Using.md
+++ b/docs/Using.md
@@ -28,6 +28,10 @@ If you do not provide this value, `hipcc` will check for existance of the follow
 /opt/rocm
 ```
 
+#### CHIP\_RTC\_SAVE\_TEMPS
+
+Preserves runtime temporary compilation files when this variable is set to `1`.
+
 ### Disabling GPU hangcheck
 
 Note that long-running GPU compute kernels can trigger hang detection mechanism in the GPU driver, which will cause the kernel execution to be terminated and the runtime will report an error. Consult the documentation of your GPU driver on how to disable this hangcheck.

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -93,7 +93,7 @@ add_library(LLVMHipDefrost MODULE HipDefrost.cpp)
 add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipDynMem.cpp HipStripUsedIntrinsics.cpp HipDefrost.cpp
     HipPrintf.cpp HipGlobalVariables.cpp HipTextureLowering.cpp HipAbort.cpp
-    ${EXTRA_OBJS})
+    HipEmitLoweredNames.cpp ${EXTRA_OBJS})
 
 if("${LLVM_VERSION}" VERSION_GREATER_EQUAL 14.0)
   set_target_properties(LLVMHipPasses PROPERTIES

--- a/llvm_passes/HipEmitLoweredNames.cpp
+++ b/llvm_passes/HipEmitLoweredNames.cpp
@@ -1,0 +1,133 @@
+//===- HipEmitLoweredNames.cpp --------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// A pass to produce a file for mapping hiprtc name expressions to
+// lowered/mangled function and global variable names needed to implement
+// hiprtcGetLoweredName().
+//
+// This pass looks for a magic variable produced from:
+//
+//   extern "C" __device__ constexpr void *_chip_name_exprs[] = {
+//     (void *)<name expression 1>,
+//     (void *)<name expression 2>,
+//     ...
+//   };
+//
+// and writes the lowered names, respectively, into a file passed in another
+// magic C-string variable '_chip_name_expr_output_file' (because pass plugin
+// provided command-line options do not work yet).
+//
+// Finally, the magic variables are removed from the module.
+//
+// Copyright (c) 2021-22 CHIP-SPV developers
+//===----------------------------------------------------------------------===//
+
+#include "HipEmitLoweredNames.h"
+
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/CommandLine.h"
+
+#include <fstream>
+
+#define PASS_NAME "emit-lowered-names"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+namespace {
+
+// Traverse constant expression to extract a C-string in it.
+static std::optional<StringRef> getString(Constant *C) {
+  C = C->stripPointerCasts();
+
+  if (auto *GV = dyn_cast<GlobalVariable>(C)) {
+    if (GV->hasInitializer())
+      return getString(GV->getInitializer());
+    return std::nullopt;
+  }
+
+  if (auto *CDS = dyn_cast<ConstantDataSequential>(C)) {
+    if (CDS->isString())
+      return CDS->getAsString();
+    return std::nullopt;
+  }
+
+  return std::nullopt;
+}
+
+// Traverse constant expression to extract lowered name expressions.
+static std::vector<std::string> getLoweredNames(Constant *C) {
+  std::vector<std::string> Result;
+  C = C->stripPointerCasts();
+
+  if (auto *CA = dyn_cast<ConstantAggregate>(C)) {
+    for (Value *Op : CA->operand_values()) {
+      auto *COp = cast<Constant>(Op)->stripPointerCasts();
+      if (auto *F = dyn_cast<Function>(COp))
+        Result.emplace_back(F->hasName() ? F->getName() : "");
+      else
+        Result.emplace_back("");
+    }
+  }
+
+  return Result;
+}
+
+static bool emitLoweredNames(Module &M) {
+  auto *LoweredNamesGV = M.getGlobalVariable("_chip_name_exprs");
+  if (!LoweredNamesGV)
+    return false;
+  assert(LoweredNamesGV->hasInitializer());
+
+  std::ofstream OutputStream;
+  auto *OutputGV = M.getGlobalVariable("_chip_name_expr_output_file");
+  if (OutputGV) {
+    assert(OutputGV->hasInitializer());
+    if (auto OutputOpt = getString(OutputGV->getInitializer()))
+      OutputStream = std::ofstream(OutputOpt->str());
+  }
+
+  if (OutputStream.is_open())
+    for (const auto &LoweredName :
+         getLoweredNames(LoweredNamesGV->getInitializer()))
+      OutputStream << LoweredName << "\n";
+
+  if (OutputGV && OutputGV->hasNUses(0))
+    OutputGV->eraseFromParent();
+
+  if (LoweredNamesGV->hasNUses(0))
+    LoweredNamesGV->eraseFromParent();
+
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses HipEmitLoweredNamesPass::run(Module &M,
+                                               ModuleAnalysisManager &AM) {
+
+  return emitLoweredNames(M) ? PreservedAnalyses::none()
+                             : PreservedAnalyses::all();
+}
+
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == PASS_NAME) {
+                    FPM.addPass(HipEmitLoweredNamesPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/llvm_passes/HipEmitLoweredNames.h
+++ b/llvm_passes/HipEmitLoweredNames.h
@@ -1,0 +1,33 @@
+//===- HipEmitLoweredNames.h ----------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// A pass to produce a file for mapping hiprtc name expressions to
+// lowered/mangled function and global variables needed to implement
+// hiprtcGetLoweredName().
+//
+// Copyright (c) 2021-22 CHIP-SPV developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_EMIT_LOWERED_NAMES_H
+#define LLVM_PASSES_HIP_EMIT_LOWERED_NAMES_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+#if LLVM_VERSION_MAJOR < 14
+#error LLVM 14+ required.
+#endif
+
+class HipEmitLoweredNamesPass : public PassInfoMixin<HipEmitLoweredNamesPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -20,6 +20,7 @@
 #include "HipPrintf.h"
 #include "HipGlobalVariables.h"
 #include "HipTextureLowering.h"
+#include "HipEmitLoweredNames.h"
 
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
@@ -75,6 +76,9 @@ public:
 };
 
 static void addFullLinkTimePasses(ModulePassManager &MPM) {
+  /// For extracting name expression to lowered name expressions (hiprtc).
+  MPM.addPass(HipEmitLoweredNamesPass());
+
   // Remove attributes that may prevent the device code from being optimized.
   MPM.addPass(RemoveNoInlineOptNoneAttrsPass());
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -696,6 +696,12 @@ class CHIPProgram {
   /// Include headers.
   std::map<std::string, std::string> Headers_;
 
+  /// Name expressions added before compilation as key to the
+  /// map. After compilation they point to their lowered/mangled
+  /// names. The map value may also be empty meaning the lowered name
+  /// is unknown.
+  std::map<std::string, std::string> NameExpressions_;
+
   std::string ProgramLog_; ///< Captured compilation log.
   std::string Code_;       ///< Compiled program.
 
@@ -717,12 +723,28 @@ public:
 
   void addCode(std::string_view Code) { Code_.append(Code); }
 
+  void addNameExpression(std::string_view NameExpr) {
+    assert(!isAfterCompilation() &&
+           "Must not add name expressions after compilation!");
+    NameExpressions_.emplace(std::make_pair(NameExpr, ""));
+  }
+
   const std::map<std::string, std::string> &getHeaders() const {
     return Headers_;
   }
   const std::string &getSource() const { return ProgramSource_; }
   const std::string &getProgramLog() const { return ProgramLog_; }
   const std::string &getCode() const { return Code_; }
+
+  const std::map<std::string, std::string> &getNameExpressionMap() const {
+    return NameExpressions_;
+  }
+  std::map<std::string, std::string> &getNameExpressionMap() {
+    return NameExpressions_;
+  }
+
+  /// Return true if the program has been compiled.
+  bool isAfterCompilation() const { return !Code_.empty(); }
 };
 
 /**

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -188,3 +188,12 @@ convertExtraArgsToPointerArray(void *ExtraArgBuf, const OCLFuncInfo &FuncInfo) {
   }
   return PointerArray;
 }
+
+std::string_view trim(std::string_view Str) {
+  auto IsWhitespace = [](char C) -> bool { return (C == ' ' || C == '\t'); };
+  while (!Str.empty() && IsWhitespace(Str.front()))
+    Str.remove_prefix(1);
+  while (!Str.empty() && IsWhitespace(Str.back()))
+    Str.remove_suffix(1);
+  return Str;
+}

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -75,4 +75,6 @@ std::string_view extractSPIRVModule(const void *ClangOffloadBundle,
 std::vector<void *> convertExtraArgsToPointerArray(void *ExtraArgBuf,
                                                    const OCLFuncInfo &FuncInfo);
 
+std::string_view trim(std::string_view Str);
+
 #endif

--- a/tests/hiprtc/CMakeLists.txt
+++ b/tests/hiprtc/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+#  CMake build system files
+#
+#  Copyright (c) 2022 CHIP-SPV developers
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+#
+#=============================================================================
+
+function(add_hip_test MAIN_SOURCE)
+  get_filename_component(EXEC_NAME ${MAIN_SOURCE} NAME_WLE)
+  set_source_files_properties(${MAIN_SOURCE} PROPERTIES LANGUAGE CXX)
+  add_executable("${EXEC_NAME}" ${MAIN_SOURCE})
+  set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+
+  target_link_libraries("${EXEC_NAME}" CHIP deviceInternal)
+  target_include_directories("${EXEC_NAME}"
+    PUBLIC ${CMAKE_SOURCE_DIR}/HIP/include ${CMAKE_SOURCE_DIR}/include)
+
+  add_test(NAME ${EXEC_NAME} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME})
+endfunction()
+
+add_hip_test(TestHiprtcCPPKernels.cc)
+add_hip_test(TestHiprtcOptions.cc)

--- a/tests/hiprtc/TestCommon.hh
+++ b/tests/hiprtc/TestCommon.hh
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021-22 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <hip/hiprtc.h>
+#include <hip/hip_runtime_api.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#define TEST_ASSERT(_X)                                                        \
+  do {                                                                         \
+    if (!(_X)) {                                                               \
+      std::cerr << __FILE__ << ":" << __func__ << ":" << __LINE__              \
+                << ": Test assertion failed.\n";                               \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define HIPRTC_CHECK(_RESULT)                                                  \
+  do {                                                                         \
+    hiprtcResult ResultCode = (_RESULT);                                       \
+    if (ResultCode != HIPRTC_SUCCESS) {                                        \
+      std::cerr << "Failure at " << __FILE__ << ":" << __func__ << ":"         \
+                << __LINE__ << ": " << hiprtcGetErrorString(ResultCode)        \
+                << "\n";                                                       \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define HIP_CHECK(_RESULT)                                                     \
+  do {                                                                         \
+    hipError_t ResultCode = (_RESULT);                                         \
+    if (ResultCode != hipSuccess) {                                            \
+      std::cerr << "Failure at " << __FILE__ << ":" << __func__ << ":"         \
+                << __LINE__ << ": " << hipGetErrorString(ResultCode) << "\n";  \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+hiprtcProgram HiprtcAssertCreateProgram(const std::string &Src) {
+  hiprtcProgram Program;
+  HIPRTC_CHECK(
+      hiprtcCreateProgram(&Program, Src.c_str(), "foo", 0, nullptr, nullptr));
+  return Program;
+}
+
+std::vector<char> HiprtcAssertCompileProgram(
+    hiprtcProgram Program,
+    const std::vector<const char *> &Options = std::vector<const char *>()) {
+  auto Result = hiprtcCompileProgram(Program, Options.size(),
+                                     (const char **)Options.data());
+
+  size_t LogSize;
+  HIPRTC_CHECK(hiprtcGetProgramLogSize(Program, &LogSize));
+  if (Result != HIPRTC_SUCCESS && LogSize) {
+    std::string Log(LogSize, '\0');
+    HIPRTC_CHECK(hiprtcGetProgramLog(Program, &Log[0]));
+    std::cerr << Log << "\n";
+  }
+
+  HIPRTC_CHECK(Result);
+
+  size_t CodeSize;
+  HIPRTC_CHECK(hiprtcGetCodeSize(Program, &CodeSize));
+  std::vector<char> Code(CodeSize);
+  HIPRTC_CHECK(hiprtcGetCode(Program, Code.data()));
+
+  return Code;
+}

--- a/tests/hiprtc/TestHiprtcCPPKernels.cc
+++ b/tests/hiprtc/TestHiprtcCPPKernels.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021-22 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// Test invoking C++/mangled kernels for which hiprtcAddNameExpression() and
+// hiprtcGetLoweredName() are needed.
+
+#include "TestCommon.hh"
+
+// Overloaded kernels do not work with the current clang.
+#define TEST_OVERLOADED_KERNELS 0
+
+template <typename OutT, typename InT>
+static void checkUnaryKernel(hipModule_t Module, const char *KernelName,
+                             InT InputH, OutT ExpectedOutput) {
+  std::cerr << "Checking Kernel: " << KernelName << "\n";
+
+  hipFunction_t Kernel;
+  HIP_CHECK(hipModuleGetFunction(&Kernel, Module, KernelName));
+
+  OutT OutputH;
+  InT *InputD = nullptr;
+  OutT *OutputD = nullptr;
+  HIP_CHECK(hipMalloc(&OutputD, sizeof(OutT)));
+  HIP_CHECK(hipMalloc(&InputD, sizeof(InT)));
+  HIP_CHECK(hipMemcpy(InputD, &InputH, sizeof(InT), hipMemcpyHostToDevice));
+
+  void *Args[] = {&OutputD, &InputD};
+  HIP_CHECK(hipModuleLaunchKernel(Kernel, 1, 1, 1, 1, 1, 1, 0, nullptr, Args,
+                                  nullptr));
+
+  HIP_CHECK(hipMemcpy(&OutputH, OutputD, sizeof(OutT), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(InputD));
+  HIP_CHECK(hipFree(OutputD));
+
+  TEST_ASSERT(OutputH == ExpectedOutput);
+}
+
+static constexpr auto Source = R"---(
+#define MY_FLOAT float
+typedef int my_int_t;
+__global__ void add1(int *Dst, const int *Src) { *Dst = *Src + 1; }
+__global__ void mul2(int *Dst, const int *Src) { *Dst = *Src * 2; }
+__global__ void mul2(float *Dst, const float *Src) { *Dst = *Src * 2; }
+template<class T> __global__ void sub1(T *Dst, const T *Src) {
+  *Dst = *Src - 1;
+}
+template<class DstT, class SrcT>
+__global__ void cast(DstT *Dst, const SrcT *Src) { *Dst = *Src; }
+namespace foo {
+namespace bar {
+__global__ void add2(int *Dst, const int *Src) { *Dst = *Src + 1; }
+}
+}
+)---";
+
+int main() {
+
+  auto Prog = HiprtcAssertCreateProgram(Source);
+
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "add1"));
+
+#if TEST_OVERLOADED_KERNELS
+  HIPRTC_CHECK(
+      hiprtcAddNameExpression(Prog, "(void(*)(int *, const int *))mul2"));
+  HIPRTC_CHECK(
+      hiprtcAddNameExpression(Prog, "(void(*)(float *, const float *))mul2"));
+#endif
+
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "sub1<int>"));
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "sub1<float>"));
+
+  // Both of these name expressions are point to the same kernel.
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "cast<int, MY_FLOAT>"));
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "cast<my_int_t, float>"));
+
+  HIPRTC_CHECK(hiprtcAddNameExpression(Prog, "foo::bar::add2"));
+
+  auto Code = HiprtcAssertCompileProgram(Prog, {"--std=c++11"});
+
+  TEST_ASSERT(hiprtcAddNameExpression(Prog, "after_compilation") ==
+              HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION);
+
+  const char *LoweredName = nullptr;
+  TEST_ASSERT(hiprtcGetLoweredName(Prog, "does_not_exist", &LoweredName) ==
+              HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID);
+
+  const char *LoweredAdd1;
+  auto npos = std::string::npos;
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "add1", &LoweredAdd1));
+  TEST_ASSERT(std::string_view(LoweredAdd1).find("add1") != npos);
+
+#if TEST_OVERLOADED_KERNELS
+  const char *LoweredMul2Int, *LoweredMul2Float;
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "(void(*)(int *, const int *))mul2",
+                                    &LoweredMul2Int));
+  HIPRTC_CHECK(hiprtcGetLoweredName(
+      Prog, "(void(*)(float *, const float *))mul2", &LoweredMul2Float));
+  TEST_ASSERT(std::string_view(LoweredMul2Int).find("mul2") != npos);
+  TEST_ASSERT(std::string_view(LoweredMul2Float).find("mul2") != npos);
+  TEST_ASSERT(std::string_view(LoweredMul2Int) != LoweredMul2Float);
+#endif
+
+  const char *LoweredSub1Int, *LoweredSub1Float;
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "sub1<int>", &LoweredSub1Int));
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "sub1<float>", &LoweredSub1Float));
+  TEST_ASSERT(std::string_view(LoweredSub1Int).find("sub1") != npos);
+  TEST_ASSERT(std::string_view(LoweredSub1Float).find("sub1") != npos);
+  TEST_ASSERT(std::string_view(LoweredSub1Int) != LoweredSub1Float);
+
+  const char *LoweredCastF2I0, *LoweredCastF2I1;
+  HIPRTC_CHECK(
+      hiprtcGetLoweredName(Prog, "cast<int, MY_FLOAT>", &LoweredCastF2I0));
+  HIPRTC_CHECK(
+      hiprtcGetLoweredName(Prog, "cast<my_int_t, float>", &LoweredCastF2I1));
+  TEST_ASSERT(std::string_view(LoweredCastF2I0).find("cast") != npos);
+  TEST_ASSERT(std::string_view(LoweredCastF2I1).find("cast") != npos);
+  // The expressions should point to the same kernel.
+  TEST_ASSERT(std::string_view(LoweredCastF2I0) == LoweredCastF2I1);
+
+  const char *LoweredAdd2;
+  HIPRTC_CHECK(hiprtcGetLoweredName(Prog, "foo::bar::add2", &LoweredAdd2));
+  TEST_ASSERT(std::string_view(LoweredAdd2).find("add2") != npos);
+
+  hipModule_t Module;
+  HIP_CHECK(hipModuleLoadData(&Module, Code.data()));
+
+  checkUnaryKernel(Module, LoweredAdd1, 123, 124);
+#if TEST_OVERLOADED_KERNELS
+  checkUnaryKernel(Module, LoweredMul2Int, 12, 24);
+  checkUnaryKernel(Module, LoweredMul2Float, 2.5f, 5.0f);
+#endif
+  checkUnaryKernel(Module, LoweredSub1Int, 12, 11);
+  checkUnaryKernel(Module, LoweredSub1Float, 1.75f, 0.75f);
+  checkUnaryKernel(Module, LoweredCastF2I0, 1.23f, 1);
+
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Prog));
+
+  return 0;
+}

--- a/tests/hiprtc/TestHiprtcOptions.cc
+++ b/tests/hiprtc/TestHiprtcOptions.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021-22 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "TestCommon.hh"
+
+#include <regex>
+
+static constexpr auto DefaultSource = R"---(
+__global__ void add1(int *Dst, const int *Src) { *Dst = *Src + 1; }
+)---";
+
+static constexpr auto AssertFooMacro = R"---(
+#ifndef FOO
+#error FOO was not set!
+#endif
+__global__ void add1(int *Dst, const int *Src) { *Dst = *Src + 1; }
+)---";
+
+static constexpr auto Greet = R"---(
+#ifndef GREETING
+#error GREETING was not set!
+#endif
+__global__ void greet(char *Dst) {
+  const char *Greeting = GREETING;
+  for (size_t i = 0; i < sizeof(GREETING), i++)
+    Dst[i] = Greeting[i];
+}
+)---";
+
+static hiprtcResult compile(hiprtcProgram Program, std::string_view Option,
+                            std::string &LogOut) {
+  const char *OptArray[] = {Option.data()};
+  auto Result = hiprtcCompileProgram(Program, 1, OptArray);
+
+  size_t LogSize;
+  HIPRTC_CHECK(hiprtcGetProgramLogSize(Program, &LogSize));
+  if (LogSize) {
+    LogOut = std::string(LogSize, '\0');
+    HIPRTC_CHECK(hiprtcGetProgramLog(Program, &LogOut[0]));
+  }
+
+  if (Result != HIPRTC_SUCCESS)
+    std::cerr << LogOut;
+
+  return Result;
+}
+
+void checkOption(std::string_view Option, const char *Source = DefaultSource) {
+  std::cerr << "Checking option '" << Option << "'.\n";
+  auto Program = HiprtcAssertCreateProgram(Source);
+
+  std::string Log;
+  auto Result = compile(Program, Option, Log);
+
+  TEST_ASSERT(!std::regex_search(Log, std::regex("warning: ignored option")));
+  HIPRTC_CHECK(Result);
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Program));
+}
+
+void checkIgnored(std::string_view Option) {
+  std::cerr << "Checking ignored option '" << Option << "'.\n";
+  auto Program = HiprtcAssertCreateProgram(DefaultSource);
+
+  std::string Log;
+  auto Result = compile(Program, Option, Log);
+
+  TEST_ASSERT(std::regex_search(Log, std::regex("warning: ignored option")));
+  HIPRTC_CHECK(Result);
+  HIPRTC_CHECK(hiprtcDestroyProgram(&Program));
+}
+
+int main() {
+
+  checkOption("--std=c++11");
+  checkOption("-O1");
+  checkOption("-O2");
+  checkOption("-O3");
+  checkOption("-DFOO=123", AssertFooMacro);
+  // TODO: Does not work with current hipcc probably due to lack of shell
+  //       escaping.
+  // checkOption("-DGREETING=\"Hello, World!\"", Greet);
+
+  checkIgnored("--nonexistent-flag");
+  checkIgnored("non_option");
+
+  return 0;
+}


### PR DESCRIPTION
* Implements hiprtcAddNameExpression(), hiprtcGetLoweredName() for supporting invocation of C++ kernels. These functions do not support global `__device__` and `__constant__ `variables in this patch.
* hiprtcCompileProgram now accepts some of the user options. This includes --std, -O and -D. All unrecognized options are ignored by default and warnings are given when they are encountered.

TODOs before PR:

- [x] Merge https://github.com/CHIP-SPV/chip-spv/pull/160.