### PR TITLE
Fix filesystem issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ target_compile_definitions(CHIP PRIVATE ${CHIP_SPV_DEFINITIONS})
 
 target_link_libraries(CHIP INTERFACE ${CHIP_INTERFACE_LIBS})
 if(HAS_EXPERIMENTAL_FILESYSTEM)
-  target_link_libraries(CHIP stdc++fs)
+  target_link_libraries(CHIP PUBLIC stdc++fs)
 endif()
 
 # Previously these were set to SYSTEM which resulted in CMake picking up

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,9 @@ target_compile_options(CHIP PRIVATE ${HIP_ENABLE_SPIRV} ${CHIP_SPV_COMPILE_FLAGS
 target_compile_definitions(CHIP PRIVATE ${CHIP_SPV_DEFINITIONS})
 
 target_link_libraries(CHIP INTERFACE ${CHIP_INTERFACE_LIBS})
+if(HAS_EXPERIMENTAL_FILESYSTEM)
+  target_link_libraries(CHIP stdc++fs)
+endif()
 
 # Previously these were set to SYSTEM which resulted in CMake picking up
 # OpenCL headers from the system where the version might differ resulting in errors.

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -24,7 +24,6 @@
 
 #include "logging.hh"
 
-#include <filesystem>
 #include <fstream>
 #include <random>
 
@@ -92,7 +91,7 @@ std::optional<std::string> readFromFile(const fs::path Path) {
   return std::nullopt;
 }
 
-std::optional<std::filesystem::path> getHIPCCPath() {
+std::optional<fs::path> getHIPCCPath() {
   // TODO: Probably should detect if we are using a built or an
   //       installed CHIP library. Mixing the installed and the built
   //       resources could lead to obscure issues.


### PR DESCRIPTION
* Fix included <filesystem> instead of one provided by the Filesystem.hh.

* Fix used 'std::filesystem' namespace instead of 'fs' provided by the Filesystem.hh.

Fixes #200.