### PR TITLE
Add hipProfiler{Start,Stop} without an implementation

### DIFF
--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -4170,4 +4170,18 @@ const char *hipGetBackendName() {
   return CHIPGetBackendName();
 }
 
+hipError_t hipProfilerStart() {
+  CHIP_TRY
+  CHIPInitialize();
+  UNIMPLEMENTED(hipErrorNotSupported);
+  CHIP_CATCH
+}
+
+hipError_t hipProfilerStop() {
+  CHIP_TRY
+  CHIPInitialize();
+  UNIMPLEMENTED(hipErrorNotSupported);
+  CHIP_CATCH
+}
+
 #endif


### PR DESCRIPTION
... just for fixing undefined reference linker error.