### PR TITLE
hipGetNativeHandle should call CHIPInitialize()

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -3467,6 +3467,7 @@ hipError_t hipGetDeviceFlags(unsigned int *Flags) {
 int hipGetBackendNativeHandles(uintptr_t Stream, uintptr_t *NativeHandles,
                                int *NumHandles) {
   CHIP_TRY
+  CHIPInitialize();
   logDebug("hipGetBackendNativeHandles");
   CHIPQueue *HipStream = Backend->findQueue((hipStream_t)Stream);
   RETURN(HipStream->getBackendHandles(NativeHandles, NumHandles));


### PR DESCRIPTION
hipGetNativeHandle assumes that CHIP is already initialized but there can be cases where hipGetNativeHandle is the first call hence CHIPInitialize() need to be called.