### PR TITLE
Fix for #262

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -1897,7 +1897,7 @@ hipError_t hipMalloc3DArray(hipArray **Array,
   void **Ptr = &Array[0]->data;
 
   size_t AllocSize =
-      Width * std::max<size_t>(Height, 1) * getChannelByteSize(*Desc);
+      Width * std::max<size_t>(Height, 1) * Depth * getChannelByteSize(*Desc);
 
   void *RetVal = Backend->getActiveContext()->allocate(
       AllocSize, hipMemoryType::hipMemoryTypeDevice);


### PR DESCRIPTION
During array allocation CHIP-SPV runtime was not including depth hence the memory overflow.