### PR TITLE
Fix missing backend uninitialization causes occational crashes

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1184,7 +1184,11 @@ std::string CHIPBackend::getJitFlags() {
   return Flags;
 }
 
-CHIPBackend::CHIPBackend() { logDebug("CHIPBackend Base Constructor"); };
+CHIPBackend::CHIPBackend() {
+  logDebug("CHIPBackend Base Constructor");
+  Logger = spdlog::default_logger();
+};
+
 CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
   while (!ChipExecStack.empty())

--- a/src/CHIPDriver.cc
+++ b/src/CHIPDriver.cc
@@ -35,6 +35,7 @@
 #include "CHIPDriver.hh"
 
 #include <string>
+#include <memory>
 
 #include "backend/backends.hh"
 
@@ -42,8 +43,22 @@ std::once_flag Initialized;
 std::once_flag EnvInitialized;
 std::once_flag Uninitialized;
 bool UsingDefaultBackend;
-CHIPBackend *Backend;
+CHIPBackend *Backend = nullptr;
 std::string CHIPPlatformStr, CHIPDeviceTypeStr, CHIPDeviceStr, CHIPBackendType;
+
+// Uninitializes the backend when the application exits.
+void __attribute__((destructor)) uninitializeBackend() {
+  // Generally, __hipUnregisterFatBinary would uninitialize the
+  // backend when it finishes unregistration of all modules. However,
+  // there won't be hip(Un)registerFatBinary() calls if the HIP
+  // program does not have embedded kernels. This makes sure we
+  // uninitialize the backend at exit.
+  if (Backend && Backend->getNumRegisteredModules() == 0) {
+    CHIPUninitialize();
+    delete Backend;
+    Backend = nullptr;
+  }
+}
 
 std::string read_env_var(std::string EnvVar, bool Lower = true) {
   logDebug("Reading {} from env", EnvVar);
@@ -88,7 +103,7 @@ void CHIPReadEnvVars() {
 }
 
 static void createBackendObject() {
-
+  assert(Backend == nullptr);
   const std::string ChipBe = CHIPBackendType;
 
   if (!ChipBe.compare("opencl")) {
@@ -110,7 +125,6 @@ static void createBackendObject() {
                           hipErrorInitializationError);
 #endif
   } else if (!ChipBe.compare("default")) {
-    Backend = nullptr;
 #ifdef HAVE_LEVEL0
     if (!Backend) {
       logDebug("CHIPBE=default... trying Level0 Backend");
@@ -149,8 +163,11 @@ extern void CHIPInitialize() {
 
 void CHIPUninitializeCallOnce() {
   logDebug("Uninitializing CHIP...");
-  Backend->uninitialize();
-  delete Backend;
+  if (Backend) {
+    Backend->uninitialize();
+    delete Backend;
+    Backend = nullptr;
+  }
 }
 
 extern void CHIPUninitialize() {
@@ -170,6 +187,7 @@ extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
     logDebug("uninitializing existing Backend object.");
     Backend->uninitialize();
     delete Backend;
+    Backend = nullptr;
   }
 
   createBackendObject();
@@ -177,6 +195,7 @@ extern hipError_t CHIPReinitialize(const uintptr_t *NativeHandles,
   int RequiredHandles = Backend->ReqNumHandles();
   if (RequiredHandles != NumHandles) {
     delete Backend;
+    Backend = nullptr;
     CHIPERR_LOG_AND_THROW("Invalid number of native handles",
                           hipErrorInitializationError);
   }

--- a/tests/hiprtc/TestHiprtcCPPKernels.cc
+++ b/tests/hiprtc/TestHiprtcCPPKernels.cc
@@ -153,6 +153,6 @@ int main() {
   checkUnaryKernel(Module, LoweredCastF2I0, 1.23f, 1);
 
   HIPRTC_CHECK(hiprtcDestroyProgram(&Prog));
-
+  HIP_CHECK(hipModuleUnload(Module));
   return 0;
 }


### PR DESCRIPTION
Missing backend uninitialization at program exit is known to cause crashes occasionally due to monitor threads being still in-flight and making references to destructed objects.

* Fix HIP programs without embedded modules (occasionally) crash at program exit.

* Make sure spdlog is destructed after the CHIP backend is uninitialized.

Fixes #228. 