### PR TITLE
Fix no template named 'optional' in namespace 'std'

### DIFF
--- a/llvm_passes/HipEmitLoweredNames.cpp
+++ b/llvm_passes/HipEmitLoweredNames.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/CommandLine.h"
 
 #include <fstream>
+#include <optional>
 
 #define PASS_NAME "emit-lowered-names"
 #define DEBUG_TYPE PASS_NAME


### PR DESCRIPTION
...error encountered on LLVM 15.

Fixes #217.
