### PR TITLE
Refactor hipStreamPerThread & syncQueues

### DIFF
--- a/samples/cuda_samples/0_Simple/simpleCallback/simpleCallback.cu
+++ b/samples/cuda_samples/0_Simple/simpleCallback/simpleCallback.cu
@@ -27,7 +27,7 @@
 
 #include "multithreading.h"
 
-const int N_workloads  = 8;
+const int N_workloads  = 4;
 const int N_elements_per_workload = 100000;
 
 CUTBarrier thread_barrier;

--- a/samples/hipMultiThreadAddCallback/hipMultiThreadAddCallback.cc
+++ b/samples/hipMultiThreadAddCallback/hipMultiThreadAddCallback.cc
@@ -35,7 +35,7 @@ multiple Threads.
 #define HIPCHECK(x) assert(x == hipSuccess)
 #define HIP_CHECK(x) assert(x == hipSuccess)
 
-static constexpr size_t N = 4096;
+static constexpr size_t N = 1024;
 static constexpr int numThreads = 1000;
 static std::atomic<int> Cb_count{0}, Data_mismatch{0};
 static hipStream_t mystream;

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1176,6 +1176,7 @@ void CHIPBackend::syncAllQueues() {
   logDebug("CHIPBackend::syncAllQueues");
    auto Queues = getAllQueues();
    for(auto Q: Queues) {
+    // WHY DOES THIS KEEP FAILING
     Q->finish();
    }
  

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -445,7 +445,7 @@ CHIPQueue *CHIPDevice::getDefaultQueue() {
 }
 
 CHIPQueue *CHIPDevice::getPerThreadDefaultQueue() {
-  if(getpid() == gettid()) {
+  if (getpid() == gettid()) {
     return getLegacyDefaultQueue();
   }
 
@@ -1208,7 +1208,8 @@ void CHIPBackend::waitForThreadExit() {
    * So we just wait for 0.1 seconds before starting to check for thread exit.
    */
   pthread_yield();
-  unsigned long long int sleepMicroSeconds = 500000 + Backend->ThreadCount * 1000;
+  unsigned long long int sleepMicroSeconds =
+      500000 + Backend->ThreadCount * 1000;
   usleep(sleepMicroSeconds);
 
   logDebug("CHIPBackend::waitForThreadExit() checking per-thread queues. "

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -866,8 +866,7 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
 }
 
 // TODO SyncThredsPerThread maybe we should have a noLock variant? Often times we get queues and then do operations. If locked inside then when lock exists we can delete it while still doing operations on preveiously acquired queueds
-std::vector<CHIPQueue *> &CHIPDevice::getQueues() {
-  return ChipQueues_;
+std::vector<CHIPQueue *> CHIPDevice::getQueues() {
 }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -818,6 +818,7 @@ void CHIPDevice::registerDeviceVariable(std::string *ModuleStr,
 }
 
 void CHIPDevice::addQueue(CHIPQueue *ChipQueue) {
+  std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
   // TODO SyncThreadsPerThread add pthread_yield after added
   logDebug("{} CHIPDevice::addQueue({})", (void *)this, (void *)ChipQueue);
   // TODO SyncThreadsPerThread Why BackendMtx and not DeviceMtx?
@@ -896,6 +897,7 @@ hipSharedMemConfig CHIPDevice::getSharedMemConfig() {
 }
 
 bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
+  std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
   logDebug("CHIPDevice::removeQueue({})", (void *)ChipQueue);
 
   // If attempting to remove the default queue (during uninitialize), don't
@@ -1298,7 +1300,7 @@ std::vector<CHIPQueue *> CHIPBackend::getDefaultQueues() {
 }
 
 // TODO SyncTHreadsPerThread Should we keep PerThreadQueues in Backend? Not in individual device?
-std::vector<CHIPQueue *> &CHIPBackend::getPerThreadQueues() {
+std::vector<CHIPQueue *> CHIPBackend::getPerThreadQueues() {
   std::lock_guard<std::mutex> LockBackend(BackendMtx);
   return PerThreadQueues;
 }

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1142,7 +1142,7 @@ public:
   bool PerThreadStreamUsed = false;
   std::mutex DeviceMtx;
 
-  CHIPQueue* LegacyDefaultQueue;
+  CHIPQueue *LegacyDefaultQueue;
   inline static thread_local std::unique_ptr<CHIPQueue> PerThreadDefaultQueue;
 
   /**
@@ -1729,7 +1729,7 @@ public:
 
   /**
    * @brief Wait for all per-thread queues to finish
-   * 
+   *
    */
   void waitForThreadExit();
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1727,6 +1727,12 @@ public:
   virtual void uninitialize();
 
   /**
+   * @brief Wait for all per-thread queues to finish
+   * 
+   */
+  void waitForThreadExit();
+
+  /**
    * @brief Get the Queues object
    *
    * @return std::vector<CHIPQueue*>&

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1638,6 +1638,7 @@ public:
   std::stack<CHIPExecItem *> ChipExecStack;
   std::vector<CHIPContext *> ChipContexts;
   std::vector<CHIPQueue *> ChipQueues;
+  std::vector<CHIPQueue *> PerThreadQueues;
   std::vector<CHIPDevice *> ChipDevices;
 
   /**
@@ -1732,6 +1733,7 @@ public:
    */
   std::vector<CHIPQueue *> &getQueues();
 
+  std::vector<CHIPQueue *> &getPerThreadQueues();
   /**
    * @brief Get the Active Context object. Returns the context of the active
    * queue.
@@ -1779,6 +1781,8 @@ public:
    * @param q_in
    */
   void addQueue(CHIPQueue *ChipQueue);
+
+  void addPerThreadQueue(CHIPQueue *ChipQueue);
   /**
    * @brief  Add a device to this backend.
    *

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1144,7 +1144,7 @@ public:
   std::mutex DeviceMtx;
   std::mutex DeviceModulesMtx;
 
-  CHIPQueue *LegacyDefaultQueue; // TODO SyncThreadsPerThread Why am I not making this unique so that I can just delete the Device and these will be destroyed automatically?
+  std::unique_ptr<CHIPQueue> LegacyDefaultQueue; 
   inline static thread_local std::unique_ptr<CHIPQueue> PerThreadDefaultQueue;
 
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1264,7 +1264,7 @@ public:
    *
    * @return std::vector<CHIPQueue*>
    */
-  std::vector<CHIPQueue *> &getQueues();
+  std::vector<CHIPQueue *> getQueues();
 
   /**
    * @brief Remove a queue from this device's queue vector

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1194,9 +1194,7 @@ public:
 
   CHIPAllocationTracker *AllocationTracker = nullptr;
 
-  virtual ~CHIPDevice(
-    // TODO SyncThreadsPerThread delete all queues?
-  );
+  virtual ~CHIPDevice();
 
   /**
    * @brief Get the Kernels object

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1627,6 +1627,7 @@ protected:
   CHIPDevice *ActiveDev_;
 
 public:
+  std::mutex QueueAddOrRemove;
   std::mutex SetActiveMtx;
   std::mutex QueueCreateDestroyMtx;
   std::mutex BackendMtx;
@@ -1641,7 +1642,6 @@ public:
 
   std::stack<CHIPExecItem *> ChipExecStack;
   std::vector<CHIPContext *> ChipContexts;
-  std::vector<std::unique_ptr<CHIPQueue>> ChipQueues;
   std::vector<CHIPQueue *> PerThreadQueues;
   std::atomic<int> ThreadCount = 0;
   std::vector<CHIPDevice *> ChipDevices;
@@ -1749,7 +1749,7 @@ public:
 
   std::vector<CHIPQueue *> getAllQueues();
 
-  std::vector<CHIPQueue *> &getPerThreadQueues();
+  std::vector<CHIPQueue *> getPerThreadQueues();
 
   bool removePerThreadQueue(CHIPQueue* ChipQueue);
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1627,6 +1627,8 @@ protected:
   CHIPDevice *ActiveDev_;
 
 public:
+  int getPerThreadQueuesActive();
+  void syncAllQueues();
   std::mutex QueueAddOrRemove;
   std::mutex SetActiveMtx;
   std::mutex QueueCreateDestroyMtx;
@@ -1794,7 +1796,6 @@ public:
    */
   void addContext(CHIPContext *ChipContext);
 
-  void addPerThreadQueue(CHIPQueue *ChipQueue);
   /**
    * @brief  Add a device to this backend.
    *

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1751,7 +1751,7 @@ public:
 
   std::vector<CHIPQueue *> &getPerThreadQueues();
 
-  void removePerThreadQueue(CHIPQueue* ChipQueue);
+  bool removePerThreadQueue(CHIPQueue* ChipQueue);
   /**
    * @brief Get the Active Context object. Returns the context of the active
    * queue.

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1639,6 +1639,7 @@ public:
   std::vector<CHIPContext *> ChipContexts;
   std::vector<CHIPQueue *> ChipQueues;
   std::vector<CHIPQueue *> PerThreadQueues;
+  std::atomic<int> ThreadCount = 0;
   std::vector<CHIPDevice *> ChipDevices;
 
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -55,6 +55,8 @@
 #include "macros.hh"
 #include "CHIPException.hh"
 
+#define DEFAULT_QUEUE_PRIORITY 1
+
 static inline size_t getChannelByteSize(hipChannelFormatDesc Desc) {
   unsigned TotalNumBits = Desc.x + Desc.y + Desc.z + Desc.w;
   return ((TotalNumBits + 7u) / 8u); // Round upwards.
@@ -1173,7 +1175,8 @@ public:
    * @param Priority
    * @return CHIPQueue*
    */
-  CHIPQueue *createQueueAndRegister(CHIPQueueFlags Flags, int Priority);
+  CHIPQueue *createQueueAndRegister(CHIPQueueFlags Flags = CHIPQueueFlags(),
+                                    int Priority = DEFAULT_QUEUE_PRIORITY);
 
   CHIPQueue *createQueueAndRegister(const uintptr_t *NativeHandles,
                                     const size_t NumHandles);
@@ -2082,7 +2085,7 @@ public:
     if (!LastEvent_)
       return true;
 
-    if(LastEvent_->updateFinishStatus(false))
+    if (LastEvent_->updateFinishStatus(false))
       LastEvent_->decreaseRefCount("query(): event became ready");
     if (LastEvent_->isFinished())
       return true;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1142,7 +1142,7 @@ public:
   bool PerThreadStreamUsed = false;
   std::mutex DeviceMtx;
 
-  std::unique_ptr<CHIPQueue> LegacyDefaultQueue;
+  CHIPQueue* LegacyDefaultQueue;
   inline static thread_local std::unique_ptr<CHIPQueue> PerThreadDefaultQueue;
 
   /**

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -3274,7 +3274,6 @@ extern "C" void **__hipRegisterFatBinary(const void *Data) {
 
 extern "C" void __hipUnregisterFatBinary(void *Data) {
   CHIP_TRY
-  CHIPInitialize();
   std::string *Module = reinterpret_cast<std::string *>(Data);
 
   logDebug("Unregister module: {} \n", (void *)Module);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1326,6 +1326,7 @@ hipError_t hipStreamDestroy(hipStream_t Stream) {
   Stream = Backend->findQueue(Stream);
 
   CHIPDevice *Dev = Backend->getActiveDevice();
+  Stream->finish();
 
   // This will call finish, setLastEvent, removeQueue
   //TODO SyncThreadsPerThread make removeQueue() protected?

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -782,10 +782,7 @@ hipError_t hipDeviceSynchronize(void) {
   CHIP_TRY
   CHIPInitialize();
 
-  std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
-  for (auto Q : Backend->getAllQueues()) {
-    Q->finish();
-  }
+  Backend->syncAllQueues();
 
   // TODO SyncThreadsPerThread
   // for(auto Q: Backend->getPerThreadQueues()) {

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1303,6 +1303,9 @@ hipError_t hipStreamDestroy(hipStream_t Stream) {
   if(Stream == hipStreamPerThread) 
     CHIPERR_LOG_AND_THROW("Attemped to destroy default per-thread queue", hipErrorTbd);
 
+  if(Stream == hipStreamLegacy) 
+    CHIPERR_LOG_AND_THROW("Attemped to destroy default legacy queue", hipErrorTbd);
+
   Stream = Backend->findQueue(Stream);
 
   CHIPDevice *Dev = Backend->getActiveDevice();

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1329,6 +1329,7 @@ hipError_t hipStreamDestroy(hipStream_t Stream) {
 
   // This will call finish, setLastEvent, removeQueue
   //TODO SyncThreadsPerThread make removeQueue() protected?
+  Dev->removeQueue(Stream);
   delete Stream;
 
   RETURN(hipSuccess);

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1300,6 +1300,9 @@ hipError_t hipStreamDestroy(hipStream_t Stream) {
   CHIP_TRY
   CHIPInitialize();
 
+  if(Stream == hipStreamPerThread) 
+    CHIPERR_LOG_AND_THROW("Attemped to destroy default per-thread queue", hipErrorTbd);
+
   Stream = Backend->findQueue(Stream);
 
   CHIPDevice *Dev = Backend->getActiveDevice();

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -782,7 +782,8 @@ hipError_t hipDeviceSynchronize(void) {
   CHIP_TRY
   CHIPInitialize();
 
-  for (auto Q : Backend->getUserQueues()) {
+  std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
+  for (auto Q : Backend->getAllQueues()) {
     Q->finish();
   }
 

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -42,6 +42,7 @@ std::once_flag Initialized;
 std::once_flag EnvInitialized;
 std::once_flag Uninitialized;
 bool UsingDefaultBackend;
+std::mutex InitMtx;
 CHIPBackend *Backend;
 std::string CHIPPlatformStr, CHIPDeviceTypeStr, CHIPDeviceStr, CHIPBackendType;
 
@@ -144,6 +145,7 @@ void CHIPInitializeCallOnce() {
 }
 
 extern void CHIPInitialize() {
+  std::lock_guard<std::mutex> LockInit(InitMtx);
   std::call_once(Initialized, &CHIPInitializeCallOnce);
 }
 
@@ -153,6 +155,7 @@ void CHIPUninitializeCallOnce() {
 }
 
 extern void CHIPUninitialize() {
+  std::lock_guard<std::mutex> LockInit(InitMtx);
   std::call_once(Uninitialized, &CHIPUninitializeCallOnce);
 }
 

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -180,7 +180,7 @@ extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
   auto Modules = Backend->getActiveDevice()->getModules();
 
   if (Backend) {
-    logDebug("uninitializing existing Backend object.");
+    logDebug("CHIPReinitialize: uninitializing existing Backend object.");
     Backend->uninitialize();
     delete Backend;
   }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1342,7 +1342,6 @@ void CHIPBackendLevel0::uninitialize() {
   logTrace("CHIPBackendLevel0::uninitialize()");
   waitForThreadExit(); // All Per-Thread Queues exit
 
-
   auto AllQueues = Backend->getAllQueues();
   assert(AllQueues.size() == 0);
 
@@ -1470,7 +1469,7 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
 void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles,
                                              int NumHandles) {
   logTrace("CHIPBackendLevel0 InitializeNative");
-  MinQueuePriority_ = ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH;
+  MinQueuePriority_ = ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH; // TODO Why is this not default?
 
   ze_driver_handle_t Drv = (ze_driver_handle_t)NativeHandles[0];
   ze_device_handle_t Dev = (ze_device_handle_t)NativeHandles[1];
@@ -1483,10 +1482,11 @@ void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles,
   ChipCtx->addDevice(ChipDev);
   addDevice(ChipDev);
 
-  std::lock_guard<std::mutex> Lock(Backend->BackendMtx);
-  auto ChipQueue = ChipDev->createQueue(NativeHandles, NumHandles);
-  ChipDev->LegacyDefaultQueue = std::unique_ptr<CHIPQueue>(ChipQueue);
+  // TODO SyncThreadsPerThread since the queue is null anyways see #???, we don't need to do this
+  // auto ChipQueue = ChipDev->createQueue(NativeHandles, NumHandles);
+  // ChipDev->LegacyDefaultQueue = std::unique_ptr<CHIPQueue>(ChipQueue);
 
+  std::lock_guard<std::mutex> Lock(Backend->BackendMtx);
   StaleEventMonitor =
       (CHIPStaleEventMonitorLevel0 *)Backend->createStaleEventMonitor();
   CallbackEventMonitor =

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1485,7 +1485,7 @@ void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles,
 
   std::lock_guard<std::mutex> Lock(Backend->BackendMtx);
   auto ChipQueue = ChipDev->createQueue(NativeHandles, NumHandles);
-  ChipDev->LegacyDefaultQueue = ChipQueue;
+  ChipDev->LegacyDefaultQueue = std::unique_ptr<CHIPQueue>(ChipQueue);
 
   StaleEventMonitor =
       (CHIPStaleEventMonitorLevel0 *)Backend->createStaleEventMonitor();

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1342,14 +1342,14 @@ void CHIPBackendLevel0::uninitialize() {
   logTrace("CHIPBackendLevel0::uninitialize()");
   waitForThreadExit();
   if (CallbackEventMonitor) {
-    logTrace("CHIPBackend::uninitialize(): Killing CallbackEventMonitor");
+    logTrace("CHIPBackendLevel0::uninitialize(): Killing CallbackEventMonitor");
     std::lock_guard Lock(CallbackEventMonitor->EventMonitorMtx);
     CallbackEventMonitor->Stop = true;
   }
   CallbackEventMonitor->join();
 
   {
-    logTrace("CHIPBackend::uninitialize(): Killing StaleEventMonitor");
+    logTrace("CHIPBackendLevel0::uninitialize(): Killing StaleEventMonitor");
     std::lock_guard Lock(StaleEventMonitor->EventMonitorMtx);
     StaleEventMonitor->Stop = true;
   }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1340,7 +1340,16 @@ CHIPEventLevel0 *CHIPBackendLevel0::createCHIPEvent(CHIPContext *ChipCtx,
 
 void CHIPBackendLevel0::uninitialize() {
   logTrace("CHIPBackendLevel0::uninitialize()");
-  waitForThreadExit();
+  waitForThreadExit(); // All Per-Thread Queues exit
+
+
+  auto AllQueues = Backend->getAllQueues();
+  assert(AllQueues.size() == 0);
+
+  // TODO SyncThreadsPerThread delete all devices  which delete their default queues
+  // TODO SyncThreadsPerThread make sure all UserQueues have been deleted. Delete by force and warn
+
+
   if (CallbackEventMonitor) {
     logTrace("CHIPBackendLevel0::uninitialize(): Killing CallbackEventMonitor");
     std::lock_guard Lock(CallbackEventMonitor->EventMonitorMtx);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1201,6 +1201,7 @@ CHIPEvent *CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src,
 }
 
 void CHIPQueueLevel0::finish() {
+  logTrace("{} CHIPQueueLevel0::finish()", (void*)this);
   // The finish Event_ that denotes the finish of current command list items
   pthread_yield();
   // Using zeCommandQueueSynchronize() for ensuring the device printf

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1476,7 +1476,7 @@ void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles,
 
   std::lock_guard<std::mutex> Lock(Backend->BackendMtx);
   auto ChipQueue = ChipDev->createQueue(NativeHandles, NumHandles);
-  ChipDev->LegacyDefaultQueue = std::unique_ptr<CHIPQueue>(ChipQueue);
+  ChipDev->LegacyDefaultQueue = ChipQueue;
 
   StaleEventMonitor =
       (CHIPStaleEventMonitorLevel0 *)Backend->createStaleEventMonitor();

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -601,8 +601,9 @@ void CHIPStaleEventMonitorLevel0::monitor() {
     std::lock_guard<std::mutex> AllEventsLock(Backend->EventsMtx);
     std::lock_guard<std::mutex> AllCommandListsLock(
         ((CHIPBackendLevel0 *)Backend)->CommandListsMtx);
-    logTrace("CHIPStaleEventMonitorLevel0::monitor() # events {} # queues {}",
-             Backend->Events.size(), LzBackend->EventCommandListMap.size());
+    // logTrace("CHIPStaleEventMonitorLevel0::monitor() # events {} # queues
+    // {}",
+    //          Backend->Events.size(), LzBackend->EventCommandListMap.size());
 
     auto EventCommandListMap =
         &((CHIPBackendLevel0 *)Backend)->EventCommandListMap;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -187,6 +187,7 @@ public:
 
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, ze_command_queue_handle_t ZeQue);
   ~CHIPQueueLevel0() {
+    std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
     logTrace("{} ~CHIPQueueLevel0()", (void *)this);
     //finish();  // Can't call finish here because the underlaying context could already be destroyed. 
     // TODO SyncThreadsPerThread context destructor should finish all of it's queues

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -188,7 +188,8 @@ public:
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, ze_command_queue_handle_t ZeQue);
   ~CHIPQueueLevel0() {
     logTrace("{} ~CHIPQueueLevel0()", (void *)this);
-    finish();
+    //finish();  // Can't call finish here because the underlaying context could already be destroyed. 
+    // TODO SyncThreadsPerThread context destructor should finish all of it's queues
   }
 
   virtual void addCallback(hipStreamCallback_t Callback,

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -186,7 +186,10 @@ public:
                   LevelZeroQueueType TheQueueType);
 
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, ze_command_queue_handle_t ZeQue);
-  virtual ~CHIPQueueLevel0() { logTrace("CHIPQueueLevel0 DEST"); }
+  ~CHIPQueueLevel0() {
+    logTrace("{} ~CHIPQueueLevel0()", (void *)this);
+    finish();
+  }
 
   virtual void addCallback(hipStreamCallback_t Callback,
                            void *UserData) override;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -187,7 +187,7 @@ public:
 
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, ze_command_queue_handle_t ZeQue);
   ~CHIPQueueLevel0() {
-    std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
+    updateLastEvent(nullptr);
     logTrace("{} ~CHIPQueueLevel0()", (void *)this);
     //finish();  // Can't call finish here because the underlaying context could already be destroyed. 
     // TODO SyncThreadsPerThread context destructor should finish all of it's queues

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -187,6 +187,7 @@ public:
 
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, ze_command_queue_handle_t ZeQue);
   ~CHIPQueueLevel0() {
+    std::lock_guard<std::mutex> LockQueues(Backend->QueueAddOrRemove);
     updateLastEvent(nullptr);
     logTrace("{} ~CHIPQueueLevel0()", (void *)this);
     //finish();  // Can't call finish here because the underlaying context could already be destroyed. 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -251,7 +251,7 @@ class CHIPContextLevel0 : public CHIPContext {
 
 public:
   CHIPEventLevel0 *getEventFromPool() {
-
+    std::lock_guard<std::mutex> LockContext(ContextMtx);
     // go through all pools and try to get an allocated event
     for (size_t i = 0; i < EventPools_.size(); i++) {
       CHIPEventLevel0 *Event = EventPools_[i]->getEvent();

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1212,35 +1212,10 @@ int CHIPExecItemOpenCL::setupAllArgs(CHIPKernelOpenCL *Kernel) {
 //*************************************************************************
 
 void CHIPBackendOpenCL::uninitialize() {
-  logTrace("CHIPBackendOpenCL::uninitialize(): Setting the LastEvent to null for all "
-           "user-created queues");
-  // TODO I need to check that there are no more per-thread default queues
-  // because it could be the case that they are still doing work
-  while (true) {
-    {
-      std::lock_guard<std::mutex> LockBackend(BackendMtx);
-      auto NumPerThreadQueuesActive = Backend->getPerThreadQueues().size();
-      if (!NumPerThreadQueuesActive)
-        break;
-      logTrace(
-          "CHIPBackendLevel0::uninitialize() per-thread queues still active "
-          "{}. Sleeping for 1s..",
-          NumPerThreadQueuesActive);
-    }
-    sleep(1);
-  }
-
-  {
-    std::lock_guard<std::mutex> LockBackend(BackendMtx);
-    for (auto Q : Backend->getQueues()) {
-      //      TODO finish?
-      //      if (!Q) // TODO
-      //        continue;
-      std::lock_guard Lock(Q->QueueMtx);
-      Q->updateLastEvent(nullptr);
-    }
-  }
+  logTrace("CHIPBackendOpenCL::uninitialize()");
+  waitForThreadExit();
 }
+
 CHIPQueue *CHIPBackendOpenCL::createCHIPQueue(CHIPDevice *ChipDev) {
   CHIPDeviceOpenCL *ChipDevCl = (CHIPDeviceOpenCL *)ChipDev;
   return new CHIPQueueOpenCL(ChipDevCl, OCL_DEFAULT_QUEUE_PRIORITY);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -932,7 +932,10 @@ CHIPQueueOpenCL::CHIPQueueOpenCL(CHIPDevice *ChipDevice, int Priority,
   }
 }
 
-CHIPQueueOpenCL::~CHIPQueueOpenCL() {}
+CHIPQueueOpenCL::~CHIPQueueOpenCL() {
+  logTrace("{} ~CHIPQueueOpenCL()", (void*)this);
+  finish();
+};
 
 CHIPEvent *CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src,
                                              size_t Size) {
@@ -960,6 +963,7 @@ CHIPEvent *CHIPQueueOpenCL::memCopyAsyncImpl(void *Dst, const void *Src,
 }
 
 void CHIPQueueOpenCL::finish() {
+  logTrace("{} CHIPQueueOpenCL::finish()", (void*)this);
   auto Status = ClQueue_->finish();
   CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
 }

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -266,6 +266,7 @@ public:
   virtual void initializeFromNative(const uintptr_t *NativeHandles,
                                     int NumHandles) override;
 
+  virtual void uninitialize() override;
   virtual std::string getDefaultJitFlags() override;
 
   virtual int ReqNumHandles() override { return 4; }


### PR DESCRIPTION
Was trying to debug #180 the main issue being that 2 of the hipStreamPerThread test cases fail on OpenCL CPU backend. That issue is still outstanding - valgrind reports a ton of race conditions in the OpenCL CPU runtime.

In this PR:
* Refactor syncQueues - code is easier to understand
* Refactor hipStreamPerThread - previously if hipStreamPerThread threads were detached, the main thread could run all the way to uninitialization. `CHIPQueue::finish()` would be called but that would just ensure that whatever work is already submitted to the queue was complete. If the thread was still alive and submitting additional tasks then the queues would be destroyed prematurely. 



`Arcticus Level Zero`
- [ ] sycl_chip_interop (Timeout)
- [ ] sycl_chip_interop_usm (Timeout)
- [ ] Unit_hipStreamPerThread_MultiThread (SEGFAULT)
- [ ] Unit_hipStreamPerThread_DeviceReset_1 (SEGFAULT)

`Arcticus OCL GPU`
- [ ] 2d_shuffle (Failed)
- [ ] hipStreamSemantics (Failed)
- [ ] hipConstantTestDeviceSymbol (Subprocess aborted)
- [ ] hipAddressingModes (Failed)
- [ ] cuda-blackscholes (Failed)
- [ ] Unit_hipStreamPerThread_MultiThread (Subprocess aborted)
- [ ] Unit_hipStreamPerThread_DeviceReset_1 (Failed)


`Arcticus OCL CPU`
- [ ] 2d_shuffle (Failed)
- [ ] hipStreamSemantics (Failed)
- [ ] hipConstantTestDeviceSymbol (Subprocess aborted)
- [ ] hipAddressingModes (Failed)
- [ ] cuda-blackscholes (Failed)
- [ ] Unit_hipMemcpy_MultiThread-AllAPIs (SEGFAULT)
- [ ] Unit_hipStreamPerThread_MultiThread (SEGFAULT)
- [ ] Unit_hipStreamPerThread_DeviceReset_1 (Subprocess aborted)

