### PR TITLE
Add regression test for an ihipEvent_t use case

### DIFF
--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -34,3 +34,4 @@ function(add_hipcc_test MAIN_SOURCE)
 endfunction()
 
 add_hipcc_test(TestNoinlineAttrs.hip HIPCC_OPTIONS -c)
+add_hipcc_test(TestAPIObjects.hip HIPCC_OPTIONS -c)

--- a/tests/compiler/TestAPIObjects.hip
+++ b/tests/compiler/TestAPIObjects.hip
@@ -1,0 +1,13 @@
+// Test an user defined pointer derived from ihipEvent_t found in a
+// hipified CUDA application.
+#include <hip/hip_runtime.h>
+#include <vector>
+
+struct ihipEvent_t; // Forward declaration
+
+std::vector<ihipEvent_t *> testIHipEvent() {
+  ihipEvent_t *Event;
+  hipEventCreate(&Event);
+  std::vector<ihipEvent_t *> Result = {Event};
+  return Result;
+}


### PR DESCRIPTION
Ensure the case featured in this patch does not regress.