### PR TITLE
Fixes SYCL bindings build for oneAPI 2023.0.0

### DIFF
--- a/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop/onemkl_gemm_wrapper/onemkl_gemm_wrapper.cpp
@@ -21,9 +21,15 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <oneapi/mkl.hpp>
+#if INTEL_MKL_VERSION >= 20230000
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+#else
+#include <CL/sycl/backend/level_zero.hpp>
+#endif
+
 #include "../../../include/ze_api.h"
-#include "CL/sycl/backend/level_zero.hpp"
-#include "oneapi/mkl.hpp"
+
 #include <stdlib.h>
 #include <vector>
 #include <string.h>

--- a/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
+++ b/samples/hip_sycl_interop_no_buffers/onemkl_gemm_wrapper_no_buffers/onemkl_gemm_wrapper.cpp
@@ -21,9 +21,15 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <oneapi/mkl.hpp>
+#if INTEL_MKL_VERSION >= 20230000
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+#else
+#include <CL/sycl/backend/level_zero.hpp>
+#endif
+
 #include "../../../include/ze_api.h"
-#include "CL/sycl/backend/level_zero.hpp"
-#include "oneapi/mkl.hpp"
+
 #include <stdlib.h>
 #include <vector>
 #include <string.h>

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -25,8 +25,8 @@
 #include <stdint.h>
 #include "../../../include/ze_api.h"
 #include <CL/sycl.hpp>
-#include <CL/sycl/stl.hpp>
-#include "CL/sycl/backend/level_zero.hpp"
+#include <sycl/stl.hpp>
+#include "sycl/ext/oneapi/backend/level_zero.hpp"
 
 #include "sycl_chip_interop.h"
 
@@ -102,10 +102,10 @@ int main() {
     // Initialize CHIP-SPV Level-Zero Backend via providing native runtime
     // information
     uintptr_t Args[] = {
-        (uintptr_t)Plt.template get_native<sycl::backend::level_zero>(),
-        (uintptr_t)Devs[0].template get_native<sycl::backend::level_zero>(),
-        (uintptr_t)Ctx.template get_native<sycl::backend::level_zero>(),
-        (uintptr_t)myQueue.template get_native<sycl::backend::level_zero>()};
+        (uintptr_t)get_native<sycl::backend::level_zero>(Plt),
+        (uintptr_t)get_native<sycl::backend::level_zero>(Devs[0]),
+        (uintptr_t)get_native<sycl::backend::level_zero>(Ctx),
+        (uintptr_t)get_native<sycl::backend::level_zero>(myQueue)};
     hipInitFromNativeHandles(Args, 4);
 
 #ifdef USM

--- a/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
+++ b/samples/sycl_hip_interop/sycl_hip_interop_driver/sycl_chip_interop.cpp
@@ -22,11 +22,18 @@
  */
 
 
+#include <oneapi/mkl.hpp>
+#if INTEL_MKL_VERSION >= 20230000
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+#include <sycl/stl.hpp>
+#else
+#include <CL/sycl/backend/level_zero.hpp>
+#include <CL/sycl/stl.hpp>
+#endif
+
 #include <stdint.h>
 #include "../../../include/ze_api.h"
 #include <CL/sycl.hpp>
-#include <sycl/stl.hpp>
-#include "sycl/ext/oneapi/backend/level_zero.hpp"
 
 #include "sycl_chip_interop.h"
 


### PR DESCRIPTION
Likely doesn't preserve backwards compatibility.

The interop test runs are still skipped for me for some reason:
```
The following tests did not run:
	 65 - sycl_chip_interop (Skipped)
	 66 - sycl_chip_interop_usm (Skipped)

```