### PR TITLE
Fix Level Zero Queue initialization

### DIFF
--- a/samples/hipStreamSemantics/hipStreamSemantics.cc
+++ b/samples/hipStreamSemantics/hipStreamSemantics.cc
@@ -76,7 +76,7 @@ bool TestStreamSemantics_1() {
     // printf("Failed, queue status is %s but expected is hipErrorNotReady\n",
     // hipGetErrorName(status));
   } else {
-    printf("Passed\n");
+    printf("PASSED\n");
   }
 
   // Wait for all tasks to be finished
@@ -128,7 +128,7 @@ bool TestStreamSemantics_2() {
     // printf("host_ptr = %d, stream_shared_data = %d\n", *host_ptr,
     // *stream_shared_data);fflush(stdout);
   } else {
-    printf("Passed\n");
+    printf("PASSED\n");
   }
 
   // Wait for all tasks to be finished
@@ -181,7 +181,7 @@ bool TestStreamSemantics_3() {
     // printf("Failed, queue status is %s but expected is hipErrorNotReady\n",
     // hipGetErrorName(status));
   } else {
-    printf("Passed\n");
+    printf("PASSED\n");
   }
 
   CHECK(hipDeviceSynchronize());
@@ -216,7 +216,7 @@ bool TestStreamSemantics_4() {
   printf("Waiting for device to finish the task\n");
   CHECK(hipDeviceSynchronize());
 
-  printf("%s (stream destroy): Passed\n", __FUNCTION__);
+  printf("%s (stream destroy): PASSED\n", __FUNCTION__);
 
   free(stream_shared_data);
   return true;
@@ -250,7 +250,7 @@ bool TestStreamSemantics_5() {
     testStatus = false;
     printf("%s %s %s\n", "\033[0;31m", "Failed", "\033[0m");
   } else {
-    printf("Passed\n");
+    printf("PASSED\n");
   }
 
   CHECK(hipDeviceSynchronize());

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -897,6 +897,7 @@ CHIPDeviceLevel0::getNextComputeQueueDesc(int Priority) {
 
   auto MaxQueues = ComputeQueueProperties_.numQueues;
   std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
+  CommandQueueComputeDesc.index = NextComputeQueueIndex_;
   NextComputeQueueIndex_ = (NextComputeQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueComputeDesc;
@@ -909,6 +910,7 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc(int Priority) {
 
   auto MaxQueues = CopyQueueProperties_.numQueues;
   std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
+  CommandQueueCopyDesc.index = NextCopyQueueIndex_;
   NextCopyQueueIndex_ = (NextCopyQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueCopyDesc;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -908,7 +908,7 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc(int Priority) {
   CommandQueueCopyDesc.ordinal = CopyQueueGroupOrdinal_;
 
   auto MaxQueues = CopyQueueProperties_.numQueues;
-    std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
+  std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
   NextCopyQueueIndex_ = (NextCopyQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueCopyDesc;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -896,6 +896,7 @@ CHIPDeviceLevel0::getNextComputeQueueDesc(int Priority) {
   CommandQueueComputeDesc.ordinal = ComputeQueueGroupOrdinal_;
 
   auto MaxQueues = ComputeQueueProperties_.numQueues;
+  std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
   NextComputeQueueIndex_ = (NextComputeQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueComputeDesc;
@@ -907,6 +908,7 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc(int Priority) {
   CommandQueueCopyDesc.ordinal = CopyQueueGroupOrdinal_;
 
   auto MaxQueues = CopyQueueProperties_.numQueues;
+    std::lock_guard<std::mutex> LockQueueIndexIterator(NextQueueIndexMtx_);
   NextCopyQueueIndex_ = (NextCopyQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueCopyDesc;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -828,7 +828,6 @@ void CHIPDeviceLevel0::initializeQueueGroupProperties() {
       ComputeQueueGroupOrdinal_ = i;
       ComputeQueueProperties_ = CmdqueueGroupProperties[i];
       logTrace("Found compute command group");
-      // TODO fix-207 print queue properties
       continue;
     }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -833,10 +833,10 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextComputeQueueDesc() {
       NextComputeQueueIndex_, // index
       0,                      // flags
       ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
-      ZE_COMMAND_QUEUE_PRIORITY_NORMAL}; // TODO: use priority
+      ZE_COMMAND_QUEUE_PRIORITY_NORMAL}; // TODO fix-207: use priority
 
   auto MaxQueues = ComputeQueueProperties_.numQueues;
-  NextCopyQueueIndex_ = (NextCopyQueueIndex_ + 1) % MaxQueues;
+  NextComputeQueueIndex_ = (NextComputeQueueIndex_ + 1) % MaxQueues;
 
   return CommandQueueComputeDesc;
 }
@@ -847,10 +847,10 @@ ze_command_queue_desc_t CHIPDeviceLevel0::getNextCopyQueueDesc() {
       ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
       nullptr, // pNext
       (unsigned int)CopyQueueGroupOrdinal_,
-      NextComputeQueueIndex_, // index
-      0,                      // flags
+      NextCopyQueueIndex_, // index
+      0,                   // flags
       ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
-      ZE_COMMAND_QUEUE_PRIORITY_NORMAL}; // TODO: use priority
+      ZE_COMMAND_QUEUE_PRIORITY_NORMAL}; // TODO fix-207: use priority
 
   auto MaxQueues = CopyQueueProperties_.numQueues;
   NextCopyQueueIndex_ = (NextCopyQueueIndex_ + 1) % MaxQueues;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -695,7 +695,10 @@ CHIPEventLevel0 *CHIPQueueLevel0::getLastEvent() {
 }
 
 ze_command_list_handle_t CHIPDeviceLevel0::getCmdListCopy() {
-  // TODO fix-207 check if copy queue is available
+  if(!CopyQueueAvailable) {
+    logWarn("Copy queue not available. Returning Compute queue instead.");
+    return getCmdListCompute();
+  }
 #ifdef L0_IMM_QUEUES
   return ZeCmdListCopyImm_;
 #else
@@ -790,6 +793,7 @@ void CHIPDeviceLevel0::initializeQueueGroupProperties() {
       ComputeQueueGroupOrdinal_ = i;
       ComputeQueueProperties_ = CmdqueueGroupProperties[i];
       logTrace("Found compute command group");
+      // TODO fix-207 print queue properties
       continue;
     }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -168,8 +168,9 @@ protected:
 
   ze_command_queue_group_properties_t CopyQueueProperties_;
   ze_command_queue_group_properties_t ComputeQueueProperties_;
-  unsigned int CopyQueueGroupOrdinal_;
-  unsigned int ComputeQueueGroupOrdinal_;
+  bool CopyQueueAvailable = false;
+  int CopyQueueGroupOrdinal_ = -1;
+  int ComputeQueueGroupOrdinal_ = -1;
 
   void initializeQueueGroupProperties();
   void initializeCopyListImm();

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -382,6 +382,7 @@ class CHIPDeviceLevel0 : public CHIPDevice {
   // Queues need ot be created on separate queue group indices in order to be
   // independent from one another. Use this variable to do round-robin
   // distribution across queues every time you create a queue.
+  std::mutex NextQueueIndexMtx_;
   unsigned int NextCopyQueueIndex_ = 0;
   unsigned int NextComputeQueueIndex_ = 0;
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -144,18 +144,8 @@ protected:
   ze_context_handle_t ZeCtx_;
   ze_device_handle_t ZeDev_;
 
-  // Queues need ot be created on separate queue group indices in order to be
-  // independent from one another. Use this variable to do round-robin
-  // distribution across queues every time you create a queue.
-  unsigned int NextCopyQueueIndex_ = 0;
-  unsigned int NextComputeQueueIndex_ = 0;
-
-  size_t MaxMemoryFillPatternSize = 0;
   // The shared memory buffer
   void *SharedBuf_;
-
-  ze_command_list_handle_t ZeCmdListComputeImm_;
-  ze_command_list_handle_t ZeCmdListCopyImm_;
 
   /**
    * @brief Command queue handle
@@ -165,22 +155,6 @@ protected:
    * Current implementation does nothing with it.
    */
   ze_command_queue_handle_t ZeCmdQ_;
-
-  ze_command_queue_group_properties_t CopyQueueProperties_;
-  ze_command_queue_group_properties_t ComputeQueueProperties_;
-  bool CopyQueueAvailable = false;
-  int CopyQueueGroupOrdinal_ = -1;
-  int ComputeQueueGroupOrdinal_ = -1;
-
-  void initializeQueueGroupProperties();
-  void initializeCopyListImm();
-  void initializeComputeListImm();
-
-  ze_command_queue_desc_t getNextComputeQueueDesc();
-  ze_command_queue_desc_t getNextCopyQueueDesc();
-
-  ze_command_list_desc_t CommandListComputeDesc_;
-  ze_command_list_desc_t CommandListMemoryDesc_;
 
 public:
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev);
@@ -201,21 +175,6 @@ public:
 
   virtual CHIPEvent *memCopyAsyncImpl(void *Dst, const void *Src,
                                       size_t Size) override;
-
-  /**
-   * @brief Get a copy list handle. Using not using immediate command lists,
-   * create a new copy list
-   *
-   * @return ze_command_list_handle_t
-   */
-  ze_command_list_handle_t getCmdListCopy();
-  /**
-   * @brief Get a compute list handle. Using not using immediate command lists,
-   * create a new compute list
-   *
-   * @return ze_command_list_handle_t
-   */
-  ze_command_list_handle_t getCmdListCompute();
 
   /**
    * @brief Execute a given command list
@@ -295,7 +254,7 @@ public:
                      CHIPHostAllocFlags Flags = CHIPHostAllocFlags()) override;
 
   bool isAllocatedPtrMappedToVM(void *Ptr) override { return false; } // TODO
-  void freeImpl(void *Ptr) override{};                         // TODO
+  void freeImpl(void *Ptr) override{};                                // TODO
   ze_context_handle_t &get() { return ZeCtx; }
 
 }; // CHIPContextLevel0
@@ -395,6 +354,27 @@ class CHIPDeviceLevel0 : public CHIPDevice {
   ze_device_handle_t ZeDev_;
   ze_context_handle_t ZeCtx_;
 
+  ze_command_queue_group_properties_t CopyQueueProperties_;
+  ze_command_queue_group_properties_t ComputeQueueProperties_;
+  bool CopyQueueAvailable = false;
+  int CopyQueueGroupOrdinal_ = -1;
+  int ComputeQueueGroupOrdinal_ = -1;
+  // Queues need ot be created on separate queue group indices in order to be
+  // independent from one another. Use this variable to do round-robin
+  // distribution across queues every time you create a queue.
+  unsigned int NextCopyQueueIndex_ = 0;
+  unsigned int NextComputeQueueIndex_ = 0;
+
+  ze_command_list_desc_t CommandListComputeDesc_;
+  ze_command_list_desc_t CommandListMemoryDesc_;
+
+  ze_command_list_handle_t ZeCmdListComputeImm_;
+  ze_command_list_handle_t ZeCmdListCopyImm_;
+  void initializeCopyListImm();
+  void initializeComputeListImm();
+
+  void initializeQueueGroupProperties();
+
   // The handle of device properties
   ze_device_properties_t ZeDeviceProps_;
 
@@ -402,6 +382,24 @@ class CHIPDeviceLevel0 : public CHIPDevice {
                    int Idx);
 
 public:
+  size_t MaxMemoryFillPatternSize = 0;
+  ze_command_queue_desc_t getNextComputeQueueDesc();
+  ze_command_queue_desc_t getNextCopyQueueDesc();
+  /**
+   * @brief Get a copy list handle. Using not using immediate command lists,
+   * create a new copy list
+   *
+   * @return ze_command_list_handle_t
+   */
+  ze_command_list_handle_t getCmdListCopy();
+  /**
+   * @brief Get a compute list handle. Using not using immediate command lists,
+   * create a new compute list
+   *
+   * @return ze_command_list_handle_t
+   */
+  ze_command_list_handle_t getCmdListCompute();
+
   static CHIPDeviceLevel0 *create(ze_device_handle_t ZeDev,
                                   CHIPContextLevel0 *ChipCtx, int Idx);
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -153,8 +153,6 @@ protected:
   // The shared memory buffer
   void *SharedBuf_;
 
-  size_t MaxMemoryFillPatternSize_;
-
   /**
    * @brief Command queue handle
    * CHIP-SPV Uses the immediate command list for all its operations. However,
@@ -172,7 +170,7 @@ protected:
 
 public:
   ze_command_list_handle_t getCmdList();
-  size_t getMaxMemoryFillPatternSize() { return MaxMemoryFillPatternSize_; }
+  size_t getMaxMemoryFillPatternSize() { return QueueProperties_.maxMemoryFillPatternSize; }
   LevelZeroQueueType QueueType = LevelZeroQueueType::Unknown;
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev);
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, CHIPQueueFlags Flags);

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -382,7 +382,12 @@ class CHIPDeviceLevel0 : public CHIPDevice {
                    int Idx);
 
 public:
-  size_t MaxMemoryFillPatternSize = 0;
+  ze_command_queue_group_properties_t getComputeQueueProps() {
+    return ComputeQueueProperties_;
+  }
+  ze_command_queue_group_properties_t getCopyQueueProps() {
+    return CopyQueueProperties_;
+  }
   ze_command_queue_desc_t getNextComputeQueueDesc();
   ze_command_queue_desc_t getNextCopyQueueDesc();
   /**

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -170,7 +170,9 @@ protected:
 
 public:
   ze_command_list_handle_t getCmdList();
-  size_t getMaxMemoryFillPatternSize() { return QueueProperties_.maxMemoryFillPatternSize; }
+  size_t getMaxMemoryFillPatternSize() {
+    return QueueProperties_.maxMemoryFillPatternSize;
+  }
   LevelZeroQueueType QueueType = LevelZeroQueueType::Unknown;
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev);
   CHIPQueueLevel0(CHIPDeviceLevel0 *ChipDev, CHIPQueueFlags Flags);

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -400,18 +400,26 @@ class CHIPDeviceLevel0 : public CHIPDevice {
   CHIPDeviceLevel0(ze_device_handle_t ZeDev, CHIPContextLevel0 *ChipCtx,
                    int Idx);
 
+  ze_command_queue_desc_t getQueueDesc_(int Priority);
+
 public:
   bool copyQueueIsAvailable() { return CopyQueueAvailable_; }
-  ze_command_list_desc_t getCommandListComputeDesc() { return CommandListComputeDesc_; }
-  ze_command_list_desc_t getCommandListCopyDesc() { return CommandListCopyDesc_; }
+  ze_command_list_desc_t getCommandListComputeDesc() {
+    return CommandListComputeDesc_;
+  }
+  ze_command_list_desc_t getCommandListCopyDesc() {
+    return CommandListCopyDesc_;
+  }
   ze_command_queue_group_properties_t getComputeQueueProps() {
     return ComputeQueueProperties_;
   }
   ze_command_queue_group_properties_t getCopyQueueProps() {
     return CopyQueueProperties_;
   }
-  ze_command_queue_desc_t getNextComputeQueueDesc();
-  ze_command_queue_desc_t getNextCopyQueueDesc();
+  ze_command_queue_desc_t
+  getNextComputeQueueDesc(int Priority = L0_DEFAULT_QUEUE_PRIORITY);
+  ze_command_queue_desc_t
+  getNextCopyQueueDesc(int Priority = L0_DEFAULT_QUEUE_PRIORITY);
 
   static CHIPDeviceLevel0 *create(ze_device_handle_t ZeDev,
                                   CHIPContextLevel0 *ChipCtx, int Idx);


### PR DESCRIPTION
The L0 queue initialization was incorrect - always creating a copy queue even when one was unavailable. Fixes #207 

- [x] Fix the queue initialization process - combine two separate loops into one
- [x] Move queue ordinal properties and their getters into `CHIPDeviceLevel0`
- [x] Refactor `CHIPQueueLevel0::getNextComputeQueueDesc()` -> `CHIPDeviceLevel0::getNextComputeQueueDesc()`
- [x] `CHIPDeviceLevel0::getNextComputeQueueDesc()` respect queue priority
- [x] `CHIPDeviceLevel0::getNextCopyQueueDesc()` to use copy queue index iterator
- [x] `CHIPDeviceLevel0::getNextCopyQueueDesc()` check if copy queue is available\
- [x] Fix `maxMemoryFillPatternSize` checks
- [x] `CHIPQueueLevel0` add `LevelZeroQueueType::Compute/Copy`
    - [x] `CHIPQueueLevel0` include `MaxMemoryFillPatternSize`
    - [x] `CHIPQueueLevel0::getCmdList()` command list acquisition to only differentiate between immediate command lists and regular command lists
- [x] Create a follow-up PR for taking advantage of copy queues
