### PR TITLE
Make hip_runtime.h compilable by regular C++ compilers

### DIFF
--- a/include/hip/spirv_hip_fp16.h
+++ b/include/hip/spirv_hip_fp16.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include <type_traits>
 #include <utility>
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(__HIP__)
 
 #if defined(__HIP_DEVICE_COMPILE__)
 typedef _Float16 _hip_f16;

--- a/include/hip/spirv_hip_vector_types.h
+++ b/include/hip/spirv_hip_vector_types.h
@@ -28,7 +28,12 @@ THE SOFTWARE.
 #ifndef HIP_INCLUDE_HIP_HCC_DETAIL_HIP_VECTOR_TYPES_H
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_VECTOR_TYPES_H
 
-#define __NATIVE_VECTOR__(n, ...) __attribute__((ext_vector_type(n)))
+#if defined(__cplusplus) && defined(__has_attribute) &&                        \
+    __has_attribute(ext_vector_type)
+#define __NATIVE_VECTOR__(n, T) T __attribute__((ext_vector_type(n)))
+#else
+#define __NATIVE_VECTOR__(n, T) T[n]
+#endif
 
 #if defined(__cplusplus)
 #include <type_traits>
@@ -45,7 +50,7 @@ struct HIP_vector_base<T, 1> {
   //
   // When the SPIR-V backend lands on the LLVM we may reintroduce one
   // element vectors.
-  typedef T Native_vec_ /* __NATIVE_VECTOR__(1, T)*/;
+  using Native_vec_ = T /*__NATIVE_VECTOR__(1, T) */;
 
   union {
     Native_vec_ data;
@@ -58,7 +63,7 @@ struct HIP_vector_base<T, 1> {
 
 template <typename T>
 struct HIP_vector_base<T, 2> {
-  typedef T Native_vec_ __NATIVE_VECTOR__(2, T);
+  using Native_vec_ = __NATIVE_VECTOR__(2, T);
 
   union {
     Native_vec_ data;
@@ -72,7 +77,7 @@ struct HIP_vector_base<T, 2> {
 
 template <typename T>
 struct HIP_vector_base<T, 3> {
-  typedef T Native_vec_ __NATIVE_VECTOR__(3, T);
+  using Native_vec_ = __NATIVE_VECTOR__(3, T);
 
   union {
     Native_vec_ data;
@@ -87,7 +92,7 @@ struct HIP_vector_base<T, 3> {
 
 template <typename T>
 struct HIP_vector_base<T, 4> {
-  typedef T Native_vec_ __NATIVE_VECTOR__(4, T);
+  using Native_vec_ = __NATIVE_VECTOR__(4, T);
 
   union {
     Native_vec_ data;
@@ -455,48 +460,24 @@ inline HIP_vector_type<T, n> operator<<(
 
 #else  // __cplusplus
 
-#define __MAKE_VECTOR_TYPE__(CUDA_name, T)             \
-  typedef T CUDA_name##1_impl __NATIVE_VECTOR__(1, T); \
-  typedef T CUDA_name##2_impl __NATIVE_VECTOR__(2, T); \
-  typedef T CUDA_name##3_impl __NATIVE_VECTOR__(3, T); \
-  typedef T CUDA_name##4_impl __NATIVE_VECTOR__(4, T); \
-  typedef struct {                                     \
-    union {                                            \
-      CUDA_name##1_impl data;                          \
-      struct {                                         \
-        T x;                                           \
-      };                                               \
-    };                                                 \
-  } CUDA_name##1;                                      \
-  typedef struct {                                     \
-    union {                                            \
-      CUDA_name##2_impl data;                          \
-      struct {                                         \
-        T x;                                           \
-        T y;                                           \
-      };                                               \
-    };                                                 \
-  } CUDA_name##2;                                      \
-  typedef struct {                                     \
-    union {                                            \
-      CUDA_name##3_impl data;                          \
-      struct {                                         \
-        T x;                                           \
-        T y;                                           \
-        T z;                                           \
-      };                                               \
-    };                                                 \
-  } CUDA_name##3;                                      \
-  typedef struct {                                     \
-    union {                                            \
-      CUDA_name##4_impl data;                          \
-      struct {                                         \
-        T x;                                           \
-        T y;                                           \
-        T z;                                           \
-        T w;                                           \
-      };                                               \
-    };                                                 \
+#define __MAKE_VECTOR_TYPE__(CUDA_name, T)                                     \
+  typedef struct {                                                             \
+    T x;                                                                       \
+  } CUDA_name##1;                                                              \
+  typedef struct {                                                             \
+    T x;                                                                       \
+    T y;                                                                       \
+  } CUDA_name##2;                                                              \
+  typedef struct {                                                             \
+    T x;                                                                       \
+    T y;                                                                       \
+    T z;                                                                       \
+  } CUDA_name##3;                                                              \
+  typedef struct {                                                             \
+    T x;                                                                       \
+    T y;                                                                       \
+    T z;                                                                       \
+    T w;                                                                       \
   } CUDA_name##4;
 
 /*

--- a/include/hip/spirv_math_fwd.h
+++ b/include/hip/spirv_math_fwd.h
@@ -22,12 +22,11 @@ THE SOFTWARE.
 
 #pragma once
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+#if defined(__clang__) && defined(__HIP__)
+
+#include "spirv_hip_vector_types.h"
 
 // DOT FUNCTIONS
-#if __HIP_CLANG_ONLY__
 __device__ __attribute__((const)) int __ockl_sdot2(
     HIP_vector_base<short, 2>::Native_vec_,
     HIP_vector_base<short, 2>::Native_vec_, int, bool);
@@ -49,8 +48,6 @@ __device__ __attribute__((const)) int __ockl_sdot8(int, int, int, bool);
 __device__ __attribute__((const)) unsigned int __ockl_udot8(unsigned int,
                                                             unsigned int,
                                                             unsigned int, bool);
-#endif
-
 #if !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
 // BEGIN FLOAT
 __device__ __attribute__((const)) float __ocml_acos_f32(float);
@@ -314,8 +311,5 @@ __device__ __attribute__((const)) double __llvm_amdgcn_rsq_f64(double) __asm(
 // END INTRINSICS
 // END DOUBLE
 
-#endif  // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
-
-#if defined(__cplusplus)
-}  // extern "C"
-#endif
+#endif // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
+#endif // __HIP_CLANG_ONLY__

--- a/include/hip/spirv_texture_functions.h
+++ b/include/hip/spirv_texture_functions.h
@@ -26,6 +26,9 @@ THE SOFTWARE.
 #ifdef __cplusplus
 #include "spirv_hip_vector_types.h"
 #include "spirv_hip_texture_types.h"
+#endif
+
+#if defined(__clang__) && defined(__HIP__)
 
 #define __TEXTURE_FUNCTIONS_DECL__ static inline __device__
 
@@ -328,5 +331,5 @@ DEF_TEXREF(int4, float4);
 DEF_TEXREF(uint4, float4);
 DEF_TEXREF(float4, float4);
 
-#endif // cplusplus
-#endif // include guard
+#endif // defined(__clang__) && defined(__HIP__)
+#endif

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -22,16 +22,33 @@
 #=============================================================================
 
 # add_hipcc_test(<main-source>
+#  [TEST_NAME <name>]
 #  [HIPCC_OPTIONS <option>...])
 function(add_hipcc_test MAIN_SOURCE)
+  set(oneValueArgs TEST_NAME)
   set(multiValueArgs HIPCC_OPTIONS)
-  cmake_parse_arguments(TEST "" "" "${multiValueArgs}" ${ARGN} )
-  get_filename_component(MAIN_NAME ${MAIN_SOURCE} NAME_WLE)
-  add_test(NAME "hipcc-${MAIN_NAME}"
+  cmake_parse_arguments(TESTOPT
+    "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(TESTOPT_TEST_NAME)
+    set(TEST_NAME ${TESTOPT_TEST_NAME})
+  else()
+    get_filename_component(MAIN_NAME ${MAIN_SOURCE} NAME_WLE)
+    set(TEST_NAME "hipcc-${MAIN_NAME}")
+  endif()
+
+  add_test(NAME "${TEST_NAME}"
     COMMAND ${CMAKE_BINARY_DIR}/bin/hipcc.bin
-    ${TEST_HIPCC_OPTIONS}
+    ${TESTOPT_HIPCC_OPTIONS}
     ${CMAKE_CURRENT_SOURCE_DIR}/${MAIN_SOURCE} -o /dev/null)
 endfunction()
 
 add_hipcc_test(TestNoinlineAttrs.hip HIPCC_OPTIONS -c)
 add_hipcc_test(TestAPIObjects.hip HIPCC_OPTIONS -c)
+
+# Test the hip_runtime.h header compiles in C++ mode. If the test
+# passes - the header probably is compilable by other regular C++
+# compilers too (e.g. g++).
+add_hipcc_test(TestHipRuntimeHeaderInclude.cpp
+  TEST_NAME hip-runtime-header-cpp-mode
+  HIPCC_OPTIONS -x c++ -fsyntax-only)

--- a/tests/compiler/TestHipRuntimeHeaderInclude.cpp
+++ b/tests/compiler/TestHipRuntimeHeaderInclude.cpp
@@ -1,0 +1,7 @@
+#include <hip/hip_runtime.h>
+
+// Vector implementations use Clang recognized attribute - should
+// still compile in other compilers.
+int4 test_make_vector(int x, int y, int z, int w) {
+  return make_int4(x, y, z, w);
+}


### PR DESCRIPTION
Found out that a HIP client includes the `hip_runtime.h` header while compiling the sources in C++ mode by a non-HIP compiler (e.g. g++ in my case). ROCm's HIP supports this but CHIP-SPV does not currently.

Adjust the headers included by the `hip_runtime.h` header so that they are compilable by regular C++ compilers - including the `hipcc` with `-x c++` option.