### PR TITLE
Correctness first with the CUDA math intrinsics

### DIFF
--- a/include/hip/devicelib/single_precision/sp_intrinsics.hh
+++ b/include/hip/devicelib/single_precision/sp_intrinsics.hh
@@ -36,7 +36,7 @@
 // __device__​ float __fdiv_rn ( float  x, float  y )
 // __device__​ float __fdiv_ru ( float  x, float  y )
 // __device__​ float __fdiv_rz ( float  x, float  y )
-// __device__​ float __fdividef ( float  x, float  y )
+__device__ float __fdividef(float x, float y);
 // __device__​ float __fmaf_ieee_rd ( float  x, float  y, float  z )
 // __device__​ float __fmaf_ieee_rn ( float  x, float  y, float  z )
 // __device__​ float __fmaf_ieee_ru ( float  x, float  y, float  z )

--- a/include/hip/spirv_hip_devicelib.hh
+++ b/include/hip/spirv_hip_devicelib.hh
@@ -562,7 +562,6 @@ EXPORT unsigned __activemask()
 
 // native(fast) approximations
 EXPORT float __powf(float x, float y) { return __exp2f(y * __log2f(x)); }
-EXPORT float __fdividef(float x, float y) { return __dividef(x, y); }
 
 // NAN/NANF
 


### PR DESCRIPTION
OpenCL native_* functions have no accuracy quarantees whatsoever whereas the __* math intrinsics of CUDA do. Thus, we cannot use the native functions by default if we want to retain portable correctness in the produced SPIR-Vs.

Fixes cuda-blackscholes for OpenCL/CPU. See Issue #222.

While fixing this, I noticed the builtin library implementation looks a bit messy and has similar codes in two places. What is the idea and longer term plan with it @pvelesko?