### PR TITLE
Add missing ihipEvent_t type 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ add_subdirectory(bitcode)
 
 add_subdirectory(tests/cuda)
 add_subdirectory(tests/hiprtc)
+add_subdirectory(tests/compiler)
 add_subdirectory(./samples samples)
 set(HIPCC_BUILD_PATH "${CMAKE_BINARY_DIR}/bin")
 add_subdirectory(HIPCC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,7 +562,7 @@ install(FILES ${PROJECT_BINARY_DIR}/share/.hipInfo_install
 
 # Copy over includes for hipcc to work in the build dir
 file(COPY ${CMAKE_SOURCE_DIR}/include DESTINATION ${CMAKE_BINARY_DIR})
-file(COPY ${CMAKE_SOURCE_DIR}/HIP/include/hip DESTINATION ${INCLUDE_INSTALL_DIR})
+file(COPY ${CMAKE_SOURCE_DIR}/HIP/include/hip DESTINATION ${CMAKE_BINARY_DIR}/include)
 
 # Copy hipconfig, hipvars, etc to bin
 install(FILES ${CMAKE_BINARY_DIR}/bin/hipcc.bin DESTINATION ${BIN_INSTALL_DIR} RENAME hipcc PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ)

--- a/include/hip/hip_to_chip.hh
+++ b/include/hip/hip_to_chip.hh
@@ -32,8 +32,9 @@ class CHIPBackend;
 class CHIPEvent;
 class CHIPQueue;
 class CHIPTexture;
+
 /* implementation details */
-typedef CHIPEvent *hipEvent_t;
+typedef struct ihipEvent_t *hipEvent_t;
 typedef CHIPKernel *hipFunction_t;
 typedef CHIPModule *hipModule_t;
 typedef CHIPQueue *hipStream_t;

--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -28,36 +28,7 @@
 #include <stdint.h>
 
 #include <hip/driver_types.h>
-
-#if defined(__clang__) && defined(__HIP__)
-
-#define __host__ __attribute__((host))
-#define __device__ __attribute__((device))
-#define __global__ __attribute__((global))
-#define __shared__ __attribute__((shared))
-#define __constant__ __attribute__((constant))
-
-#define __noinline__ __attribute__((noinline))
-#define __forceinline__ inline __attribute__((always_inline))
-
-#define __launch_bounds__(...)
-#else
-
-/**
- * Function and kernel markers
- */
-#define __host__
-#define __device__
-#define __global__
-#define __shared__
-#define __constant__
-
-#define __noinline__
-#define __forceinline__ inline
-
-#define __launch_bounds__(...)
-
-#endif
+#include <hip/spirv_hip_host_defines.h>
 
 #if defined(__clang__) && defined(__HIP__)
 #include "spirv_hip_devicelib.hh"

--- a/include/hip/spirv_hip_host_defines.h
+++ b/include/hip/spirv_hip_host_defines.h
@@ -25,6 +25,13 @@
 
 #if defined(__clang__) && defined(__HIP__)
 
+// Undefine the __noinline__ coming from the CHIP-SPV's fork of the
+// HIP-Common as it is shadowing the keyword in Clang 15+. The
+// upstream HIP has removed the __noinline__ definition and also the
+// other HIP function attributes and let the implementers define them.
+// TODO: We should probably remove the HIP attributes in the HIP-Common fork.
+#undef __noinline__
+
 #if !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
 #define __host__ __attribute__((host))
 #define __device__ __attribute__((device))
@@ -33,7 +40,15 @@
 #define __constant__ __attribute__((constant))
 #endif  // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
 
-#define __noinline__ __attribute__((noinline))
+#if !defined(__has_feature) || !__has_feature(cuda_noinline_keyword)
+// In Clang 15+ __noinline__ is a keyword which works within
+// __attribute__(()) and standalone. For the earlier Clang versions (and
+// compilers which don't recognize the keyword) we have to substitute
+// it to empty string so C++ code using __attribute__((__noinline__))
+// compiles.
+#define __noinline__
+#endif
+
 #define __forceinline__ inline __attribute__((always_inline))
 
 #else

--- a/include/hip/spirv_hip_host_defines.h
+++ b/include/hip/spirv_hip_host_defines.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021-22 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef HIP_SPIRV_HIP_HOST_DEFINES_H
+#define HIP_SPIRV_HIP_HOST_DEFINES_H
+
+#if defined(__clang__) && defined(__HIP__)
+
+#if !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
+#define __host__ __attribute__((host))
+#define __device__ __attribute__((device))
+#define __global__ __attribute__((global))
+#define __shared__ __attribute__((shared))
+#define __constant__ __attribute__((constant))
+#endif  // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
+
+#define __noinline__ __attribute__((noinline))
+#define __forceinline__ inline __attribute__((always_inline))
+
+#else
+
+// Non-HCC compiler
+/**
+ * Function and kernel markers
+ */
+#define __host__
+#define __device__
+#define __global__
+#define __shared__
+#define __constant__
+
+#define __noinline__
+#define __forceinline__ inline
+
+#endif // defined(__clang__) && defined(__HIP__)
+
+#define __launch_bounds__(...)
+
+#endif

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -536,7 +536,7 @@ class CHIPQueue;
 class CHIPContext;
 class CHIPDevice;
 
-class CHIPEvent {
+class CHIPEvent : public ihipEvent_t {
 protected:
   bool UserEvent_ = false;
   bool TrackCalled_ = false;

--- a/src/common.hh
+++ b/src/common.hh
@@ -31,6 +31,10 @@
 #include <string>
 #include <memory>
 
+/// The implementation of ihipEvent_t. The CHIPEvent class inherits this so
+/// ihipEvent_t pointers may carry CHIPEvent instances.
+struct ihipEvent_t {};
+
 enum class OCLType : unsigned {
   POD,
   Pointer,

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -1,0 +1,36 @@
+#=============================================================================
+#  Copyright (c) 2022 CHIP-SPV developers
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+#
+#=============================================================================
+
+# add_hipcc_test(<main-source>
+#  [HIPCC_OPTIONS <option>...])
+function(add_hipcc_test MAIN_SOURCE)
+  set(multiValueArgs HIPCC_OPTIONS)
+  cmake_parse_arguments(TEST "" "" "${multiValueArgs}" ${ARGN} )
+  get_filename_component(MAIN_NAME ${MAIN_SOURCE} NAME_WLE)
+  add_test(NAME "hipcc-${MAIN_NAME}"
+    COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin
+    ${TEST_HIPCC_OPTIONS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/${MAIN_SOURCE} -o /dev/null)
+endfunction()
+
+add_hipcc_test(TestNoinlineAttrs.hip HIPCC_OPTIONS -c)

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -34,3 +34,4 @@ function(add_hipcc_test MAIN_SOURCE)
 endfunction()
 
 add_hipcc_test(TestNoinlineAttrs.hip HIPCC_OPTIONS -c)
+add_hipcc_test(TestAPIObjects.hip HIPCC_OPTIONS -c)

--- a/tests/compiler/TestAPIObjects.hip
+++ b/tests/compiler/TestAPIObjects.hip
@@ -1,0 +1,11 @@
+#include <hip/hip_runtime.h>
+#include <vector>
+
+// A reduced case from PyTorch.
+struct ihipEvent_t; // Forward declaration
+std::vector<ihipEvent_t *> testIHipEvent() {
+  ihipEvent_t *Event;
+  hipEventCreate(&Event);
+  std::vector<ihipEvent_t *> Result = {Event};
+  return Result;
+}

--- a/tests/compiler/TestNoinlineAttrs.hip
+++ b/tests/compiler/TestNoinlineAttrs.hip
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <hip/hip_runtime.h>
+__attribute__((__noinline__)) void foo(int *x) { *x += 1; }
+__noinline__ void bar(int *x) { *x -= 1; }

--- a/tests/hiprtc/TestCommon.hh
+++ b/tests/hiprtc/TestCommon.hh
@@ -22,6 +22,9 @@
 
 #include <hip/hiprtc.h>
 #include <hip/hip_runtime_api.h>
+// TODO: Remove this header when it is included by the
+//       hip_runtime_api.h header.
+#include <hip/spirv_hip_host_defines.h>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Found out that a HIP client is using `ihipEvent_t` type, which is missing in the CHIP-SPV, so add one.

NOTE: This patch is stacked on #264. 
