### PR TITLE
Copy the latest AMD HIP fp16 implementation

### DIFF
--- a/include/hip/devicelib/macros.hh
+++ b/include/hip/devicelib/macros.hh
@@ -54,8 +54,8 @@
 typedef _Float16 api_half;
 typedef _Float16 api_half2 __attribute__((ext_vector_type(2)));
 #else
-typedef short api_half;
-typedef short api_half2 __attribute__((ext_vector_type(2)));
+typedef _Float16 api_half;
+typedef _Float16 api_half2 __attribute__((ext_vector_type(2)));
 #endif // __HIP_DEVICE_COMPILE__
 
 #if defined(__HIP_DEVICE_COMPILE__)

--- a/include/hip/hip_fp16_gcc.h
+++ b/include/hip/hip_fp16_gcc.h
@@ -1,0 +1,259 @@
+/*
+  This file is a verbatim copy of
+  hipamd /include/hip/amd_detail/hip_fp16_gcc.h (revision befe7835).
+*/
+
+#pragma once
+
+#if defined(__cplusplus)
+    #include <cstring>
+#endif
+
+struct __half_raw {
+    unsigned short x;
+};
+
+struct __half2_raw {
+    unsigned short x;
+    unsigned short y;
+};
+
+#if defined(__cplusplus)
+    struct __half;
+
+    __half __float2half(float);
+    float __half2float(__half);
+
+    // BEGIN STRUCT __HALF
+    struct __half {
+    protected:
+        unsigned short __x;
+    public:
+        // CREATORS
+        __half() = default;
+        __half(const __half_raw& x) : __x{x.x} {}
+        #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+            __half(float x) : __x{__float2half(x).__x} {}
+            __half(double x) : __x{__float2half(x).__x} {}
+        #endif
+        __half(const __half&) = default;
+        __half(__half&&) = default;
+        ~__half() = default;
+
+        // MANIPULATORS
+        __half& operator=(const __half&) = default;
+        __half& operator=(__half&&) = default;
+        __half& operator=(const __half_raw& x) { __x = x.x; return *this; }
+        #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+            __half& operator=(float x)
+            {
+                __x = __float2half(x).__x;
+                return *this;
+            }
+            __half& operator=(double x)
+            {
+                return *this = static_cast<float>(x);
+            }
+        #endif
+
+        // ACCESSORS
+        operator float() const { return __half2float(*this); }
+        operator __half_raw() const { return __half_raw{__x}; }
+    };
+    // END STRUCT __HALF
+
+    // BEGIN STRUCT __HALF2
+    struct __half2 {
+    public:
+        __half x;
+        __half y;
+
+        // CREATORS
+        __half2() = default;
+        __half2(const __half2_raw& ix)
+            :
+            x{reinterpret_cast<const __half&>(ix.x)},
+            y{reinterpret_cast<const __half&>(ix.y)}
+        {}
+        __half2(const __half& ix, const __half& iy) : x{ix}, y{iy} {}
+        __half2(const __half2&) = default;
+        __half2(__half2&&) = default;
+        ~__half2() = default;
+
+        // MANIPULATORS
+        __half2& operator=(const __half2&) = default;
+        __half2& operator=(__half2&&) = default;
+        __half2& operator=(const __half2_raw& ix)
+        {
+            x = reinterpret_cast<const __half_raw&>(ix.x);
+            y = reinterpret_cast<const __half_raw&>(ix.y);
+            return *this;
+        }
+
+        // ACCESSORS
+        operator __half2_raw() const
+        {
+            return __half2_raw{
+                reinterpret_cast<const unsigned short&>(x),
+                reinterpret_cast<const unsigned short&>(y)};
+        }
+    };
+    // END STRUCT __HALF2
+
+    inline
+    unsigned short __internal_float2half(
+        float flt, unsigned int& sgn, unsigned int& rem)
+    {
+        unsigned int x{};
+        std::memcpy(&x, &flt, sizeof(flt));
+
+        unsigned int u = (x & 0x7fffffffU);
+        sgn = ((x >> 16) & 0x8000U);
+
+        // NaN/+Inf/-Inf
+        if (u >= 0x7f800000U) {
+            rem = 0;
+            return static_cast<unsigned short>(
+                (u == 0x7f800000U) ? (sgn | 0x7c00U) : 0x7fffU);
+        }
+        // Overflows
+        if (u > 0x477fefffU) {
+            rem = 0x80000000U;
+            return static_cast<unsigned short>(sgn | 0x7bffU);
+        }
+        // Normal numbers
+        if (u >= 0x38800000U) {
+            rem = u << 19;
+            u -= 0x38000000U;
+            return static_cast<unsigned short>(sgn | (u >> 13));
+        }
+        // +0/-0
+        if (u < 0x33000001U) {
+            rem = u;
+            return static_cast<unsigned short>(sgn);
+        }
+        // Denormal numbers
+        unsigned int exponent = u >> 23;
+        unsigned int mantissa = (u & 0x7fffffU);
+        unsigned int shift = 0x7eU - exponent;
+        mantissa |= 0x800000U;
+        rem = mantissa << (32 - shift);
+        return static_cast<unsigned short>(sgn | (mantissa >> shift));
+    }
+
+    inline
+    __half __float2half(float x)
+    {
+        __half_raw r;
+        unsigned int sgn{};
+        unsigned int rem{};
+        r.x = __internal_float2half(x, sgn, rem);
+        if (rem > 0x80000000U || (rem == 0x80000000U && (r.x & 0x1))) ++r.x;
+
+        return r;
+    }
+
+    inline
+    __half __float2half_rn(float x) { return __float2half(x); }
+
+    inline
+    __half __float2half_rz(float x)
+    {
+        __half_raw r;
+        unsigned int sgn{};
+        unsigned int rem{};
+        r.x = __internal_float2half(x, sgn, rem);
+
+        return r;
+    }
+
+    inline
+    __half __float2half_rd(float x)
+    {
+        __half_raw r;
+        unsigned int sgn{};
+        unsigned int rem{};
+        r.x = __internal_float2half(x, sgn, rem);
+        if (rem && sgn) ++r.x;
+
+        return r;
+    }
+
+    inline
+    __half __float2half_ru(float x)
+    {
+        __half_raw r;
+        unsigned int sgn{};
+        unsigned int rem{};
+        r.x = __internal_float2half(x, sgn, rem);
+        if (rem && !sgn) ++r.x;
+
+        return r;
+    }
+
+    inline
+    __half2 __float2half2_rn(float x)
+    {
+        return __half2{__float2half_rn(x), __float2half_rn(x)};
+    }
+
+    inline
+    __half2 __floats2half2_rn(float x, float y)
+    {
+        return __half2{__float2half_rn(x), __float2half_rn(y)};
+    }
+
+    inline
+    float __internal_half2float(unsigned short x)
+    {
+        unsigned int sign = ((x >> 15) & 1);
+        unsigned int exponent = ((x >> 10) & 0x1f);
+        unsigned int mantissa = ((x & 0x3ff) << 13);
+
+        if (exponent == 0x1fU) { /* NaN or Inf */
+            mantissa = (mantissa ? (sign = 0, 0x7fffffU) : 0);
+            exponent = 0xffU;
+        } else if (!exponent) { /* Denorm or Zero */
+            if (mantissa) {
+                unsigned int msb;
+                exponent = 0x71U;
+                do {
+                    msb = (mantissa & 0x400000U);
+                    mantissa <<= 1; /* normalize */
+                    --exponent;
+                } while (!msb);
+                mantissa &= 0x7fffffU; /* 1.mantissa is implicit */
+            }
+        } else {
+            exponent += 0x70U;
+        }
+        unsigned int u = ((sign << 31) | (exponent << 23) | mantissa);
+        float f;
+        memcpy(&f, &u, sizeof(u));
+
+        return f;
+    }
+
+    inline
+    float __half2float(__half x)
+    {
+        return __internal_half2float(static_cast<__half_raw>(x).x);
+    }
+
+    inline
+    float __low2float(__half2 x)
+    {
+        return __internal_half2float(static_cast<__half2_raw>(x).x);
+    }
+
+    inline
+    float __high2float(__half2 x)
+    {
+        return __internal_half2float(static_cast<__half2_raw>(x).y);
+    }
+
+    #if !defined(HIP_NO_HALF)
+        using half = __half;
+        using half2 = __half2;
+    #endif
+#endif // defined(__cplusplus)

--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -18,1011 +18,1648 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+  This file is an almost verbatim copy of
+  hipamd /include/hip/amd_detail/amd_hip_fp16.h (revision 348a177).
+
 */
 
 
-#ifndef HIP_INCLUDE_HIP_FP16_H
-#define HIP_INCLUDE_HIP_FP16_H
+#pragma once
+#ifndef HIP_INCLUDE_SPIRV_HIP_FP16_H
+#define HIP_INCLUDE_SPIRV_HIP_FP16_H
 
-#include <cassert>
-
-#include <algorithm>
-#include <type_traits>
-#include <utility>
-
-#if defined(__clang__) && defined(__HIP__)
-
-#if defined(__HIP_DEVICE_COMPILE__)
-typedef _Float16 _hip_f16;
-typedef _Float16 _hip_f16_2 __attribute__((ext_vector_type(2)));
+#if defined(__HIPCC_RTC__)
+  #define __HOST_DEVICE__ __device__
 #else
-typedef short _hip_f16;
-typedef short _hip_f16_2 __attribute__((ext_vector_type(2)));
+  #define __HOST_DEVICE__ __host__ __device__
+  #include <assert.h>
+  #if defined(__cplusplus)
+    #include <algorithm>
+    #include <type_traits>
+    #include <utility>
 #endif
+#endif // !defined(__HIPCC_RTC__)
 
-struct __half_raw {
-  union {
-    static_assert(sizeof(_hip_f16) == sizeof(unsigned short), "");
+#if __HIP_CLANG_ONLY__
+    typedef _Float16 _Float16_2 __attribute__((ext_vector_type(2)));
 
-    _hip_f16 data;
-    unsigned short x;
-  };
-};
+    struct __half_raw {
+        union {
+            static_assert(sizeof(_Float16) == sizeof(unsigned short), "");
 
-struct __half2_raw {
-  union {
-    static_assert(sizeof(_hip_f16_2) == sizeof(unsigned short[2]), "");
-
-    _hip_f16_2 data;
-    struct {
-      unsigned short x;
-      unsigned short y;
+            _Float16 data;
+            unsigned short x;
+        };
     };
-  };
-};
 
-#if defined(__cplusplus)
-#include "spirv_hip_vector_types.h"
+    struct __half2_raw {
+        union {
+            static_assert(sizeof(_Float16_2) == sizeof(unsigned short[2]), "");
 
-namespace std {
-template <>
-struct is_floating_point<_hip_f16> : std::true_type {};
-}  // namespace std
-
-template <bool cond, typename T = void>
-using Enable_if_t = typename std::enable_if<cond, T>::type;
-
-// BEGIN STRUCT __HALF
-struct __half {
- protected:
-  union {
-    static_assert(sizeof(_hip_f16) == sizeof(unsigned short), "");
-
-    _hip_f16 data;
-    unsigned short __x;
-  };
-
- public:
-  // CREATORS
-  __host__ __device__ __half() = default;
-  __host__ __device__ __half(const __half_raw& x) : data{x.data} {}
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  __host__ __device__ __half(decltype(data) x) : data{x} {}
-  template <typename T, Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
-  __host__ __device__ __half(T x) : data{static_cast<_hip_f16>(x)} {}
-#endif
-  __host__ __device__ __half(const __half&) = default;
-  __host__ __device__ __half(__half&&) = default;
-  __host__ __device__ ~__half() = default;
-
-// CREATORS - DEVICE ONLY
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  template <typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
-  __device__ __half(T x) : data{static_cast<_hip_f16>(x)} {}
-#endif
-
-  // MANIPULATORS
-  __host__ __device__ __half& operator=(const __half&) = default;
-  __host__ __device__ __half& operator=(__half&&) = default;
-  __host__ __device__ __half& operator=(const __half_raw& x) {
-    data = x.data;
-    return *this;
-  }
-  __host__ __device__ volatile __half& operator=(const __half_raw& x) volatile {
-    data = x.data;
-    return *this;
-  }
-  volatile __half& operator=(const volatile __half_raw& x) volatile {
-    data = x.data;
-    return *this;
-  }
-  __half& operator=(__half_raw&& x) {
-    data = x.data;
-    return *this;
-  }
-  volatile __half& operator=(__half_raw&& x) volatile {
-    data = x.data;
-    return *this;
-  }
-  volatile __half& operator=(volatile __half_raw&& x) volatile {
-    data = x.data;
-    return *this;
-  }
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  template <typename T, Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
-  __host__ __device__ __half& operator=(T x) {
-    data = static_cast<_hip_f16>(x);
-    return *this;
-  }
-#endif
-
-// MANIPULATORS - DEVICE ONLY
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  template <typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
-  __device__ __half& operator=(T x) {
-    data = static_cast<_hip_f16>(x);
-    return *this;
-  }
-#endif
-
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  __device__ __half& operator+=(const __half& x) {
-    data += x.data;
-    return *this;
-  }
-  __device__ __half& operator-=(const __half& x) {
-    data -= x.data;
-    return *this;
-  }
-  __device__ __half& operator*=(const __half& x) {
-    data *= x.data;
-    return *this;
-  }
-  __device__ __half& operator/=(const __half& x) {
-    data /= x.data;
-    return *this;
-  }
-  __device__ __half& operator++() {
-    ++data;
-    return *this;
-  }
-  __device__ __half operator++(int) {
-    __half tmp{*this};
-    ++*this;
-    return tmp;
-  }
-  __device__ __half& operator--() {
-    --data;
-    return *this;
-  }
-  __device__ __half operator--(int) {
-    __half tmp{*this};
-    --*this;
-    return tmp;
-  }
-#endif
-
-// ACCESSORS
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  template <typename T, Enable_if_t<std::is_floating_point<T>{} &&
-                                    !std::is_same<T, double>{}>* = nullptr>
-  operator T() const {
-    return data;
-  }
-#endif
-  __host__ __device__ operator __half_raw() const { return __half_raw{data}; }
-  __host__ __device__ operator volatile __half_raw() const volatile {
-    return __half_raw{data};
-  }
-
-// ACCESSORS - DEVICE ONLY
-#if !defined(__HIP_NO_HALF_CONVERSIONS__)
-  template <typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
-  __device__ operator T() const {
-    return data;
-  }
-#endif
-
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  __device__ __half operator+() const { return *this; }
-  __device__ __half operator-() const {
-    __half tmp{*this};
-    tmp.data = -tmp.data;
-    return tmp;
-  }
-#endif
-
-// FRIENDS
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  friend inline __device__ __half operator+(const __half& x, const __half& y) {
-    return __half{x} += y;
-  }
-  friend inline __device__ __half operator-(const __half& x, const __half& y) {
-    return __half{x} -= y;
-  }
-  friend inline __device__ __half operator*(const __half& x, const __half& y) {
-    return __half{x} *= y;
-  }
-  friend inline __device__ __half operator/(const __half& x, const __half& y) {
-    return __half{x} /= y;
-  }
-  friend inline __device__ bool operator==(const __half& x, const __half& y) {
-    return x.data == y.data;
-  }
-  friend inline __device__ bool operator!=(const __half& x, const __half& y) {
-    return !(x == y);
-  }
-  friend inline __device__ bool operator<(const __half& x, const __half& y) {
-    return x.data < y.data;
-  }
-  friend inline __device__ bool operator>(const __half& x, const __half& y) {
-    return y.data < x.data;
-  }
-  friend inline __device__ bool operator<=(const __half& x, const __half& y) {
-    return !(y < x);
-  }
-  friend inline __device__ bool operator>=(const __half& x, const __half& y) {
-    return !(x < y);
-  }
-#endif  // !defined(__HIP_NO_HALF_OPERATORS__)
-};
-// END STRUCT __HALF
-
-// BEGIN STRUCT __HALF2
-struct __half2 {
- protected:
-  union {
-    static_assert(sizeof(_hip_f16_2) == sizeof(unsigned short[2]), "");
-
-    _hip_f16_2 data;
-    struct {
-      unsigned short x;
-      unsigned short y;
+            _Float16_2 data;
+            struct {
+                unsigned short x;
+                unsigned short y;
+            };
+        };
     };
-  };
 
- public:
-  // CREATORS
-  __host__ __device__ __half2() = default;
-  __host__ __device__ __half2(const __half2_raw& x) : data{x.data} {}
-  __host__ __device__ __half2(decltype(data) x) : data{x} {}
-  __host__ __device__ __half2(const __half& x, const __half& y)
-      : data{static_cast<__half_raw>(x).data, static_cast<__half_raw>(y).data} {
-  }
-  __host__ __device__ __half2(const __half2&) = default;
-  __host__ __device__ __half2(__half2&&) = default;
-  __host__ __device__ ~__half2() = default;
+    #if defined(__cplusplus)
+        #include "spirv_math_fwd.h"
+        #include "spirv_hip_vector_types.h"
 
-  // MANIPULATORS
-  __host__ __device__ __half2& operator=(const __half2&) = default;
-  __host__ __device__ __half2& operator=(__half2&&) = default;
-  __host__ __device__ __half2& operator=(const __half2_raw& x) {
-    data = x.data;
-    return *this;
-  }
+        namespace std
+        {
+            template<> struct is_floating_point<_Float16> : std::true_type {};
+        }
 
-// MANIPULATORS - DEVICE ONLY
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  __device__ __half2& operator+=(const __half2& x) {
-    data += x.data;
-    return *this;
-  }
-  __device__ __half2& operator-=(const __half2& x) {
-    data -= x.data;
-    return *this;
-  }
-  __device__ __half2& operator*=(const __half2& x) {
-    data *= x.data;
-    return *this;
-  }
-  __device__ __half2& operator/=(const __half2& x) {
-    data /= x.data;
-    return *this;
-  }
-  __device__ __half2& operator++() { return *this += _hip_f16_2{1, 1}; }
-  __device__ __half2 operator++(int) {
-    __half2 tmp{*this};
-    ++*this;
-    return tmp;
-  }
-  __device__ __half2& operator--() { return *this -= _hip_f16_2{1, 1}; }
-  __device__ __half2 operator--(int) {
-    __half2 tmp{*this};
-    --*this;
-    return tmp;
-  }
-#endif
+        template<bool cond, typename T = void>
+        using Enable_if_t = typename std::enable_if<cond, T>::type;
 
-  // ACCESSORS
-  __host__ __device__ operator decltype(data)() const { return data; }
-  __host__ __device__ operator __half2_raw() const { return __half2_raw{data}; }
+        // BEGIN STRUCT __HALF
+        struct __half {
+        protected:
+            union {
+                static_assert(sizeof(_Float16) == sizeof(unsigned short), "");
 
-// ACCESSORS - DEVICE ONLY
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  __device__ __half2 operator+() const { return *this; }
-  __device__ __half2 operator-() const {
-    __half2 tmp{*this};
-    tmp.data = -tmp.data;
-    return tmp;
-  }
-#endif
+                _Float16 data;
+                unsigned short __x;
+            };
+        public:
+            // CREATORS
+            __HOST_DEVICE__
+            __half() = default;
+            __HOST_DEVICE__
+            __half(const __half_raw& x) : data{x.data} {}
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                __HOST_DEVICE__
+                __half(decltype(data) x) : data{x} {}
+                template<
+                    typename T,
+                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                __HOST_DEVICE__
+                __half(T x) : data{static_cast<_Float16>(x)} {}
+            #endif
+            __HOST_DEVICE__
+            __half(const __half&) = default;
+            __HOST_DEVICE__
+            __half(__half&&) = default;
+            __HOST_DEVICE__
+            ~__half() = default;
 
-// FRIENDS
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-  friend inline __device__ __half2 operator+(const __half2& x,
-                                             const __half2& y) {
-    return __half2{x} += y;
-  }
-  friend inline __device__ __half2 operator-(const __half2& x,
-                                             const __half2& y) {
-    return __half2{x} -= y;
-  }
-  friend inline __device__ __half2 operator*(const __half2& x,
-                                             const __half2& y) {
-    return __half2{x} *= y;
-  }
-  friend inline __device__ __half2 operator/(const __half2& x,
-                                             const __half2& y) {
-    return __half2{x} /= y;
-  }
-  friend inline __device__ bool operator==(const __half2& x, const __half2& y) {
-    auto r = x.data == y.data;
-    return r.x != 0 && r.y != 0;
-  }
-  friend inline __device__ bool operator!=(const __half2& x, const __half2& y) {
-    return !(x == y);
-  }
-  friend inline __device__ bool operator<(const __half2& x, const __half2& y) {
-    auto r = x.data < y.data;
-    return r.x != 0 && r.y != 0;
-  }
-  friend inline __device__ bool operator>(const __half2& x, const __half2& y) {
-    return y < x;
-  }
-  friend inline __device__ bool operator<=(const __half2& x, const __half2& y) {
-    return !(y < x);
-  }
-  friend inline __device__ bool operator>=(const __half2& x, const __half2& y) {
-    return !(x < y);
-  }
-#endif  // !defined(__HIP_NO_HALF_OPERATORS__)
-};
-// END STRUCT __HALF2
+            // CREATORS - DEVICE ONLY
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                template<
+                    typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
+                __HOST_DEVICE__
+                __half(T x) : data{static_cast<_Float16>(x)} {}
+            #endif
 
-namespace {
-inline __host__ __device__ __half2 make_half2(__half x, __half y) {
-  return __half2{x, y};
-}
+            // MANIPULATORS
+            __HOST_DEVICE__
+            __half& operator=(const __half&) = default;
+            __HOST_DEVICE__
+            __half& operator=(__half&&) = default;
+            __HOST_DEVICE__
+            __half& operator=(const __half_raw& x)
+            {
+                data = x.data;
+                return *this;
+            }
+            __HOST_DEVICE__
+            volatile __half& operator=(const __half_raw& x) volatile
+            {
+                data = x.data;
+                return *this;
+            }
+            volatile __half& operator=(const volatile __half_raw& x) volatile
+            {
+                data = x.data;
+                return *this;
+            }
+            __half& operator=(__half_raw&& x)
+            {
+                data = x.data;
+                return *this;
+            }
+            volatile __half& operator=(__half_raw&& x) volatile
+            {
+                data = x.data;
+                return *this;
+            }
+            volatile __half& operator=(volatile __half_raw&& x) volatile
+            {
+                data = x.data;
+                return *this;
+            }
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                template<
+                    typename T,
+                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                __HOST_DEVICE__
+                __half& operator=(T x)
+                {
+                    data = static_cast<_Float16>(x);
+                    return *this;
+                }
+            #endif
 
-inline __host__ __device__ __half
-__low2half (__half2 x)
-{
-  return __half{__half_raw{static_cast<__half2_raw>(x).data.x}};
-}
+            // MANIPULATORS - DEVICE ONLY
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                template<
+                    typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
+                __device__
+                __half& operator=(T x)
+                {
+                    data = static_cast<_Float16>(x);
+                    return *this;
+                }
+            #endif
 
-inline __host__ __device__ __half
-__high2half (__half2 x)
-{
-  return __half{__half_raw{static_cast<__half2_raw>(x).data.y}};
-}
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                __device__
+                __half& operator+=(const __half& x)
+                {
+                    data += x.data;
+                    return *this;
+                }
+                __device__
+                __half& operator-=(const __half& x)
+                {
+                    data -= x.data;
+                    return *this;
+                }
+                __device__
+                __half& operator*=(const __half& x)
+                {
+                    data *= x.data;
+                    return *this;
+                }
+                __device__
+                __half& operator/=(const __half& x)
+                {
+                    data /= x.data;
+                    return *this;
+                }
+                __device__
+                __half& operator++() { ++data; return *this; }
+                __device__
+                __half operator++(int)
+                {
+                    __half tmp{*this};
+                    ++*this;
+                    return tmp;
+                }
+                __device__
+                __half& operator--() { --data; return *this; }
+                __device__
+                __half operator--(int)
+                {
+                    __half tmp{*this};
+                    --*this;
+                    return tmp;
+                }
+            #endif
 
-inline __device__ __half2 __half2half2(__half x) { return __half2{x, x}; }
+            // ACCESSORS
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                template<
+                    typename T,
+                    Enable_if_t<std::is_floating_point<T>{}>* = nullptr>
+                __HOST_DEVICE__
+                operator T() const { return data; }
+            #endif
+            __HOST_DEVICE__
+            operator __half_raw() const { return __half_raw{data}; }
+            __HOST_DEVICE__
+            operator __half_raw() const volatile
+            {
+                return __half_raw{data};
+            }
 
-inline __device__ __half2 __halves2half2(__half x, __half y) {
-  return __half2{x, y};
-}
+            #if !defined(__HIP_NO_HALF_CONVERSIONS__)
+                template<
+                    typename T, Enable_if_t<std::is_integral<T>{}>* = nullptr>
+                __HOST_DEVICE__
+                operator T() const { return data; }
+            #endif
 
-inline __device__ __half2 __low2half2(__half2 x) {
-  return __half2{_hip_f16_2{static_cast<__half2_raw>(x).data.x,
-                            static_cast<__half2_raw>(x).data.x}};
-}
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                __device__
+                __half operator+() const { return *this; }
+                __device__
+                __half operator-() const
+                {
+                    __half tmp{*this};
+                    tmp.data = -tmp.data;
+                    return tmp;
+                }
+            #endif
 
-inline __device__ __half2 __high2half2(__half2 x) {
-  return __half2_raw{_hip_f16_2{static_cast<__half2_raw>(x).data.y,
-                                static_cast<__half2_raw>(x).data.y}};
-}
+            // FRIENDS
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                friend
+                inline
+                __device__
+                __half operator+(const __half& x, const __half& y)
+                {
+                    return __half{x} += y;
+                }
+                friend
+                inline
+                __device__
+                __half operator-(const __half& x, const __half& y)
+                {
+                    return __half{x} -= y;
+                }
+                friend
+                inline
+                __device__
+                __half operator*(const __half& x, const __half& y)
+                {
+                    return __half{x} *= y;
+                }
+                friend
+                inline
+                __device__
+                __half operator/(const __half& x, const __half& y)
+                {
+                    return __half{x} /= y;
+                }
+                friend
+                inline
+                __device__
+                bool operator==(const __half& x, const __half& y)
+                {
+                    return x.data == y.data;
+                }
+                friend
+                inline
+                __device__
+                bool operator!=(const __half& x, const __half& y)
+                {
+                    return !(x == y);
+                }
+                friend
+                inline
+                __device__
+                bool operator<(const __half& x, const __half& y)
+                {
+                    return x.data < y.data;
+                }
+                friend
+                inline
+                __device__
+                bool operator>(const __half& x, const __half& y)
+                {
+                    return y.data < x.data;
+                }
+                friend
+                inline
+                __device__
+                bool operator<=(const __half& x, const __half& y)
+                {
+                    return !(y < x);
+                }
+                friend
+                inline
+                __device__
+                bool operator>=(const __half& x, const __half& y)
+                {
+                    return !(x < y);
+                }
+            #endif // !defined(__HIP_NO_HALF_OPERATORS__)
+        };
+        // END STRUCT __HALF
 
-inline __device__ __half2 __lows2half2(__half2 x, __half2 y) {
-  return __half2_raw{_hip_f16_2{static_cast<__half2_raw>(x).data.x,
-                                static_cast<__half2_raw>(y).data.x}};
-}
+        // BEGIN STRUCT __HALF2
+        struct __half2 {
+        public:
+            union {
+                static_assert(
+                    sizeof(_Float16_2) == sizeof(unsigned short[2]), "");
 
-inline __device__ __half2 __highs2half2(__half2 x, __half2 y) {
-  return __half2_raw{_hip_f16_2{static_cast<__half2_raw>(x).data.y,
-                                static_cast<__half2_raw>(y).data.y}};
-}
+                _Float16_2 data;
+                struct {
+                    unsigned short x;
+                    unsigned short y;
+                };
+            };
 
-inline __device__ __half2 __lowhigh2highlow(__half2 x) {
-  return __half2_raw{_hip_f16_2{static_cast<__half2_raw>(x).data.y,
-                                static_cast<__half2_raw>(x).data.x}};
-}
+            // CREATORS
+            __HOST_DEVICE__
+            __half2() = default;
+            __HOST_DEVICE__
+            __half2(const __half2_raw& x) : data{x.data} {}
+            __HOST_DEVICE__
+            __half2(decltype(data) x) : data{x} {}
+            __HOST_DEVICE__
+            __half2(const __half& x, const __half& y)
+                :
+                data{
+                    static_cast<__half_raw>(x).data,
+                    static_cast<__half_raw>(y).data}
+            {}
+            __HOST_DEVICE__
+            __half2(const __half2&) = default;
+            __HOST_DEVICE__
+            __half2(__half2&&) = default;
+            __HOST_DEVICE__
+            ~__half2() = default;
 
-// Bitcasts
-inline __device__ short __half_as_short(__half x) {
-  return static_cast<__half_raw>(x).x;
-}
+            // MANIPULATORS
+            __HOST_DEVICE__
+            __half2& operator=(const __half2&) = default;
+            __HOST_DEVICE__
+            __half2& operator=(__half2&&) = default;
+            __HOST_DEVICE__
+            __half2& operator=(const __half2_raw& x)
+            {
+                data = x.data;
+                return *this;
+            }
 
-inline __device__ unsigned short __half_as_ushort(__half x) {
-  return static_cast<__half_raw>(x).x;
-}
+            // MANIPULATORS - DEVICE ONLY
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                __device__
+                __half2& operator+=(const __half2& x)
+                {
+                    data += x.data;
+                    return *this;
+                }
+                __device__
+                __half2& operator-=(const __half2& x)
+                {
+                    data -= x.data;
+                    return *this;
+                }
+                __device__
+                __half2& operator*=(const __half2& x)
+                {
+                    data *= x.data;
+                    return *this;
+                }
+                __device__
+                __half2& operator/=(const __half2& x)
+                {
+                    data /= x.data;
+                    return *this;
+                }
+                __device__
+                __half2& operator++() { return *this += _Float16_2{1, 1}; }
+                __device__
+                __half2 operator++(int)
+                {
+                    __half2 tmp{*this};
+                    ++*this;
+                    return tmp;
+                }
+                __device__
+                __half2& operator--() { return *this -= _Float16_2{1, 1}; }
+                __device__
+                __half2 operator--(int)
+                {
+                    __half2 tmp{*this};
+                    --*this;
+                    return tmp;
+                }
+            #endif
 
-inline __device__ __half __short_as_half(short x) {
-  __half_raw r;
-  r.x = x;
-  return r;
-}
+            // ACCESSORS
+            __HOST_DEVICE__
+            operator decltype(data)() const { return data; }
+            __HOST_DEVICE__
+            operator __half2_raw() const { return __half2_raw{data}; }
 
-inline __device__ __half __ushort_as_half(unsigned short x) {
-  __half_raw r;
-  r.x = x;
-  return r;
-}
+            // ACCESSORS - DEVICE ONLY
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                __device__
+                __half2 operator+() const { return *this; }
+                __device__
+                __half2 operator-() const
+                {
+                    __half2 tmp{*this};
+                    tmp.data = -tmp.data;
+                    return tmp;
+                }
+            #endif
 
-// TODO: rounding behaviour is not correct.
-// float -> half | half2
-inline __device__ __host__ __half __float2half(float x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __host__ __half __float2half_rn(float x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __host__ __half __float2half_rz(float x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __host__ __half __float2half_rd(float x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __host__ __half __float2half_ru(float x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __host__ __half2 __float2half2_rn(float x) {
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(x), static_cast<_hip_f16>(x)}};
-}
-inline __device__ __host__ __half2 __floats2half2_rn(float x, float y) {
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(x), static_cast<_hip_f16>(y)}};
-}
-inline __device__ __host__ __half2 __float22half2_rn(float2 x) {
-  return __floats2half2_rn(x.x, x.y);
-}
+            // FRIENDS
+            #if !defined(__HIP_NO_HALF_OPERATORS__)
+                friend
+                inline
+                __device__
+                __half2 operator+(const __half2& x, const __half2& y)
+                {
+                    return __half2{x} += y;
+                }
+                friend
+                inline
+                __device__
+                __half2 operator-(const __half2& x, const __half2& y)
+                {
+                    return __half2{x} -= y;
+                }
+                friend
+                inline
+                __device__
+                __half2 operator*(const __half2& x, const __half2& y)
+                {
+                    return __half2{x} *= y;
+                }
+                friend
+                inline
+                __device__
+                __half2 operator/(const __half2& x, const __half2& y)
+                {
+                    return __half2{x} /= y;
+                }
+                friend
+                inline
+                __device__
+                bool operator==(const __half2& x, const __half2& y)
+                {
+                    auto r = x.data == y.data;
+                    return r.x != 0 && r.y != 0;
+                }
+                friend
+                inline
+                __device__
+                bool operator!=(const __half2& x, const __half2& y)
+                {
+                    return !(x == y);
+                }
+                friend
+                inline
+                __device__
+                bool operator<(const __half2& x, const __half2& y)
+                {
+                    auto r = x.data < y.data;
+                    return r.x != 0 && r.y != 0;
+                }
+                friend
+                inline
+                __device__
+                bool operator>(const __half2& x, const __half2& y)
+                {
+                    return y < x;
+                }
+                friend
+                inline
+                __device__
+                bool operator<=(const __half2& x, const __half2& y)
+                {
+                    return !(y < x);
+                }
+                friend
+                inline
+                __device__
+                bool operator>=(const __half2& x, const __half2& y)
+                {
+                    return !(x < y);
+                }
+            #endif // !defined(__HIP_NO_HALF_OPERATORS__)
+        };
+        // END STRUCT __HALF2
 
-// half | half2 -> float
-inline __device__ __host__ float __half2float(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ __host__ float __low2float(__half2 x) {
-  return static_cast<__half2_raw>(x).data.x;
-}
-inline __device__ __host__ float __high2float(__half2 x) {
-  return static_cast<__half2_raw>(x).data.y;
-}
-inline __device__ __host__ float2 __half22float2(__half2 x) {
-  return make_float2(static_cast<__half2_raw>(x).data.x,
-                     static_cast<__half2_raw>(x).data.y);
-}
+        namespace
+        {
+            inline
+            __HOST_DEVICE__
+            __half2 make_half2(__half x, __half y)
+            {
+                return __half2{x, y};
+            }
 
-// half -> int
-inline __device__ int __half2int_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ int __half2int_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ int __half2int_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ int __half2int_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __HOST_DEVICE__
+            __half __low2half(__half2 x)
+            {
+                return __half{__half_raw{static_cast<__half2_raw>(x).data.x}};
+            }
 
-// int -> half
-inline __device__ __half __int2half_rn(int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __int2half_rz(int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __int2half_rd(int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __int2half_ru(int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            inline
+            __HOST_DEVICE__
+            __half __high2half(__half2 x)
+            {
+                return __half{__half_raw{static_cast<__half2_raw>(x).data.y}};
+            }
 
-// half -> short
-inline __device__ short __half2short_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ short __half2short_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ short __half2short_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ short __half2short_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __half2half2(__half x)
+            {
+                return __half2{x, x};
+            }
 
-// short -> half
-inline __device__ __half __short2half_rn(short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __short2half_rz(short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __short2half_rd(short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __short2half_ru(short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __halves2half2(__half x, __half y)
+            {
+                return __half2{x, y};
+            }
 
-// half -> long long
-inline __device__ long long __half2ll_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ long long __half2ll_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ long long __half2ll_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ long long __half2ll_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __low2half2(__half2 x)
+            {
+                return __half2{
+                    _Float16_2{
+                        static_cast<__half2_raw>(x).data.x,
+                        static_cast<__half2_raw>(x).data.x}};
+            }
 
-// long long -> half
-inline __device__ __half __ll2half_rn(long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ll2half_rz(long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ll2half_rd(long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ll2half_ru(long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __high2half2(__half2 x)
+            {
+                return __half2_raw{
+                    _Float16_2{
+                        static_cast<__half2_raw>(x).data.y,
+                        static_cast<__half2_raw>(x).data.y}};
+            }
 
-// half -> unsigned int
-inline __device__ unsigned int __half2uint_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned int __half2uint_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned int __half2uint_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned int __half2uint_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __lows2half2(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    _Float16_2{
+                        static_cast<__half2_raw>(x).data.x,
+                        static_cast<__half2_raw>(y).data.x}};
+            }
 
-// unsigned int -> half
-inline __device__ __half __uint2half_rn(unsigned int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __uint2half_rz(unsigned int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __uint2half_rd(unsigned int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __uint2half_ru(unsigned int x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __highs2half2(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    _Float16_2{
+                        static_cast<__half2_raw>(x).data.y,
+                        static_cast<__half2_raw>(y).data.y}};
+            }
 
-// half -> unsigned short
-inline __device__ unsigned short __half2ushort_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned short __half2ushort_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned short __half2ushort_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned short __half2ushort_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __HOST_DEVICE__
+            __half2 __lowhigh2highlow(__half2 x)
+            {
+                return __half2_raw{
+                    _Float16_2{
+                        static_cast<__half2_raw>(x).data.y,
+                        static_cast<__half2_raw>(x).data.x}};
+            }
 
-// unsigned short -> half
-inline __device__ __half __ushort2half_rn(unsigned short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ushort2half_rz(unsigned short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ushort2half_rd(unsigned short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ushort2half_ru(unsigned short x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            // Bitcasts
+            inline
+            __device__
+            short __half_as_short(__half x)
+            {
+                return static_cast<__half_raw>(x).x;
+            }
 
-// half -> unsigned long long
-inline __device__ unsigned long long __half2ull_rn(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned long long __half2ull_rz(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned long long __half2ull_rd(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
-inline __device__ unsigned long long __half2ull_ru(__half x) {
-  return static_cast<__half_raw>(x).data;
-}
+            inline
+            __device__
+            unsigned short __half_as_ushort(__half x)
+            {
+                return static_cast<__half_raw>(x).x;
+            }
 
-// unsigned long long -> half
-inline __device__ __half __ull2half_rn(unsigned long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ull2half_rz(unsigned long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ull2half_rd(unsigned long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
-inline __device__ __half __ull2half_ru(unsigned long long x) {
-  return __half_raw{static_cast<_hip_f16>(x)};
-}
+            inline
+            __device__
+            __half __short_as_half(short x)
+            {
+                __half_raw r; r.x = x;
+                return r;
+            }
 
-// Load primitives
-inline __device__ __half __ldg(const __half* ptr) { return *ptr; }
-inline __device__ __half __ldcg(const __half* ptr) { return *ptr; }
-inline __device__ __half __ldca(const __half* ptr) { return *ptr; }
-inline __device__ __half __ldcs(const __half* ptr) { return *ptr; }
+            inline
+            __device__
+            __half __ushort_as_half(unsigned short x)
+            {
+                __half_raw r; r.x = x;
+                return r;
+            }
 
-inline __device__ __half2 __ldg(const __half2* ptr) { return *ptr; }
-inline __device__ __half2 __ldcg(const __half2* ptr) { return *ptr; }
-inline __device__ __half2 __ldca(const __half2* ptr) { return *ptr; }
-inline __device__ __half2 __ldcs(const __half2* ptr) { return *ptr; }
+            // TODO: rounding behaviour is not correct.
+            // float -> half | half2
+            inline
+            __HOST_DEVICE__
+            __half __float2half(float x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half __float2half_rn(float x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half __float2half_rz(float x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half __float2half_rd(float x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half __float2half_ru(float x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __float2half2_rn(float x)
+            {
+                return __half2_raw{
+                    _Float16_2{
+                        static_cast<_Float16>(x), static_cast<_Float16>(x)}};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __floats2half2_rn(float x, float y)
+            {
+                return __half2_raw{_Float16_2{
+                    static_cast<_Float16>(x), static_cast<_Float16>(y)}};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __float22half2_rn(float2 x)
+            {
+                return __floats2half2_rn(x.x, x.y);
+            }
 
-// Store primitives
-inline __device__ void
-__stg (__half *ptr, const __half value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stcg (__half *ptr, const __half value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stca (__half *ptr, const __half value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stcs (__half *ptr, const __half value)
-{
-  *ptr = value;
-}
+            // half | half2 -> float
+            inline
+            __HOST_DEVICE__
+            float __half2float(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __HOST_DEVICE__
+            float __low2float(__half2 x)
+            {
+                return static_cast<__half2_raw>(x).data.x;
+            }
+            inline
+            __HOST_DEVICE__
+            float __high2float(__half2 x)
+            {
+                return static_cast<__half2_raw>(x).data.y;
+            }
+            inline
+            __HOST_DEVICE__
+            float2 __half22float2(__half2 x)
+            {
+                return make_float2(
+                    static_cast<__half2_raw>(x).data.x,
+                    static_cast<__half2_raw>(x).data.y);
+            }
 
-inline __device__ void
-__stg (__half2 *ptr, const __half2 value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stcg (__half2 *ptr, const __half2 value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stca (__half2 *ptr, const __half2 value)
-{
-  *ptr = value;
-}
-inline __device__ void
-__stcs (__half2 *ptr, const __half2 value)
-{
-  *ptr = value;
-}
+            // half -> int
+            inline
+            __device__
+            int __half2int_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            int __half2int_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            int __half2int_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            int __half2int_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-// Relations
-inline __device__ bool __heq(__half x, __half y) {
-  return static_cast<__half_raw>(x).data == static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hne(__half x, __half y) {
-  return static_cast<__half_raw>(x).data != static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hle(__half x, __half y) {
-  return static_cast<__half_raw>(x).data <= static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hge(__half x, __half y) {
-  return static_cast<__half_raw>(x).data >= static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hlt(__half x, __half y) {
-  return static_cast<__half_raw>(x).data < static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hgt(__half x, __half y) {
-  return static_cast<__half_raw>(x).data > static_cast<__half_raw>(y).data;
-}
-inline __device__ bool __hequ(__half x, __half y) { return __heq(x, y); }
-inline __device__ bool __hneu(__half x, __half y) { return __hne(x, y); }
-inline __device__ bool __hleu(__half x, __half y) { return __hle(x, y); }
-inline __device__ bool __hgeu(__half x, __half y) { return __hge(x, y); }
-inline __device__ bool __hltu(__half x, __half y) { return __hlt(x, y); }
-inline __device__ bool __hgtu(__half x, __half y) { return __hgt(x, y); }
+            // int -> half
+            inline
+            __device__
+            __half __int2half_rn(int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __int2half_rz(int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __int2half_rd(int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __int2half_ru(int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-inline __device__ __half2 __heq2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data == static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hne2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data != static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hle2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data <= static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hge2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data >= static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hlt2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data < static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hgt2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(x).data > static_cast<__half2_raw>(y).data;
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hequ2(__half2 x, __half2 y) { return __heq2(x, y); }
-inline __device__ __half2 __hneu2(__half2 x, __half2 y) { return __hne2(x, y); }
-inline __device__ __half2 __hleu2(__half2 x, __half2 y) { return __hle2(x, y); }
-inline __device__ __half2 __hgeu2(__half2 x, __half2 y) { return __hge2(x, y); }
-inline __device__ __half2 __hltu2(__half2 x, __half2 y) { return __hlt2(x, y); }
-inline __device__ __half2 __hgtu2(__half2 x, __half2 y) { return __hgt2(x, y); }
+            // half -> short
+            inline
+            __device__
+            short __half2short_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            short __half2short_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            short __half2short_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            short __half2short_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-inline __device__ bool __hbeq2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__heq2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hbne2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hne2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hble2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hle2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hbge2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hge2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hblt2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hlt2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hbgt2(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hgt2(x, y));
-  return r.data.x != 0 && r.data.y != 0;
-}
-inline __device__ bool __hbequ2(__half2 x, __half2 y) { return __hbeq2(x, y); }
-inline __device__ bool __hbneu2(__half2 x, __half2 y) { return __hbne2(x, y); }
-inline __device__ bool __hbleu2(__half2 x, __half2 y) { return __hble2(x, y); }
-inline __device__ bool __hbgeu2(__half2 x, __half2 y) { return __hbge2(x, y); }
-inline __device__ bool __hbltu2(__half2 x, __half2 y) { return __hblt2(x, y); }
-inline __device__ bool __hbgtu2(__half2 x, __half2 y) { return __hbgt2(x, y); }
+            // short -> half
+            inline
+            __device__
+            __half __short2half_rn(short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __short2half_rz(short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __short2half_rd(short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __short2half_ru(short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-// Arithmetic
-inline __device__ __half __clamp_01(__half x) {
-  auto r = static_cast<__half_raw>(x);
+            // half -> long long
+            inline
+            __device__
+            long long __half2ll_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            long long __half2ll_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            long long __half2ll_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            long long __half2ll_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-  if (__hlt(x, __half_raw{0})) return __half_raw{0};
-  if (__hlt(__half_raw{1}, x)) return __half_raw{1};
-  return r;
-}
+            // long long -> half
+            inline
+            __device__
+            __half __ll2half_rn(long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ll2half_rz(long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ll2half_rd(long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ll2half_ru(long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-inline __device__ __half
-__habs (__half x)
-{
-  return __half_raw{ fabs_h (static_cast<__half_raw> (x).data) };
-}
-inline __device__ __half __hadd(__half x, __half y) {
-  return __half_raw{static_cast<_hip_f16>(static_cast<__half_raw>(x).data +
-                                          static_cast<__half_raw>(y).data)};
-}
-inline __device__ __half __hsub(__half x, __half y) {
-  return __half_raw{static_cast<_hip_f16>(static_cast<__half_raw>(x).data -
-                                          static_cast<__half_raw>(y).data)};
-}
-inline __device__ __half __hmul(__half x, __half y) {
-  return __half_raw{static_cast<_hip_f16>(static_cast<__half_raw>(x).data *
-                                          static_cast<__half_raw>(y).data)};
-}
-inline __device__ __half __hadd_sat(__half x, __half y) {
-  return __clamp_01(__hadd(x, y));
-}
-inline __device__ __half __hsub_sat(__half x, __half y) {
-  return __clamp_01(__hsub(x, y));
-}
-inline __device__ __half __hmul_sat(__half x, __half y) {
-  return __clamp_01(__hmul(x, y));
-}
-inline __device__ __half __hfma(__half x, __half y, __half z) {
-  return __half_raw{fma_h(static_cast<__half_raw>(x).data,
-                          static_cast<__half_raw>(y).data,
-                          static_cast<__half_raw>(z).data)};
-}
-inline __device__ __half __hfma_sat(__half x, __half y, __half z) {
-  return __clamp_01(__hfma(x, y, z));
-}
-inline __device__ __half __hdiv(__half x, __half y) {
-  return __half_raw{static_cast<_hip_f16>(static_cast<__half_raw>(x).data /
-                                          static_cast<__half_raw>(y).data)};
-}
+            // half -> unsigned int
+            inline
+            __device__
+            unsigned int __half2uint_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned int __half2uint_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned int __half2uint_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned int __half2uint_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-inline __device__ __half2
-__habs2 (__half2 x)
-{
-  return __half2_raw{ fabs_2h (static_cast<__half2_raw> (x).data) };
-}
-inline __device__ __half2 __hadd2(__half2 x, __half2 y) {
-  return __half2_raw{static_cast<__half2_raw>(x).data +
-                     static_cast<__half2_raw>(y).data};
-}
-inline __device__ __half2 __hsub2(__half2 x, __half2 y) {
-  return __half2_raw{static_cast<__half2_raw>(x).data -
-                     static_cast<__half2_raw>(y).data};
-}
-inline __device__ __half2 __hmul2(__half2 x, __half2 y) {
-  return __half2_raw{static_cast<__half2_raw>(x).data *
-                     static_cast<__half2_raw>(y).data};
-}
-inline __device__ __half2 __hadd2_sat(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hadd2(x, y));
-  return __half2{__clamp_01(__half_raw{r.data.x}),
-                 __clamp_01(__half_raw{r.data.y})};
-}
-inline __device__ __half2 __hsub2_sat(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hsub2(x, y));
-  return __half2{__clamp_01(__half_raw{r.data.x}),
-                 __clamp_01(__half_raw{r.data.y})};
-}
-inline __device__ __half2 __hmul2_sat(__half2 x, __half2 y) {
-  auto r = static_cast<__half2_raw>(__hmul2(x, y));
-  return __half2{__clamp_01(__half_raw{r.data.x}),
-                 __clamp_01(__half_raw{r.data.y})};
-}
-inline __device__ __half2 __hfma2(__half2 x, __half2 y, __half2 z) {
-  return __half2_raw{fma_2h(x, y, z)};
-}
-inline __device__ __half2 __hfma2_sat(__half2 x, __half2 y, __half2 z) {
-  auto r = static_cast<__half2_raw>(__hfma2(x, y, z));
-  return __half2{__clamp_01(__half_raw{r.data.x}),
-                 __clamp_01(__half_raw{r.data.y})};
-}
-inline __device__ __half2 __h2div(__half2 x, __half2 y) {
-  return __half2_raw{static_cast<__half2_raw>(x).data /
-                     static_cast<__half2_raw>(y).data};
-}
+            // unsigned int -> half
+            inline
+            __device__
+            __half __uint2half_rn(unsigned int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __uint2half_rz(unsigned int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __uint2half_rd(unsigned int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __uint2half_ru(unsigned int x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-inline __device__ __half htrunc(__half x) {
-  return __half_raw{trunc_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hceil(__half x) {
-  return __half_raw{ceil_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hfloor(__half x) {
-  return __half_raw{floor_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half
-hrint (__half x)
-{
-  return __half_raw{ rint_h (static_cast<__half_raw> (x).data) };
-}
-inline __device__ __half hsin(__half x) {
-  return __half_raw{sin_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hcos(__half x) {
-  return __half_raw{cos_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hexp(__half x) {
-  return __half_raw{exp_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hexp2(__half x) {
-  return __half_raw{exp2_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hexp10(__half x) {
-  return __half_raw{exp10_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hlog2(__half x) {
-  return __half_raw{log2_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hlog(__half x) {
-  return __half_raw{log_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hlog10(__half x) {
-  return __half_raw{log10_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half
-hmin (__half x, __half y)
-{
-  return __half_raw{ fmin_h (static_cast<__half_raw> (x).data,
-                             static_cast<__half_raw> (y).data) };
-}
-inline __device__ __half
-hmax (__half x, __half y)
-{
-  return __half_raw{ fmax_h (static_cast<__half_raw> (x).data,
-                             static_cast<__half_raw> (y).data) };
-}
-inline __device__ __half hrcp(__half x) {
-  return __half_raw{ static_cast<_hip_f16> (
-      __half_raw{ 1 }.data / static_cast<__half_raw> (x).data) };
-}
+            // half -> unsigned short
+            inline
+            __device__
+            unsigned short __half2ushort_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned short __half2ushort_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned short __half2ushort_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned short __half2ushort_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-inline __device__ __half hrsqrt(__half x) {
-  return __half_raw{rsqrt_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ __half hsqrt(__half x) {
-  return __half_raw{sqrt_h(static_cast<__half_raw>(x).data)};
-}
-inline __device__ bool __hisinf(__half x) {
-  return isinf_h(static_cast<__half_raw>(x).data);
-}
-inline __device__ bool __hisnan(__half x) {
-  return isnan_h(static_cast<__half_raw>(x).data);
-}
-inline __device__ __half __hneg(__half x) {
-  return __half_raw{static_cast<_hip_f16>(-static_cast<__half_raw>(x).data)};
-}
+            // unsigned short -> half
+            inline
+            __device__
+            __half __ushort2half_rn(unsigned short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ushort2half_rz(unsigned short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ushort2half_rd(unsigned short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ushort2half_ru(unsigned short x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-inline __device__ __half2 h2trunc(__half2 x) {
-  return __half2_raw{trunc_2h(x)};
-}
-inline __device__ __half2 h2ceil(__half2 x) { return __half2_raw{ceil_2h(x)}; }
-inline __device__ __half2 h2floor(__half2 x) {
-  return __half2_raw{floor_2h(x)};
-}
-inline __device__ __half2
-h2rint (__half2 x)
-{
-  return __half2_raw{ rint_2h (x) };
-}
-inline __device__ __half2 h2sin(__half2 x) { return __half2_raw{sin_2h(x)}; }
-inline __device__ __half2 h2cos(__half2 x) { return __half2_raw{cos_2h(x)}; }
-inline __device__ __half2 h2exp(__half2 x) { return __half2_raw{exp_2h(x)}; }
-inline __device__ __half2 h2exp2(__half2 x) { return __half2_raw{exp2_2h(x)}; }
-inline __device__ __half2 h2exp10(__half2 x) {
-  return __half2_raw{exp10_2h(x)};
-}
-inline __device__ __half2 h2log2(__half2 x) { return __half2_raw{log2_2h(x)}; }
-inline __device__ __half2 h2log(__half2 x) { return log_2h(x); }
-inline __device__ __half2 h2log10(__half2 x) { return log10_2h(x); }
-inline __device__ __half2
-hmin2 (__half2 x, __half2 y)
-{
-  return fmin_2h (x, y);
-}
-inline __device__ __half2
-hmax2 (__half2 x, __half2 y)
-{
-  return fmax_2h (x, y);
-}
-inline __device__ __half2
-h2rcp (__half2 x)
-{
-  return __half2_raw{ static_cast<_hip_f16_2> (
-      __half2_raw{ 1 }.data / static_cast<__half2_raw> (x).data) };
-}
-inline __device__ __half2 h2rsqrt(__half2 x) { return rsqrt_2h(x); }
-inline __device__ __half2 h2sqrt(__half2 x) { return sqrt_2h(x); }
-inline __device__ __half2 __hisinf2(__half2 x) {
-  auto r = isinf_2h(x);
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hisnan2(__half2 x) {
-  auto r = isnan_2h(x);
-  return __half2_raw{
-      _hip_f16_2{static_cast<_hip_f16>(r.x), static_cast<_hip_f16>(r.y)}};
-}
-inline __device__ __half2 __hneg2(__half2 x) {
-  return __half2_raw{-static_cast<__half2_raw>(x).data};
-}
-}  // Anonymous namespace.
+            // half -> unsigned long long
+            inline
+            __device__
+            unsigned long long __half2ull_rn(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned long long __half2ull_rz(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned long long __half2ull_rd(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
+            inline
+            __device__
+            unsigned long long __half2ull_ru(__half x)
+            {
+                return static_cast<__half_raw>(x).data;
+            }
 
-#if !defined(HIP_NO_HALF)
-using half = __half;
-using half2 = __half2;
-#endif
-#endif  // defined(__cplusplus)
+            // unsigned long long -> half
+            inline
+            __device__
+            __half __ull2half_rn(unsigned long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ull2half_rz(unsigned long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ull2half_rd(unsigned long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
+            inline
+            __device__
+            __half __ull2half_ru(unsigned long long x)
+            {
+                return __half_raw{static_cast<_Float16>(x)};
+            }
 
-#endif  // defined(__clang__)
+            // Load primitives
+            inline
+            __device__
+            __half __ldg(const __half* ptr) { return *ptr; }
+            inline
+            __device__
+            __half __ldcg(const __half* ptr) { return *ptr; }
+            inline
+            __device__
+            __half __ldca(const __half* ptr) { return *ptr; }
+            inline
+            __device__
+            __half __ldcs(const __half* ptr) { return *ptr; }
 
-#endif
+            inline
+            __HOST_DEVICE__
+            __half2 __ldg(const __half2* ptr) { return *ptr; }
+            inline
+            __HOST_DEVICE__
+            __half2 __ldcg(const __half2* ptr) { return *ptr; }
+            inline
+            __HOST_DEVICE__
+            __half2 __ldca(const __half2* ptr) { return *ptr; }
+            inline
+            __HOST_DEVICE__
+            __half2 __ldcs(const __half2* ptr) { return *ptr; }
+
+            // Relations
+            inline
+            __device__
+            bool __heq(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data ==
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hne(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data !=
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hle(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data <=
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hge(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data >=
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hlt(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data <
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hgt(__half x, __half y)
+            {
+                return static_cast<__half_raw>(x).data >
+                    static_cast<__half_raw>(y).data;
+            }
+            inline
+            __device__
+            bool __hequ(__half x, __half y) { return __heq(x, y); }
+            inline
+            __device__
+            bool __hneu(__half x, __half y) { return __hne(x, y); }
+            inline
+            __device__
+            bool __hleu(__half x, __half y) { return __hle(x, y); }
+            inline
+            __device__
+            bool __hgeu(__half x, __half y) { return __hge(x, y); }
+            inline
+            __device__
+            bool __hltu(__half x, __half y) { return __hlt(x, y); }
+            inline
+            __device__
+            bool __hgtu(__half x, __half y) { return __hgt(x, y); }
+
+            inline
+            __HOST_DEVICE__
+            __half2 __heq2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data ==
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hne2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data !=
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hle2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data <=
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hge2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data >=
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hlt2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data <
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hgt2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(x).data >
+                    static_cast<__half2_raw>(y).data;
+                return __builtin_convertvector(-r, _Float16_2);
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hequ2(__half2 x, __half2 y) { return __heq2(x, y); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hneu2(__half2 x, __half2 y) { return __hne2(x, y); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hleu2(__half2 x, __half2 y) { return __hle2(x, y); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hgeu2(__half2 x, __half2 y) { return __hge2(x, y); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hltu2(__half2 x, __half2 y) { return __hlt2(x, y); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hgtu2(__half2 x, __half2 y) { return __hgt2(x, y); }
+
+            inline
+            __HOST_DEVICE__
+            bool __hbeq2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__heq2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hbne2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hne2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hble2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hle2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hbge2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hge2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hblt2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hlt2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hbgt2(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hgt2(x, y));
+                return r.data.x != 0 && r.data.y != 0;
+            }
+            inline
+            __HOST_DEVICE__
+            bool __hbequ2(__half2 x, __half2 y) { return __hbeq2(x, y); }
+            inline
+            __HOST_DEVICE__
+            bool __hbneu2(__half2 x, __half2 y) { return __hbne2(x, y); }
+            inline
+            __HOST_DEVICE__
+            bool __hbleu2(__half2 x, __half2 y) { return __hble2(x, y); }
+            inline
+            __HOST_DEVICE__
+            bool __hbgeu2(__half2 x, __half2 y) { return __hbge2(x, y); }
+            inline
+            __HOST_DEVICE__
+            bool __hbltu2(__half2 x, __half2 y) { return __hblt2(x, y); }
+            inline
+            __HOST_DEVICE__
+            bool __hbgtu2(__half2 x, __half2 y) { return __hbgt2(x, y); }
+
+            // Arithmetic
+            inline
+            __device__
+            __half __clamp_01(__half x)
+            {
+                auto r = static_cast<__half_raw>(x);
+
+                if (__hlt(x, __half_raw{0})) return __half_raw{0};
+                if (__hlt(__half_raw{1}, x)) return __half_raw{1};
+                return r;
+            }
+
+            inline
+            __device__
+            __half __hadd(__half x, __half y)
+            {
+                return __half_raw{
+                    static_cast<__half_raw>(x).data +
+                    static_cast<__half_raw>(y).data};
+            }
+	    inline
+	    __device__
+	    __half __habs(__half x)
+	    {
+	        return __half_raw{
+		    __ocml_fabs_f16(static_cast<__half_raw>(x).data)};
+	    }
+            inline
+            __device__
+            __half __hsub(__half x, __half y)
+            {
+                return __half_raw{
+                    static_cast<__half_raw>(x).data -
+                    static_cast<__half_raw>(y).data};
+            }
+            inline
+            __device__
+            __half __hmul(__half x, __half y)
+            {
+                return __half_raw{
+                    static_cast<__half_raw>(x).data *
+                    static_cast<__half_raw>(y).data};
+            }
+            inline
+            __device__
+            __half __hadd_sat(__half x, __half y)
+            {
+                return __clamp_01(__hadd(x, y));
+            }
+            inline
+            __device__
+            __half __hsub_sat(__half x, __half y)
+            {
+                return __clamp_01(__hsub(x, y));
+            }
+            inline
+            __device__
+            __half __hmul_sat(__half x, __half y)
+            {
+                return __clamp_01(__hmul(x, y));
+            }
+            inline
+            __device__
+            __half __hfma(__half x, __half y, __half z)
+            {
+                return __half_raw{__ocml_fma_f16(
+                    static_cast<__half_raw>(x).data,
+                    static_cast<__half_raw>(y).data,
+                    static_cast<__half_raw>(z).data)};
+            }
+            inline
+            __device__
+            __half __hfma_sat(__half x, __half y, __half z)
+            {
+                return __clamp_01(__hfma(x, y, z));
+            }
+            inline
+            __device__
+            __half __hdiv(__half x, __half y)
+            {
+                return __half_raw{
+                    static_cast<__half_raw>(x).data /
+                    static_cast<__half_raw>(y).data};
+            }
+
+            inline
+            __HOST_DEVICE__
+            __half2 __hadd2(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    static_cast<__half2_raw>(x).data +
+                    static_cast<__half2_raw>(y).data};
+            }
+	    inline
+	    __HOST_DEVICE__
+	    __half2 __habs2(__half2 x)
+	    {
+	        return __half2_raw{
+		    __ocml_fabs_2f16(static_cast<__half2_raw>(x).data)};
+	    }
+            inline
+            __HOST_DEVICE__
+            __half2 __hsub2(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    static_cast<__half2_raw>(x).data -
+                    static_cast<__half2_raw>(y).data};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hmul2(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    static_cast<__half2_raw>(x).data *
+                    static_cast<__half2_raw>(y).data};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hadd2_sat(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hadd2(x, y));
+                return __half2{
+                    __clamp_01(__half_raw{r.data.x}),
+                    __clamp_01(__half_raw{r.data.y})};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hsub2_sat(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hsub2(x, y));
+                return __half2{
+                    __clamp_01(__half_raw{r.data.x}),
+                    __clamp_01(__half_raw{r.data.y})};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hmul2_sat(__half2 x, __half2 y)
+            {
+                auto r = static_cast<__half2_raw>(__hmul2(x, y));
+                return __half2{
+                    __clamp_01(__half_raw{r.data.x}),
+                    __clamp_01(__half_raw{r.data.y})};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hfma2(__half2 x, __half2 y, __half2 z)
+            {
+                return __half2_raw{__ocml_fma_2f16(x, y, z)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hfma2_sat(__half2 x, __half2 y, __half2 z)
+            {
+                auto r = static_cast<__half2_raw>(__hfma2(x, y, z));
+                return __half2{
+                    __clamp_01(__half_raw{r.data.x}),
+                    __clamp_01(__half_raw{r.data.y})};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __h2div(__half2 x, __half2 y)
+            {
+                return __half2_raw{
+                    static_cast<__half2_raw>(x).data /
+                    static_cast<__half2_raw>(y).data};
+            }
+
+            // Math functions
+            #if __HIP_CLANG_ONLY__
+            inline
+            __device__
+            float amd_mixed_dot(__half2 a, __half2 b, float c, bool saturate) {
+                return __ockl_fdot2(static_cast<__half2_raw>(a).data,
+                                    static_cast<__half2_raw>(b).data,
+                                    c, saturate);
+            }
+            #endif
+            inline
+            __device__
+            __half htrunc(__half x)
+            {
+                return __half_raw{
+                    __ocml_trunc_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hceil(__half x)
+            {
+                return __half_raw{
+                    __ocml_ceil_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hfloor(__half x)
+            {
+                return __half_raw{
+                   __ocml_floor_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hrint(__half x)
+            {
+                return __half_raw{
+                    __ocml_rint_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hsin(__half x)
+            {
+                return __half_raw{
+                    __ocml_sin_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hcos(__half x)
+            {
+                return __half_raw{
+                    __ocml_cos_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hexp(__half x)
+            {
+                return __half_raw{
+                    __ocml_exp_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hexp2(__half x)
+            {
+                return __half_raw{
+                    __ocml_exp2_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hexp10(__half x)
+            {
+                return __half_raw{
+                    __ocml_exp10_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hlog2(__half x)
+            {
+                return __half_raw{
+                    __ocml_log2_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hlog(__half x)
+            {
+                return __half_raw{
+                    __ocml_log_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hlog10(__half x)
+            {
+                return __half_raw{
+                    __ocml_log10_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hrcp(__half x)
+            {
+                return __half_raw{
+                    __llvm_amdgcn_rcp_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hrsqrt(__half x)
+            {
+                return __half_raw{
+                    __ocml_rsqrt_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            __half hsqrt(__half x)
+            {
+                return __half_raw{
+                    __ocml_sqrt_f16(static_cast<__half_raw>(x).data)};
+            }
+            inline
+            __device__
+            bool __hisinf(__half x)
+            {
+                return __ocml_isinf_f16(static_cast<__half_raw>(x).data);
+            }
+            inline
+            __device__
+            bool __hisnan(__half x)
+            {
+                return __ocml_isnan_f16(static_cast<__half_raw>(x).data);
+            }
+            inline
+            __device__
+            __half __hneg(__half x)
+            {
+                return __half_raw{-static_cast<__half_raw>(x).data};
+            }
+
+            inline
+            __HOST_DEVICE__
+            __half2 h2trunc(__half2 x)
+            {
+                return __half2_raw{__ocml_trunc_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2ceil(__half2 x)
+            {
+                return __half2_raw{__ocml_ceil_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2floor(__half2 x)
+            {
+                return __half2_raw{__ocml_floor_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2rint(__half2 x)
+            {
+                return __half2_raw{__ocml_rint_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2sin(__half2 x)
+            {
+                return __half2_raw{__ocml_sin_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2cos(__half2 x)
+            {
+                return __half2_raw{__ocml_cos_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2exp(__half2 x)
+            {
+                return __half2_raw{__ocml_exp_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2exp2(__half2 x)
+            {
+                return __half2_raw{__ocml_exp2_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2exp10(__half2 x)
+            {
+                return __half2_raw{__ocml_exp10_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2log2(__half2 x)
+            {
+                return __half2_raw{__ocml_log2_2f16(x)};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 h2log(__half2 x) { return __ocml_log_2f16(x); }
+            inline
+            __HOST_DEVICE__
+            __half2 h2log10(__half2 x) { return __ocml_log10_2f16(x); }
+            inline
+            __HOST_DEVICE__
+            __half2 h2rcp(__half2 x) { return __llvm_amdgcn_rcp_2f16(x); }
+            inline
+            __HOST_DEVICE__
+            __half2 h2rsqrt(__half2 x) { return __ocml_rsqrt_2f16(x); }
+            inline
+            __HOST_DEVICE__
+            __half2 h2sqrt(__half2 x) { return __ocml_sqrt_2f16(x); }
+            inline
+            __HOST_DEVICE__
+            __half2 __hisinf2(__half2 x)
+            {
+                auto r = __ocml_isinf_2f16(x);
+                return __half2_raw{_Float16_2{
+                    static_cast<_Float16>(r.x), static_cast<_Float16>(r.y)}};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hisnan2(__half2 x)
+            {
+                auto r = __ocml_isnan_2f16(x);
+                return __half2_raw{_Float16_2{
+                    static_cast<_Float16>(r.x), static_cast<_Float16>(r.y)}};
+            }
+            inline
+            __HOST_DEVICE__
+            __half2 __hneg2(__half2 x)
+            {
+                return __half2_raw{-static_cast<__half2_raw>(x).data};
+            }
+        } // Anonymous namespace.
+
+        #if !defined(HIP_NO_HALF)
+            using half = __half;
+            using half2 = __half2;
+        #endif
+    #endif // defined(__cplusplus)
+#elif defined(__GNUC__)
+    #include "hip_fp16_gcc.h"
+#endif // !defined(__clang__) && defined(__GNUC__)
+
+#endif // HIP_INCLUDE_HIP_HIP_RUNTIME_H
+

--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -22,8 +22,73 @@ THE SOFTWARE.
   This file is an almost verbatim copy of
   hipamd /include/hip/amd_detail/amd_hip_fp16.h (revision 348a177).
 
+  Let's try to keep it as close to upstream and possible. No clang-format,
+  and minimal modifications.
 */
 
+/* CHIP-SPV defines start */
+#define __ocml_fma_f16(__X, __Y, __Z) fma_h(__X, __Y, __Z)
+#define __ocml_fma_2f16(__X, __Y, __Z) fma_2h(__X, __Y, __Z)
+
+#define __ocml_fabs_f16(__X) fabs_h(__X)
+#define __ocml_fabs_2f16(__X) fabs_2h(__X)
+
+#define __ocml_trunc_f16(__X) trunc_h(__X)
+#define __ocml_trunc_2f16(__X) trunc_2h(__X)
+
+#define __ocml_ceil_f16(__X) ceil_h(__X)
+#define __ocml_ceil_2f16(__X) ceil_2h(__X)
+
+#define __ocml_floor_f16(__X) floor_h(__X)
+#define __ocml_floor_2f16(__X) floor_2h(__X)
+
+#define __ocml_rint_f16(__X) rint_h(__X)
+#define __ocml_rint_2f16(__X) rint_2h(__X)
+
+#define __ocml_sin_f16(__X) sin_h(__X)
+#define __ocml_sin_2f16(__X) sin_2h(__X)
+
+#define __ocml_cos_f16(__X) cos_h(__X)
+#define __ocml_cos_2f16(__X) cos_2h(__X)
+
+#define __ocml_exp_f16(__X) exp_h(__X)
+#define __ocml_exp_2f16(__X) exp_2h(__X)
+
+#define __ocml_exp2_f16(__X) exp2_h(__X)
+#define __ocml_exp2_2f16(__X) exp2_2h(__X)
+
+#define __ocml_exp10_f16(__X) exp10_h(__X)
+#define __ocml_exp10_2f16(__X) exp10_2h(__X)
+
+#define __ocml_log2_f16(__X) log2_h(__X)
+#define __ocml_log2_2f16(__X) log2_2h(__X)
+
+#define __ocml_log_f16(__X) log_h(__X)
+#define __ocml_log_2f16(__X) log_2h(__X)
+
+#define __ocml_log10_f16(__X) log10_h(__X)
+#define __ocml_log10_2f16(__X) log10_2h(__X)
+
+#define __llvm_amdgcn_rcp_f16(__X) ((__half)1.0f / (__half)__X)
+#define __llvm_amdgcn_rcp_2f16(__X) ((__half2)1.0f / (__half2)__X)
+
+#define __ocml_rsqrt_f16(__X) rsqrt_h(__X)
+#define __ocml_rsqrt_2f16(__X) rsqrt_2h(__X)
+
+#define __ocml_sqrt_f16(__X) sqrt_h(__X)
+#define __ocml_sqrt_2f16(__X) sqrt_2h(__X)
+
+#define __ocml_isinf_f16(__X) isinf_h(__X)
+#define __ocml_isinf_2f16(__X) isinf_2h(__X)
+
+#define __ocml_isnan_f16(__X) isnan_h(__X)
+#define __ocml_isnan_2f16(__X) isnan_2h(__X)
+
+/* CHIP-SPV defines end */
+
+#ifndef HIP_INCLUDE_HIP_HIP_RUNTIME_H
+#error Include this file after including hip/hip_runtime.h
+#endif
 
 #pragma once
 #ifndef HIP_INCLUDE_SPIRV_HIP_FP16_H

--- a/include/hip/spirv_hip_runtime.h
+++ b/include/hip/spirv_hip_runtime.h
@@ -32,6 +32,12 @@ THE SOFTWARE.
 #include <cstdint>
 #endif
 
+#if defined(__clang__) && defined(__HIP__)
+#define __HIP_CLANG_ONLY__ 1
+#else
+#define __HIP_CLANG_ONLY__ 0
+#endif
+
 #include <hip/hip_runtime_api.h>
 
 #include <hip/spirv_hip.hh>

--- a/include/hip/spirv_math_fwd.h
+++ b/include/hip/spirv_math_fwd.h
@@ -18,6 +18,10 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+  This file is an almost verbatim copy of
+  hipamd /include/hip/amd_detail/hip_fp16_math_fwd.h (revision 348a177).
+
 */
 
 #pragma once
@@ -48,141 +52,41 @@ __device__ __attribute__((const)) int __ockl_sdot8(int, int, int, bool);
 __device__ __attribute__((const)) unsigned int __ockl_udot8(unsigned int,
                                                             unsigned int,
                                                             unsigned int, bool);
+// /*
+// Half Math Functions
+// */
+
 #if !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
-// BEGIN FLOAT
-__device__ __attribute__((const)) float __ocml_acos_f32(float);
-__device__ __attribute__((pure)) float __ocml_acosh_f32(float);
-__device__ __attribute__((const)) float __ocml_asin_f32(float);
-__device__ __attribute__((pure)) float __ocml_asinh_f32(float);
-__device__ __attribute__((const)) float __ocml_atan2_f32(float, float);
-__device__ __attribute__((const)) float __ocml_atan_f32(float);
-__device__ __attribute__((pure)) float __ocml_atanh_f32(float);
-__device__ __attribute__((pure)) float __ocml_cbrt_f32(float);
-__device__ __attribute__((const)) float __ocml_ceil_f32(float);
-__device__ __attribute__((const)) __device__ float __ocml_copysign_f32(float,
-                                                                       float);
-__device__ float __ocml_cos_f32(float);
-__device__ float __ocml_native_cos_f32(float);
-__device__ __attribute__((pure)) __device__ float __ocml_cosh_f32(float);
-__device__ float __ocml_cospi_f32(float);
-__device__ float __ocml_i0_f32(float);
-__device__ float __ocml_i1_f32(float);
-__device__ __attribute__((pure)) float __ocml_erfc_f32(float);
-__device__ __attribute__((pure)) float __ocml_erfcinv_f32(float);
-__device__ __attribute__((pure)) float __ocml_erfcx_f32(float);
-__device__ __attribute__((pure)) float __ocml_erf_f32(float);
-__device__ __attribute__((pure)) float __ocml_erfinv_f32(float);
-__device__ __attribute__((pure)) float __ocml_exp10_f32(float);
-__device__ __attribute__((pure)) float __ocml_native_exp10_f32(float);
-__device__ __attribute__((pure)) float __ocml_exp2_f32(float);
-__device__ __attribute__((pure)) float __ocml_exp_f32(float);
-__device__ __attribute__((pure)) float __ocml_native_exp_f32(float);
-__device__ __attribute__((pure)) float __ocml_expm1_f32(float);
-__device__ __attribute__((const)) float __ocml_fabs_f32(float);
-__device__ __attribute__((const)) float __ocml_fdim_f32(float, float);
-__device__ __attribute__((const)) float __ocml_floor_f32(float);
-__device__ __attribute__((const)) float __ocml_fma_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_fmax_f32(float, float);
-__device__ __attribute__((const)) float __ocml_fmin_f32(float, float);
-__device__ __attribute__((const)) __device__ float __ocml_fmod_f32(float,
-                                                                   float);
-__device__ float __ocml_frexp_f32(float,
-                                  __attribute__((address_space(5))) int*);
-__device__ __attribute__((const)) float __ocml_hypot_f32(float, float);
-__device__ __attribute__((const)) int __ocml_ilogb_f32(float);
-__device__ __attribute__((const)) int __ocml_isfinite_f32(float);
-__device__ __attribute__((const)) int __ocml_isinf_f32(float);
-__device__ __attribute__((const)) int __ocml_isnan_f32(float);
-__device__ float __ocml_j0_f32(float);
-__device__ float __ocml_j1_f32(float);
-__device__ __attribute__((const)) float __ocml_ldexp_f32(float, int);
-__device__ float __ocml_lgamma_f32(float);
-__device__ __attribute__((pure)) float __ocml_log10_f32(float);
-__device__ __attribute__((pure)) float __ocml_native_log10_f32(float);
-__device__ __attribute__((pure)) float __ocml_log1p_f32(float);
-__device__ __attribute__((pure)) float __ocml_log2_f32(float);
-__device__ __attribute__((pure)) float __ocml_native_log2_f32(float);
-__device__ __attribute__((const)) float __ocml_logb_f32(float);
-__device__ __attribute__((pure)) float __ocml_log_f32(float);
-__device__ __attribute__((pure)) float __ocml_native_log_f32(float);
-__device__ float __ocml_modf_f32(float,
-                                 __attribute__((address_space(5))) float*);
-__device__ __attribute__((const)) float __ocml_nearbyint_f32(float);
-__device__ __attribute__((const)) float __ocml_nextafter_f32(float, float);
-__device__ __attribute__((const)) float __ocml_len3_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_len4_f32(float, float, float,
-                                                        float);
-__device__ __attribute__((pure)) float __ocml_ncdf_f32(float);
-__device__ __attribute__((pure)) float __ocml_ncdfinv_f32(float);
-__device__ __attribute__((pure)) float __ocml_pow_f32(float, float);
-__device__ __attribute__((pure)) float __ocml_pown_f32(float, int);
-__device__ __attribute__((pure)) float __ocml_rcbrt_f32(float);
-__device__ __attribute__((const)) float __ocml_remainder_f32(float, float);
-__device__ float __ocml_remquo_f32(float, float,
-                                   __attribute__((address_space(5))) int*);
-__device__ __attribute__((const)) float __ocml_rhypot_f32(float, float);
-__device__ __attribute__((const)) float __ocml_rint_f32(float);
-__device__ __attribute__((const)) float __ocml_rlen3_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_rlen4_f32(float, float, float,
-                                                         float);
-__device__ __attribute__((const)) float __ocml_round_f32(float);
-__device__ __attribute__((pure)) float __ocml_rsqrt_f32(float);
-__device__ __attribute__((const)) float __ocml_scalb_f32(float, float);
-__device__ __attribute__((const)) float __ocml_scalbn_f32(float, int);
-__device__ __attribute__((const)) int __ocml_signbit_f32(float);
-__device__ float __ocml_sincos_f32(float,
-                                   __attribute__((address_space(5))) float*);
-__device__ float __ocml_sincospi_f32(float,
-                                     __attribute__((address_space(5))) float*);
-__device__ float __ocml_sin_f32(float);
-__device__ float __ocml_native_sin_f32(float);
-__device__ __attribute__((pure)) float __ocml_sinh_f32(float);
-__device__ float __ocml_sinpi_f32(float);
-__device__ __attribute__((const)) float __ocml_sqrt_f32(float);
-__device__ __attribute__((const)) float __ocml_native_sqrt_f32(float);
-__device__ float __ocml_tan_f32(float);
-__device__ __attribute__((pure)) float __ocml_tanh_f32(float);
-__device__ float __ocml_tgamma_f32(float);
-__device__ __attribute__((const)) float __ocml_trunc_f32(float);
-__device__ float __ocml_y0_f32(float);
-__device__ float __ocml_y1_f32(float);
+extern "C"
+{
+    __device__ __attribute__((const)) _Float16 __ocml_ceil_f16(_Float16);
+    __device__ _Float16 __ocml_cos_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_exp_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_exp10_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_exp2_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_floor_f16(_Float16);
+    __device__ __attribute__((const))
+    _Float16 __ocml_fma_f16(_Float16, _Float16, _Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_fabs_f16(_Float16);
+    __device__ __attribute__((const)) int __ocml_isinf_f16(_Float16);
+    __device__ __attribute__((const)) int __ocml_isnan_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_log_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_log10_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_log2_f16(_Float16);
+    __device__ __attribute__((pure)) _Float16 __ocml_pown_f16(_Float16, int);
+    __device__ __attribute__((const)) _Float16 __llvm_amdgcn_rcp_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_rint_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_rsqrt_f16(_Float16);
+    __device__ _Float16 __ocml_sin_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_sqrt_f16(_Float16);
+    __device__ __attribute__((const)) _Float16 __ocml_trunc_f16(_Float16);
 
-// BEGIN INTRINSICS
-__device__ __attribute__((const)) float __ocml_add_rte_f32(float, float);
-__device__ __attribute__((const)) float __ocml_add_rtn_f32(float, float);
-__device__ __attribute__((const)) float __ocml_add_rtp_f32(float, float);
-__device__ __attribute__((const)) float __ocml_add_rtz_f32(float, float);
-__device__ __attribute__((const)) float __ocml_sub_rte_f32(float, float);
-__device__ __attribute__((const)) float __ocml_sub_rtn_f32(float, float);
-__device__ __attribute__((const)) float __ocml_sub_rtp_f32(float, float);
-__device__ __attribute__((const)) float __ocml_sub_rtz_f32(float, float);
-__device__ __attribute__((const)) float __ocml_mul_rte_f32(float, float);
-__device__ __attribute__((const)) float __ocml_mul_rtn_f32(float, float);
-__device__ __attribute__((const)) float __ocml_mul_rtp_f32(float, float);
-__device__ __attribute__((const)) float __ocml_mul_rtz_f32(float, float);
-__device__ __attribute__((const)) float __ocml_div_rte_f32(float, float);
-__device__ __attribute__((const)) float __ocml_div_rtn_f32(float, float);
-__device__ __attribute__((const)) float __ocml_div_rtp_f32(float, float);
-__device__ __attribute__((const)) float __ocml_div_rtz_f32(float, float);
-__device__ __attribute__((const)) float __ocml_sqrt_rte_f32(float);
-__device__ __attribute__((const)) float __ocml_sqrt_rtn_f32(float);
-__device__ __attribute__((const)) float __ocml_sqrt_rtp_f32(float);
-__device__ __attribute__((const)) float __ocml_sqrt_rtz_f32(float);
-__device__ __attribute__((const)) float __ocml_fma_rte_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_fma_rtn_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_fma_rtp_f32(float, float, float);
-__device__ __attribute__((const)) float __ocml_fma_rtz_f32(float, float, float);
+    typedef _Float16 __2f16 __attribute__((ext_vector_type(2)));
+    typedef short __2i16 __attribute__((ext_vector_type(2)));
 
-__device__ __attribute__((const)) float __llvm_amdgcn_cos_f32(float) __asm(
-    "llvm.amdgcn.cos.f32");
-__device__ __attribute__((const)) float __llvm_amdgcn_rcp_f32(float) __asm(
-    "llvm.amdgcn.rcp.f32");
-__device__ __attribute__((const)) float __llvm_amdgcn_rsq_f32(float) __asm(
-    "llvm.amdgcn.rsq.f32");
-__device__ __attribute__((const)) float __llvm_amdgcn_sin_f32(float) __asm(
-    "llvm.amdgcn.sin.f32");
-// END INTRINSICS
-// END FLOAT
+    #if __HIP_CLANG_ONLY__
+    __device__ __attribute__((const)) float __ockl_fdot2(__2f16 a, __2f16 b, float c, bool s);
+    #endif
 
 // BEGIN DOUBLE
 __device__ __attribute__((const)) double __ocml_acos_f64(double);
@@ -310,6 +214,31 @@ __device__ __attribute__((const)) double __llvm_amdgcn_rsq_f64(double) __asm(
     "llvm.amdgcn.rsq.f64");
 // END INTRINSICS
 // END DOUBLE
+
+    __device__ __attribute__((const)) __2f16 __ocml_ceil_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_fabs_2f16(__2f16);
+    __device__ __2f16 __ocml_cos_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_exp_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_exp10_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_exp2_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_floor_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_fma_2f16(__2f16, __2f16, __2f16);
+    __device__ __attribute__((const)) __2i16 __ocml_isinf_2f16(__2f16);
+    __device__ __attribute__((const)) __2i16 __ocml_isnan_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_log_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_log10_2f16(__2f16);
+    __device__ __attribute__((pure)) __2f16 __ocml_log2_2f16(__2f16);
+    __device__ inline
+    __2f16 __llvm_amdgcn_rcp_2f16(__2f16 x) // Not currently exposed by ROCDL.
+    {
+        return __2f16{__llvm_amdgcn_rcp_f16(x.x), __llvm_amdgcn_rcp_f16(x.y)};
+    }
+    __device__ __attribute__((const)) __2f16 __ocml_rint_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_rsqrt_2f16(__2f16);
+    __device__ __2f16 __ocml_sin_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_sqrt_2f16(__2f16);
+    __device__ __attribute__((const)) __2f16 __ocml_trunc_2f16(__2f16);
+}
 
 #endif // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
 #endif // __HIP_CLANG_ONLY__

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -48,7 +48,7 @@ function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
     set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
 
     target_link_libraries("${EXEC_NAME}" CHIP deviceInternal)
-    target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_SRC_DIR}/HIP/include ${CHIP_SRC_DIR}/include)
+    target_include_directories("${EXEC_NAME}" PUBLIC ${CHIP_SRC_DIR}/HIP/include ${CHIP_SRC_DIR}/include/hip ${CHIP_SRC_DIR}/include)
     install(TARGETS "${EXEC_NAME}"
             RUNTIME DESTINATION "${CHIP_SAMPLE_BINDIR}")
 

--- a/samples/fp16/fp16_conversion.hpp
+++ b/samples/fp16/fp16_conversion.hpp
@@ -92,7 +92,7 @@ static const half approx_float_to_half(float fl) {
 
 // from half->float code - just for verification.
 static float half_to_float(half hf) {
-  _hip_f16 temp = static_cast<_hip_f16>(hf);
+  __half temp = static_cast<__half>(hf);
   FP16 h;
   h.u = temp;
 
@@ -123,9 +123,9 @@ static float half_to_float(half hf) {
  */
 static int compare_calculated(half h1, half h2) {
   FP16 h_1, h_2;
-  _hip_f16 temp = static_cast<_hip_f16>(h1);
+  __half temp = static_cast<__half>(h1);
   h_1.u = temp;
-  temp = static_cast<_hip_f16>(h2);
+  temp = static_cast<__half>(h2);
   h_2.u = temp;
 
   // also deliberately compares equal infs and equal-value nans

--- a/samples/fp16/half2_math.cpp
+++ b/samples/fp16/half2_math.cpp
@@ -65,9 +65,9 @@ void check(std::string fn, const half2 *x, const half2 *y, const half2 *z, const
     half xx = (j == 0) ? __low2half(x[i]) : __high2half(x[i]);
     half yy = (j == 0) ? __low2half(y[i]) : __high2half(y[i]);
     half zz = (j == 0) ? __low2half(z[i]) : __high2half(z[i]);
-    float xx_computed = half_to_float(xx);
-    float yy_computed = half_to_float(yy);
-    float zz_computed = half_to_float(zz);
+    float xx_computed = xx;
+    float yy_computed = yy;
+    float zz_computed = zz;
 
     float verify;
     if (fn == "sub")

--- a/samples/fp16/half2_math.cpp
+++ b/samples/fp16/half2_math.cpp
@@ -195,8 +195,8 @@ int main(void) {
   z = (half2 *)malloc(n * sizeof(half2));
 
   for (int i = 0; i < n; i++) {
-    x[i] = __half2(static_cast<_hip_f16_2>(rnd()));
-    y[i] = __half2(static_cast<_hip_f16_2>(rnd()));
+    x[i] = __half2(static_cast<__half2>(rnd()));
+    y[i] = __half2(static_cast<__half2>(rnd()));
   }
 
   checkCuda(hipMalloc((void **)&d_x, n * sizeof(half2)));

--- a/samples/fp16/half_math.cpp
+++ b/samples/fp16/half_math.cpp
@@ -62,9 +62,9 @@ void check(std::string fn, const half *x, const half *y, const half *z, const in
     eq_oper = true;
 
   for (int i = 0; i < n; i++) {
-    float xx_computed = half_to_float(x[i]);
-    float yy_computed = half_to_float(y[i]);
-    float zz_computed = half_to_float(z[i]);
+    float xx_computed = x[i];
+    float yy_computed = y[i];
+    float zz_computed = z[i];
 
     float verify;
     if (fn == "sub") 

--- a/samples/fp16/half_math.cpp
+++ b/samples/fp16/half_math.cpp
@@ -185,8 +185,8 @@ int main(void) {
   z = (half *)malloc(n * sizeof(half));
 
   for (int i = 0; i < n; i++) {
-    x[i] = __half(static_cast<_hip_f16>(rnd()));
-    y[i] = __half(static_cast<_hip_f16>(rnd()));
+    x[i] = __half(static_cast<__half>(rnd()));
+    y[i] = __half(static_cast<__half>(rnd()));
   }
 
   checkCuda(hipMalloc((void **)&d_x, n * sizeof(half)));

--- a/samples/fp16/haxpy-base.cpp
+++ b/samples/fp16/haxpy-base.cpp
@@ -33,7 +33,7 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 
-#include "fp16_conversion.hpp"
+//#include "fp16_conversion.hpp"
 
 // This is a simple example of using FP16 types and arithmetic on
 // GPUs that support it. The code computes an AXPY (A * X + Y) operation
@@ -55,12 +55,12 @@ void check(const half *x, const half *y, const int n) {
   errors = 0;
   float eps = 2.0f;
   for (int i = 0; i < n; i++) {
-    float gpu_computed = half_to_float(y[i]);
-    float verify = half_to_float(x[i]) * 5.0f;
+    float gpu_computed = y[i];
+    float verify = (float)x[i] * 5.0f;
     if (std::fabs(gpu_computed - verify) > eps) {
       ++errors;
       if (errors < 32) {
-        std::cerr << "Error at N: " << i << " x[i]: " << half_to_float(x[i])
+        std::cerr << "Error at N: " << i << " x[i]: " << (float)x[i]
                   << " GPU: " << gpu_computed << " CPU: " << verify << "\n";
       }
     }
@@ -93,15 +93,15 @@ int main(void) {
   std::mt19937 gen(SEED);
   auto rnd = std::bind(std::uniform_int_distribution<short>{100, 1000}, gen);
 
-  const half a = approx_float_to_half(5.0f);
+  const half a = 5.0f;
 
   half *x, *y, *d_x, *d_y;
   x = (half *)malloc(n * sizeof(half));
   y = (half *)malloc(n * sizeof(half));
 
   for (int i = 0; i < n; i++) {
-    x[i] = approx_float_to_half(rnd());
-    y[i] = approx_float_to_half(16.0f);
+    x[i] = rnd();
+    y[i] = 16.0f;
   }
 
   checkCuda(hipMalloc((void **)&d_x, n * sizeof(half)));

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2093,6 +2093,15 @@ hipError_t hipStreamWaitEvent(hipStream_t Stream, hipEvent_t Event,
   CHIP_CATCH
 }
 
+int hipGetStreamDeviceId(hipStream_t Stream) {
+  CHIP_TRY
+  CHIPInitialize();
+  CHIPDevice *Device =
+    Backend->findQueue(static_cast<CHIPQueue *>(Stream))->getDevice();
+  return Device->getDeviceId();
+  CHIP_CATCH
+}
+
 hipError_t hipStreamGetFlags(hipStream_t Stream, unsigned int *Flags) {
   CHIP_TRY
   CHIPInitialize();


### PR DESCRIPTION
Also sneak in hipGetStreamDeviceId() implementation.

These updates address some of the first issues encountered while trying to build rocPRIM with CHIP-SPV.