### PR TITLE
Remove backend queues

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -880,8 +880,8 @@ bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
   {
     std::lock_guard<std::mutex> LockQueue(ChipQueue->QueueMtx);
     ChipQueue->finish();
-    // If this stream has a LastEvent, it will release it, decrement its refcount
-    // and let the StaleEventMonitor to collect it
+    // If this stream has a LastEvent, it will release it, decrement its
+    // refcount and let the StaleEventMonitor to collect it
     ChipQueue->updateLastEvent(nullptr);
   }
 
@@ -1399,7 +1399,8 @@ CHIPDevice *CHIPBackend::findDeviceMatchingProps(const hipDeviceProp_t *Props) {
 
 CHIPQueue *CHIPBackend::findQueue(CHIPQueue *ChipQueue) {
   auto Dev = Backend->getActiveDevice();
-  std::lock_guard<std::mutex> LockDevice(Dev->DeviceMtx); // CHIPDevice::ChipQueues_ via getQueues()
+  std::lock_guard<std::mutex> LockDevice(
+      Dev->DeviceMtx); // CHIPDevice::ChipQueues_ via getQueues()
 
   if (ChipQueue == hipStreamPerThread) {
     return Dev->getPerThreadDefaultQueue();

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -434,7 +434,6 @@ CHIPDevice::~CHIPDevice() {
   std::lock_guard<std::mutex> LockDevice(DeviceMtx); // CHIPDevice::ChipQueues_
   logDebug("~CHIPDevice() {}", (void *)this);
   while (this->ChipQueues_.size() > 0) {
-    ChipQueues_[0]->finish();
     delete ChipQueues_[0];
     ChipQueues_.erase(ChipQueues_.begin());
   }
@@ -978,10 +977,7 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
     return;
 #endif
   std::lock_guard<std::mutex> LockContext(ContextMtx);
-  int Size = 2 + Dev->getQueues().size();
-  std::vector<CHIPQueue*> QueuesToSyncWith;
-  // CHIPQueue* QueuesToSyncWith[Size];
-  //int QueueIntex = 0;
+  std::vector<CHIPQueue *> QueuesToSyncWith;
 
   // The per-thread default stream is not a non-blocking stream and will
   // synchronize with the legacy default stream if both are used in a program

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1399,6 +1399,7 @@ CHIPDevice *CHIPBackend::findDeviceMatchingProps(const hipDeviceProp_t *Props) {
 
 CHIPQueue *CHIPBackend::findQueue(CHIPQueue *ChipQueue) {
   auto Dev = Backend->getActiveDevice();
+  std::lock_guard<std::mutex> LockDevice(Dev->DeviceMtx); // CHIPDevice::ChipQueues_ via getQueues()
 
   if (ChipQueue == hipStreamPerThread) {
     return Dev->getPerThreadDefaultQueue();

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -878,11 +878,13 @@ hipSharedMemConfig CHIPDevice::getSharedMemConfig() {
 
 bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
   std::lock_guard<std::mutex> LockDevice(DeviceMtx);
-  std::lock_guard<std::mutex> LockQueue(ChipQueue->QueueMtx);
-  ChipQueue->finish();
-  // If this stream has a LastEvent, it will release it, decrement its refcount
-  // and let the StaleEventMonitor to collect it
-  ChipQueue->updateLastEvent(nullptr);
+  {
+    std::lock_guard<std::mutex> LockQueue(ChipQueue->QueueMtx);
+    ChipQueue->finish();
+    // If this stream has a LastEvent, it will release it, decrement its refcount
+    // and let the StaleEventMonitor to collect it
+    ChipQueue->updateLastEvent(nullptr);
+  }
 
   // Remove from device queue list
   auto FoundQueue =

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -434,6 +434,7 @@ CHIPDevice::~CHIPDevice() {
   std::lock_guard<std::mutex> LockDevice(DeviceMtx); // CHIPDevice::ChipQueues_
   logDebug("~CHIPDevice() {}", (void *)this);
   while (this->ChipQueues_.size() > 0) {
+    ChipQueues_[0]->finish();
     delete ChipQueues_[0];
     ChipQueues_.erase(ChipQueues_.begin());
   }
@@ -807,7 +808,7 @@ void CHIPDevice::registerDeviceVariable(std::string *ModuleStr,
 }
 
 void CHIPDevice::addQueue(CHIPQueue *ChipQueue) {
-  std::lock_guard<std::mutex> LockDevice(Backend->BackendMtx);
+  std::lock_guard<std::mutex> LockDevice(DeviceMtx);
 
   auto QueueFound =
       std::find(ChipQueues_.begin(), ChipQueues_.end(), ChipQueue);
@@ -841,7 +842,6 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(CHIPQueueFlags Flags,
   auto ChipQueue = createQueue(Flags, Priority);
   // Add the queue handle to the device and the Backend
   addQueue(ChipQueue);
-  Backend->addQueue(ChipQueue);
   return ChipQueue;
 }
 
@@ -850,14 +850,10 @@ CHIPQueue *CHIPDevice::createQueueAndRegister(const uintptr_t *NativeHandles,
   auto ChipQueue = createQueue(NativeHandles, NumHandles);
   // Add the queue handle to the device and the Backend
   addQueue(ChipQueue);
-  Backend->addQueue(ChipQueue);
   return ChipQueue;
 }
 
-std::vector<CHIPQueue *> &CHIPDevice::getQueues() {
-  std::lock_guard<std::mutex> LockDevice(DeviceMtx);
-  return ChipQueues_;
-}
+std::vector<CHIPQueue *> &CHIPDevice::getQueues() { return ChipQueues_; }
 
 hipError_t CHIPDevice::setPeerAccess(CHIPDevice *Peer, int Flags,
                                      bool CanAccessPeer) {
@@ -881,7 +877,9 @@ hipSharedMemConfig CHIPDevice::getSharedMemConfig() {
 }
 
 bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
-  std::lock_guard<std::mutex> LockBackend(Backend->BackendMtx);
+  std::lock_guard<std::mutex> LockDevice(DeviceMtx);
+  std::lock_guard<std::mutex> LockQueue(ChipQueue->QueueMtx);
+  ChipQueue->finish();
   // If this stream has a LastEvent, it will release it, decrement its refcount
   // and let the StaleEventMonitor to collect it
   ChipQueue->updateLastEvent(nullptr);
@@ -896,18 +894,6 @@ bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
     CHIPERR_LOG_AND_THROW(Msg, hipErrorUnknown);
   }
   ChipQueues_.erase(FoundQueue);
-
-  // Remove from the Backend Queue List
-  FoundQueue = std::find(Backend->getQueues().begin(),
-                         Backend->getQueues().end(), ChipQueue);
-  if (FoundQueue == Backend->getQueues().end()) {
-    std::string Msg = "Tried to remove a queue for a the backend but the queue "
-                      "was not found in "
-                      "backend queue list";
-    CHIPERR_LOG_AND_THROW(Msg, hipErrorUnknown);
-  }
-
-  Backend->getQueues().erase(FoundQueue);
 
   delete ChipQueue;
   return true;
@@ -928,7 +914,7 @@ bool CHIPDevice::hasPCIBusId(int PciDomainID, int PciBusID, int PciDeviceID) {
 }
 
 hipError_t CHIPDevice::allocateDeviceVariables() {
-  std::lock_guard<std::mutex> Lock(DeviceMtx);
+  std::lock_guard<std::mutex> Lock(DeviceVarMtx);
   logTrace("Allocate storage for device variables.");
   for (auto I : ChipModules) {
     auto Status =
@@ -940,21 +926,21 @@ hipError_t CHIPDevice::allocateDeviceVariables() {
 }
 
 void CHIPDevice::initializeDeviceVariables() {
-  std::lock_guard<std::mutex> Lock(DeviceMtx);
+  std::lock_guard<std::mutex> Lock(DeviceVarMtx);
   logTrace("Initialize device variables.");
   for (auto Module : ChipModules)
     Module.second->initializeDeviceVariablesNoLock(this, getDefaultQueue());
 }
 
 void CHIPDevice::invalidateDeviceVariables() {
-  std::lock_guard<std::mutex> Lock(DeviceMtx);
+  std::lock_guard<std::mutex> Lock(DeviceVarMtx);
   logTrace("invalidate device variables.");
   for (auto Module : ChipModules)
     Module.second->invalidateDeviceVariablesNoLock();
 }
 
 void CHIPDevice::deallocateDeviceVariables() {
-  std::lock_guard<std::mutex> Lock(DeviceMtx);
+  std::lock_guard<std::mutex> Lock(DeviceVarMtx);
   logTrace("Deallocate storage for device variables.");
   for (auto Module : ChipModules)
     Module.second->deallocateDeviceVariablesNoLock(this);
@@ -974,7 +960,9 @@ CHIPContext::~CHIPContext() {
 }
 
 void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
-  auto DefaultQueue = Backend->getActiveDevice()->getDefaultQueue();
+  auto Dev = Backend->getActiveDevice();
+  std::lock_guard<std::mutex> LockDevice(Dev->DeviceMtx);
+  auto DefaultQueue = Dev->getDefaultQueue();
 #ifdef HIP_API_PER_THREAD_DEFAULT_STREAM
   // The per-thread default stream is an implicit stream local to both the
   // thread and the CUcontext, and which does not synchronize with other streams
@@ -988,24 +976,25 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
     return;
 #endif
   std::lock_guard<std::mutex> LockContext(ContextMtx);
-  std::vector<CHIPQueue *> QueuesToSyncWith;
+  int Size = 2 + Dev->getQueues().size();
+  std::vector<CHIPQueue*> QueuesToSyncWith;
+  // CHIPQueue* QueuesToSyncWith[Size];
+  //int QueueIntex = 0;
 
   // The per-thread default stream is not a non-blocking stream and will
   // synchronize with the legacy default stream if both are used in a program
-  if (Backend->getActiveDevice()->PerThreadStreamUsed) {
-    if (TargetQueue == Backend->getActiveDevice()->getPerThreadDefaultQueue())
+  if (Dev->PerThreadStreamUsed) {
+    if (TargetQueue == Dev->getPerThreadDefaultQueue())
       QueuesToSyncWith.push_back(DefaultQueue);
-    else if (TargetQueue == Backend->getActiveDevice()->getLegacyDefaultQueue())
-      QueuesToSyncWith.push_back(
-          Backend->getActiveDevice()->getPerThreadDefaultQueue());
+    else if (TargetQueue == Dev->getLegacyDefaultQueue())
+      QueuesToSyncWith.push_back(Dev->getPerThreadDefaultQueue());
   }
 
-  {
-    std::lock_guard<std::mutex> LockBackend(Backend->BackendMtx);
-    // Always sycn with all blocking queues
-    for (auto &Queue : Backend->getQueues())
-      if (Queue->getQueueFlags().isBlocking())
-        QueuesToSyncWith.push_back(Queue);
+  // Always sycn with all blocking queues
+  for (auto Queue : Dev->getQueues()) {
+    std::lock_guard<std::mutex> LockQueue(Queue->QueueMtx);
+    if (Queue->getQueueFlags().isBlocking())
+      QueuesToSyncWith.push_back(Queue);
   }
 
   // default stream waits on all blocking streams to complete
@@ -1172,8 +1161,6 @@ CHIPBackend::~CHIPBackend() {
   Events.clear();
   for (auto &Ctx : ChipContexts)
     delete Ctx;
-  for (auto &Q : ChipQueues)
-    delete Q;
   for (auto &Mod : ModulesStr_)
     delete Mod;
 }
@@ -1182,39 +1169,20 @@ void CHIPBackend::initialize(std::string PlatformStr, std::string DeviceTypeStr,
                              std::string DeviceIdStr) {
   initializeImpl(PlatformStr, DeviceTypeStr, DeviceIdStr);
   CustomJitFlags = read_env_var("CHIP_JIT_FLAGS", false);
-  if (ChipDevices.size() == 0) {
-    std::string Msg = "No CHIPDevices were initialized";
+  if (ChipContexts.size() == 0) {
+    std::string Msg = "No CHIPContexts were initialized";
     CHIPERR_LOG_AND_THROW(Msg, hipErrorInitializationError);
   }
 
-  // check if all the devices had their default queues initialized
-  for (auto Dev : ChipDevices) {
-    if (Dev->LegacyDefaultQueue == nullptr)
-      CHIPERR_LOG_AND_THROW("LegacyDefaultQueue not initialized",
-                            hipErrorInitializationError);
-    // if (Dev->PerThreadDefaultQueue == nullptr)
-    //   CHIPERR_LOG_AND_THROW("PerThreadDefaultQueue not initialized",
-    //                         hipErrorInitializationError);
-  }
-  setActiveDevice(ChipDevices[0]);
+  setActiveDevice(ChipContexts[0]->getDevices()[0]);
 }
 
 void CHIPBackend::setActiveDevice(CHIPDevice *ChipDevice) {
   std::lock_guard<std::mutex> LockSetActive(Backend->SetActiveMtx);
 
-  auto DeviceFound =
-      std::find(ChipDevices.begin(), ChipDevices.end(), ChipDevice);
-  if (DeviceFound == ChipDevices.end()) {
-    std::string Msg =
-        "Tried to set active device with CHIPDevice pointer that is not in "
-        "CHIPBackend::chip_devices";
-    CHIPERR_LOG_AND_THROW(Msg, hipErrorLaunchFailure);
-  };
   ActiveDev_ = ChipDevice;
   ActiveCtx_ = ChipDevice->getContext();
 }
-std::vector<CHIPQueue *> &CHIPBackend::getQueues() { return ChipQueues; }
-
 CHIPContext *CHIPBackend::getActiveContext() {
   std::lock_guard<std::mutex> LockSetActive(Backend->SetActiveMtx);
   if (ActiveCtx_ == nullptr) {
@@ -1234,41 +1202,29 @@ CHIPDevice *CHIPBackend::getActiveDevice() {
   return ActiveDev_;
 };
 
-std::vector<CHIPDevice *> &CHIPBackend::getDevices() {
-  std::lock_guard<std::mutex> LockSetActive(Backend->SetActiveMtx);
+std::vector<CHIPDevice *> CHIPBackend::getDevices() {
+  std::vector<CHIPDevice *> Devices;
+  for (auto Ctx : ChipContexts) {
+    std::lock_guard<std::mutex> LockContext(Ctx->ContextMtx);
+    for (auto Dev : Ctx->getDevices()) {
+      Devices.push_back(Dev);
+    }
+  }
 
-  return ChipDevices;
+  return Devices;
 }
 
-size_t CHIPBackend::getNumDevices() { return ChipDevices.size(); }
+size_t CHIPBackend::getNumDevices() {
+  int NumDevices = 0;
+  for (auto Ctx : ChipContexts) {
+    NumDevices += Ctx->getDevices().size();
+  }
+  return NumDevices;
+}
 std::vector<std::string *> &CHIPBackend::getModulesStr() { return ModulesStr_; }
 
 void CHIPBackend::addContext(CHIPContext *ChipContext) {
   ChipContexts.push_back(ChipContext);
-}
-void CHIPBackend::addQueue(CHIPQueue *ChipQueue) {
-  std::lock_guard<std::mutex> LockBackend(BackendMtx);
-  auto QueueFound = std::find(ChipQueues.begin(), ChipQueues.end(), ChipQueue);
-  if (QueueFound == ChipQueues.end()) {
-    ChipQueues.push_back(ChipQueue);
-  } else {
-    CHIPERR_LOG_AND_THROW("Tried to add a queue to the backend which was "
-                          "already present in the backend queue list",
-                          hipErrorTbd);
-  }
-
-  logDebug("CHIPQueue {} added to the queue vector for backend {} ",
-           (void *)ChipQueue, (void *)this);
-
-  return;
-}
-void CHIPBackend::addDevice(CHIPDevice *ChipDevice) {
-  logDebug("CHIPDevice.add_device() {}", ChipDevice->getName());
-  std::lock_guard<std::mutex> LockBackend(BackendMtx);
-  ChipDevices.push_back(ChipDevice);
-
-  logDebug("CHIPDevice {} added to the queue vector for backend {} ",
-           (void *)ChipDevice, (void *)this);
 }
 
 void CHIPBackend::registerModuleStr(std::string *ModuleStr) {
@@ -1344,7 +1300,7 @@ void CHIPBackend::registerDeviceVariable(std::string *ModuleStr,
 CHIPDevice *CHIPBackend::findDeviceMatchingProps(const hipDeviceProp_t *Props) {
   CHIPDevice *MatchedDevice = nullptr;
   int MaxMatchedCount = 0;
-  for (auto &Dev : ChipDevices) {
+  for (auto &Dev : getDevices()) {
     hipDeviceProp_t CurrentProp = {};
     Dev->copyDeviceProperties(&CurrentProp);
     int ValidPropCount = 0;
@@ -1444,22 +1400,22 @@ CHIPDevice *CHIPBackend::findDeviceMatchingProps(const hipDeviceProp_t *Props) {
 }
 
 CHIPQueue *CHIPBackend::findQueue(CHIPQueue *ChipQueue) {
-  std::lock_guard<std::mutex> LockBackend(BackendMtx);
+  auto Dev = Backend->getActiveDevice();
 
   if (ChipQueue == hipStreamPerThread) {
-    return Backend->getActiveDevice()->getPerThreadDefaultQueue();
+    return Dev->getPerThreadDefaultQueue();
   } else if (ChipQueue == hipStreamLegacy) {
-    return Backend->getActiveDevice()->getLegacyDefaultQueue();
+    return Dev->getLegacyDefaultQueue();
   } else if (ChipQueue == nullptr) {
-    return Backend->getActiveDevice()->getDefaultQueue();
+    return Dev->getDefaultQueue();
   }
 
   // Safety Check to make sure that the requested queue is registereted
-  std::vector<CHIPQueue *> AllQueues = Backend->getActiveDevice()->getQueues();
-  AllQueues.push_back(Backend->getActiveDevice()->getLegacyDefaultQueue());
+  std::vector<CHIPQueue *> AllQueues = Dev->getQueues();
+  AllQueues.push_back(Dev->getLegacyDefaultQueue());
 
-  if (Backend->getActiveDevice()->PerThreadStreamUsed)
-    AllQueues.push_back(Backend->getActiveDevice()->getPerThreadDefaultQueue());
+  if (Dev->PerThreadStreamUsed)
+    AllQueues.push_back(Dev->getPerThreadDefaultQueue());
 
   auto QueueFound = std::find(AllQueues.begin(), AllQueues.end(), ChipQueue);
   if (QueueFound == AllQueues.end())

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -962,6 +962,7 @@ CHIPContext::~CHIPContext() {
 
 void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
   auto Dev = Backend->getActiveDevice();
+  std::lock_guard<std::mutex> LockContext(ContextMtx);
   std::lock_guard<std::mutex> LockDevice(Dev->DeviceMtx);
   auto DefaultQueue = Dev->getDefaultQueue();
 #ifdef HIP_API_PER_THREAD_DEFAULT_STREAM
@@ -976,7 +977,6 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
   if (TargetQueue == DefaultQueue)
     return;
 #endif
-  std::lock_guard<std::mutex> LockContext(ContextMtx);
   std::vector<CHIPQueue *> QueuesToSyncWith;
 
   // The per-thread default stream is not a non-blocking stream and will

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1138,6 +1138,7 @@ protected:
 public:
   hipDeviceProp_t getDeviceProps() { return HipDeviceProps_; }
   bool PerThreadStreamUsed = false;
+  std::mutex DeviceVarMtx;
   std::mutex DeviceMtx;
 
   std::unique_ptr<CHIPQueue> LegacyDefaultQueue;
@@ -1634,8 +1635,6 @@ public:
 
   std::stack<CHIPExecItem *> ChipExecStack;
   std::vector<CHIPContext *> ChipContexts;
-  std::vector<CHIPQueue *> ChipQueues;
-  std::vector<CHIPDevice *> ChipDevices;
 
   /**
    * @brief User defined compiler options to pass to the JIT compiler
@@ -1723,13 +1722,6 @@ public:
   virtual void uninitialize();
 
   /**
-   * @brief Get the Queues object
-   *
-   * @return std::vector<CHIPQueue*>&
-   */
-  std::vector<CHIPQueue *> &getQueues();
-
-  /**
    * @brief Get the Active Context object. Returns the context of the active
    * queue.
    *
@@ -1751,7 +1743,7 @@ public:
    */
   void setActiveDevice(CHIPDevice *ChipDevice);
 
-  std::vector<CHIPDevice *> &getDevices();
+  std::vector<CHIPDevice *> getDevices();
   /**
    * @brief Get the Num Devices object
    *
@@ -1770,18 +1762,7 @@ public:
    * @param ctx_in
    */
   void addContext(CHIPContext *ChipContext);
-  /**
-   * @brief Add a queue to this backend.
-   *
-   * @param q_in
-   */
-  void addQueue(CHIPQueue *ChipQueue);
-  /**
-   * @brief  Add a device to this backend.
-   *
-   * @param dev_in
-   */
-  void addDevice(CHIPDevice *ChipDevice);
+
   /**
    * @brief
    *

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -783,8 +783,9 @@ hipError_t hipDeviceSynchronize(void) {
   CHIPInitialize();
 
   // prevents queues from being destryed while iterating
-  std::lock_guard<std::mutex> LockBackend(Backend->BackendMtx);
-  for (auto Q : Backend->getActiveDevice()->getQueues()) {
+  auto Dev = Backend->getActiveDevice();
+  std::lock_guard<std::mutex> LockDevice(Dev->DeviceMtx);
+  for (auto Q : Dev->getQueues()) {
     std::lock_guard<std::mutex> LockQueue(Q->QueueMtx);
     Q->finish();
   }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1349,7 +1349,7 @@ void CHIPBackendLevel0::uninitialize() {
    * must reach the refcount of 0. At this point, all queues should have their
    * LastEvent as nullptr but in case a user didn't sync and destroy a
    * user-created stream, such stream might not have its LastEvent as nullptr.
-   * 
+   *
    * To be safe, we iterate through all the queues and update their last event.
    */
   logTrace("CHIPBackend::uninitialize(): Setting the LastEvent to null for all "
@@ -1366,8 +1366,11 @@ void CHIPBackendLevel0::uninitialize() {
       }
       int NumQueues = Dev->getQueues().size();
       if (NumQueues) {
-        logWarn("Not all user created streams have been destoyed... Queues remaining: ", NumQueues);
-        logWarn("Make sure to call hipStreamDestroy() for all queues that have been created via hipStreamCreate()");
+        logWarn("Not all user created streams have been destoyed... Queues "
+                "remaining: ",
+                NumQueues);
+        logWarn("Make sure to call hipStreamDestroy() for all queues that have "
+                "been created via hipStreamCreate()");
       }
       for (auto Q : Dev->getQueues()) {
         // std::lock_guard LockQueue(Q->QueueMtx);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1213,7 +1213,6 @@ void CHIPQueueLevel0::finish() {
   pthread_yield();
   // Using zeCommandQueueSynchronize() for ensuring the device printf
   // buffers get flushed.
-  std::lock_guard<std::mutex> LockQueues(Backend->QueueCreateDestroyMtx);
   zeCommandQueueSynchronize(ZeCmdQ_, UINT64_MAX);
 
   return;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1303,7 +1303,6 @@ void CHIPBackendOpenCL::initializeImpl(std::string CHIPPlatformStr,
 
     // Add device to context & backend
     ChipContext->addDevice(ChipDev);
-    Backend->addDevice(ChipDev);
   }
   logTrace("OpenCL Context Initialized.");
 };
@@ -1326,7 +1325,6 @@ void CHIPBackendOpenCL::initializeFromNative(const uintptr_t *NativeHandles,
 
   // Add device to context & backend
   ChipContext->addDevice(ChipDev);
-  addDevice(ChipDev);
 
   setActiveDevice(ChipDev);
 


### PR DESCRIPTION
Remove device and queue vectors from `CHIPBackend` this was originally done for convenience of not having to iterate through contexts->devices->queues to get all the queue handles but this proved to complicate things more than necessary. 

* A few other multithreading related fixes
* Clarify `CHIPBackendLevel0::uninitialize()`