### PR TITLE
hipCtx API

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -844,9 +844,7 @@ hipSharedMemConfig CHIPDevice::getSharedMemConfig() {
   UNIMPLEMENTED(hipSharedMemBankSizeDefault);
 }
 
-void CHIPDevice::removeContext(CHIPContext *CHIPContext) {
-  
-}
+void CHIPDevice::removeContext(CHIPContext *CHIPContext) {}
 
 bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
   /**
@@ -1267,7 +1265,8 @@ void CHIPBackend::initialize(std::string PlatformStr, std::string DeviceTypeStr,
   }
 
   PrimaryContext = ChipContexts[0];
-  setActiveContext(ChipContexts[0]); // pushes primary context to context stack for thread 0
+  setActiveContext(
+      ChipContexts[0]); // pushes primary context to context stack for thread 0
 }
 
 void CHIPBackend::setActiveContext(CHIPContext *ChipContext) {
@@ -1279,8 +1278,8 @@ void CHIPBackend::setActiveDevice(CHIPDevice *ChipDevice) {
 }
 
 CHIPContext *CHIPBackend::getActiveContext() {
-  //assert(ChipCtxStack.size() > 0 && "Context stack is empty");
-  if(ChipCtxStack.size() == 0) {
+  // assert(ChipCtxStack.size() > 0 && "Context stack is empty");
+  if (ChipCtxStack.size() == 0) {
     logDebug("Context stack is empty for thread {}", pthread_self());
     ChipCtxStack.push(PrimaryContext);
   }

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -844,6 +844,10 @@ hipSharedMemConfig CHIPDevice::getSharedMemConfig() {
   UNIMPLEMENTED(hipSharedMemBankSizeDefault);
 }
 
+void CHIPDevice::removeContext(CHIPContext *CHIPContext) {
+  
+}
+
 bool CHIPDevice::removeQueue(CHIPQueue *ChipQueue) {
   /**
    * If commands are still executing on the specified stream, some may complete
@@ -1002,12 +1006,8 @@ CHIPModule *CHIPDevice::getOrCreateModule(const SPVModule &SrcMod) {
 //*************************************************************************************
 CHIPContext::CHIPContext() {}
 CHIPContext::~CHIPContext() {
-  LOCK(ContextMtx); // CHIPContext::ChipDevices_
   logDebug("~CHIPContext() {}", (void *)this);
-  while (ChipDevices_.size() > 0) {
-    delete ChipDevices_[0];
-    ChipDevices_.erase(ChipDevices_.begin());
-  }
+  delete ChipDevice_;
 }
 
 void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
@@ -1068,31 +1068,9 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
   SyncQueuesEvent->track();
 }
 
-void CHIPContext::addDevice(CHIPDevice *ChipDevice) {
-  LOCK(ContextMtx); // CHIPContext::ChipDevices
-  logDebug("{} CHIPContext::addDevice() {}", (void *)this, (void *)ChipDevice);
-  ChipDevices_.push_back(ChipDevice);
-}
-
-void CHIPContext::removeDevice(CHIPDevice *ChipDevice) {
-  LOCK(ContextMtx); // CHIPContext::ChipDevices
-  logDebug("{} CHIPContext.removeDevice() {}", (void *)this,
-           (void *)ChipDevice);
-
-  auto DeviceFound =
-      std::find(ChipDevices_.begin(), ChipDevices_.end(), ChipDevice);
-  if (DeviceFound != ChipDevices_.end()) {
-    ChipDevices_.erase(DeviceFound);
-  } else {
-    std::abort();
-  }
-  return;
-}
-
-std::vector<CHIPDevice *> &CHIPContext::getDevices() {
-  if (ChipDevices_.size() == 0)
-    logWarn("CHIPContext.get_devices() was called but chip_devices is empty");
-  return ChipDevices_;
+CHIPDevice *CHIPContext::getDevice() {
+  assert(this->ChipDevice_);
+  return ChipDevice_;
 }
 
 void *CHIPContext::allocate(size_t Size, hipMemoryType MemType) {
@@ -1107,6 +1085,7 @@ void *CHIPContext::allocate(size_t Size, size_t Alignment,
 void *CHIPContext::allocate(size_t Size, size_t Alignment,
                             hipMemoryType MemType, CHIPHostAllocFlags Flags) {
   void *AllocatedPtr, *HostPtr = nullptr;
+  // TOOD hipCtx - use the device with which this context is associated
   CHIPDevice *ChipDev = Backend->getActiveDevice();
   if (!Flags.isDefault()) {
     if (Flags.isMapped())
@@ -1156,19 +1135,15 @@ void CHIPContext::reset() {
   // Free all allocations in this context
   for (auto &Ptr : AllocatedPtrs_)
     freeImpl(Ptr);
+
+  auto Dev = getDevice();
   // Free all the memory reservations on each device
-  for (auto &Dev : ChipDevices_)
-    Dev->AllocationTracker->releaseMemReservation(
-        Dev->AllocationTracker->TotalMemSize);
+  Dev->AllocationTracker->releaseMemReservation(
+      Dev->AllocationTracker->TotalMemSize);
   AllocatedPtrs_.clear();
 
-  for (auto *Dev : ChipDevices_)
-    Dev->reset();
-
-  // TODO Is all the state reset?
+  getDevice()->reset();
 }
-
-CHIPContext *CHIPContext::retain() { UNIMPLEMENTED(nullptr); }
 
 hipError_t CHIPContext::free(void *Ptr) {
   CHIPDevice *ChipDev = Backend->getActiveDevice();
@@ -1219,19 +1194,7 @@ CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
 
   Events.clear();
-  // for (auto &Ctx : ChipContexts) {
-  //   delete Ctx;
-  // }
-
   for (auto &Ctx : ChipContexts) {
-    for (auto &Dev : Ctx->getDevices()) {
-      for (auto &Q : Dev->getQueuesNoLock()) {
-        Dev->removeQueue(Q);
-        delete Q;
-      }
-      Ctx->removeDevice(Dev);
-      delete Dev;
-    }
     Backend->removeContext(Ctx);
     delete Ctx;
   }
@@ -1303,53 +1266,42 @@ void CHIPBackend::initialize(std::string PlatformStr, std::string DeviceTypeStr,
     CHIPERR_LOG_AND_THROW(Msg, hipErrorInitializationError);
   }
 
-  setActiveDevice(ChipContexts[0]->getDevices()[0]);
+  PrimaryContext = ChipContexts[0];
+  setActiveContext(ChipContexts[0]); // pushes primary context to context stack for thread 0
+}
+
+void CHIPBackend::setActiveContext(CHIPContext *ChipContext) {
+  ChipCtxStack.push(ChipContext);
 }
 
 void CHIPBackend::setActiveDevice(CHIPDevice *ChipDevice) {
-  LOCK(Backend->SetActiveMtx); // CHIPDevice::ActiveDev_
-
-  ActiveDev_ = ChipDevice;
-  ActiveCtx_ = ChipDevice->getContext();
+  Backend->setActiveContext(ChipDevice->getContext());
 }
+
 CHIPContext *CHIPBackend::getActiveContext() {
-  LOCK(Backend->SetActiveMtx); // CHIPBackend::ActiveDev_
-  if (ActiveCtx_ == nullptr) {
-    std::string Msg = "Active context is null";
-    CHIPERR_LOG_AND_THROW(Msg, hipErrorUnknown);
+  //assert(ChipCtxStack.size() > 0 && "Context stack is empty");
+  if(ChipCtxStack.size() == 0) {
+    logDebug("Context stack is empty for thread {}", pthread_self());
+    ChipCtxStack.push(PrimaryContext);
   }
-  return ActiveCtx_;
+  return ChipCtxStack.top();
 };
 
 CHIPDevice *CHIPBackend::getActiveDevice() {
-  LOCK(Backend->SetActiveMtx); // CHIPBackend::ActiveDev_
-  if (ActiveDev_ == nullptr) {
-    CHIPERR_LOG_AND_THROW(
-        "CHIPBackend.getActiveDevice() was called but active_ctx is null",
-        hipErrorUnknown);
-  }
-  return ActiveDev_;
+  CHIPContext *Ctx = getActiveContext();
+  return Ctx->getDevice();
 };
 
 std::vector<CHIPDevice *> CHIPBackend::getDevices() {
   std::vector<CHIPDevice *> Devices;
   for (auto Ctx : ChipContexts) {
-    LOCK(Ctx->ContextMtx); // CHIPContext::ChipDevices_ via getDevices()
-    for (auto Dev : Ctx->getDevices()) {
-      Devices.push_back(Dev);
-    }
+    Devices.push_back(Ctx->getDevice());
   }
 
   return Devices;
 }
 
-size_t CHIPBackend::getNumDevices() {
-  int NumDevices = 0;
-  for (auto Ctx : ChipContexts) {
-    NumDevices += Ctx->getDevices().size();
-  }
-  return NumDevices;
-}
+size_t CHIPBackend::getNumDevices() { return ChipContexts.size(); }
 
 void CHIPBackend::removeContext(CHIPContext *ChipContext) {
   auto ContextFound =

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -49,7 +49,7 @@
 
 #define DEFAULT_QUEUE_PRIORITY 1
 
-inline CHIPContext* PrimaryContext = nullptr;
+inline CHIPContext *PrimaryContext = nullptr;
 inline thread_local std::stack<CHIPExecItem *> ChipExecStack;
 inline thread_local std::stack<CHIPContext *> ChipCtxStack;
 
@@ -1162,7 +1162,6 @@ protected:
   bool PerThreadStreamUsed_ = false;
 
 public:
-
   hipDeviceProp_t getDeviceProps() { return HipDeviceProps_; }
   std::mutex DeviceVarMtx;
   std::mutex DeviceMtx;
@@ -1513,9 +1512,7 @@ public:
 
   virtual void syncQueues(CHIPQueue *TargetQueue);
 
-  void setDevice(CHIPDevice *Device) {
-    ChipDevice_ = Device;
-  }
+  void setDevice(CHIPDevice *Device) { ChipDevice_ = Device; }
 
   /**
    * @brief Get this context's CHIPDevices
@@ -1634,9 +1631,7 @@ public:
    *
    * @return CHIPContext*
    */
-  void retain() {
-    ++RefCount_;
-  }
+  void retain() { ++RefCount_; }
 
   void release() {
     --RefCount_;

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -51,6 +51,7 @@
 #include "macros.hh"
 #include "Utils.hh"
 #include "SPVRegister.hh"
+#include "hipCtx.hh"
 
 #define SVM_ALIGNMENT 128 // TODO Pass as CMAKE Define?
 
@@ -92,66 +93,6 @@ hipError_t hipExtStreamCreateWithCUMask(hipStream_t *stream,
 }
 hipError_t hipExtStreamGetCUMask(hipStream_t stream, uint32_t cuMaskSize,
                                  uint32_t *cuMask) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxCreate(hipCtx_t *ctx, unsigned int flags, hipDevice_t device) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxDestroy(hipCtx_t ctx) { UNIMPLEMENTED(hipErrorNotSupported); }
-
-hipError_t hipCtxPopCurrent(hipCtx_t *ctx) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxPushCurrent(hipCtx_t ctx) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxSetCurrent(hipCtx_t ctx) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxGetCurrent(hipCtx_t *ctx) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxGetDevice(hipDevice_t *device) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxGetApiVersion(hipCtx_t ctx, int *apiVersion) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxGetCacheConfig(hipFuncCache_t *cacheConfig) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxSetCacheConfig(hipFuncCache_t cacheConfig) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxSetSharedMemConfig(hipSharedMemConfig config) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxGetSharedMemConfig(hipSharedMemConfig *pConfig) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxSynchronize(void) { UNIMPLEMENTED(hipErrorNotSupported); }
-
-hipError_t hipCtxGetFlags(unsigned int *flags) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxEnablePeerAccess(hipCtx_t peerCtx, unsigned int flags) {
-  UNIMPLEMENTED(hipErrorNotSupported);
-}
-
-hipError_t hipCtxDisablePeerAccess(hipCtx_t peerCtx) {
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
@@ -2180,70 +2121,6 @@ hipError_t hipMemGetAddressRange(hipDeviceptr_t *Base, size_t *Size,
   *Size = AllocInfo->Size;
 
   RETURN(hipSuccess);
-  CHIP_CATCH
-}
-
-hipError_t hipDevicePrimaryCtxGetState(hipDevice_t Device, unsigned int *Flags,
-                                       int *Active) {
-  CHIP_TRY
-  CHIPInitialize();
-  NULLCHECK(Flags, Active);
-  ERROR_CHECK_DEVNUM(Device);
-
-  CHIPContext *CurrCtx = Backend->getActiveContext();
-
-  // Currently device only has 1 context
-  CHIPContext *PrimaryCtx = (Backend->getDevices()[Device])->getContext();
-
-  *Active = (PrimaryCtx == CurrCtx) ? 1 : 0;
-  *Flags = PrimaryCtx->getFlags();
-  RETURN(hipSuccess);
-
-  CHIP_CATCH
-}
-
-hipError_t hipDevicePrimaryCtxRelease(hipDevice_t Device) {
-  CHIP_TRY
-  CHIPInitialize();
-  ERROR_CHECK_DEVNUM(Device);
-  UNIMPLEMENTED(hipErrorNotSupported);
-  RETURN(hipSuccess);
-  CHIP_CATCH
-}
-
-hipError_t hipDevicePrimaryCtxRetain(hipCtx_t *Context, hipDevice_t Device) {
-  CHIP_TRY
-  CHIPInitialize();
-  NULLCHECK(Context);
-  ERROR_CHECK_DEVNUM(Device);
-
-  UNIMPLEMENTED(hipErrorNotSupported);
-  *Context = (Backend->getDevices()[Device])->getContext()->retain();
-  RETURN(hipSuccess);
-
-  CHIP_CATCH
-}
-
-hipError_t hipDevicePrimaryCtxReset(hipDevice_t Device) {
-  CHIP_TRY
-  CHIPInitialize();
-  ERROR_CHECK_DEVNUM(Device);
-
-  (Backend->getDevices()[Device])->getContext()->reset();
-
-  RETURN(hipSuccess);
-  CHIP_CATCH
-}
-
-hipError_t hipDevicePrimaryCtxSetFlags(hipDevice_t Device, unsigned int Flags) {
-  CHIP_TRY
-  CHIPInitialize();
-  ERROR_CHECK_DEVNUM(Device);
-
-  UNIMPLEMENTED(hipErrorNotSupported);
-  (Backend->getDevices()[Device])->getContext()->setFlags(Flags);
-  RETURN(hipSuccess);
-
   CHIP_CATCH
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -450,14 +450,14 @@ bool CHIPEventLevel0::updateFinishStatus(bool ThrowErrorIfNotReady) {
 
 uint32_t CHIPEventLevel0::getValidTimestampBits() {
   CHIPContextLevel0 *ChipCtxLz = (CHIPContextLevel0 *)ChipContext_;
-  CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevices()[0];
+  CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevice();
   auto Props = ChipDevLz->getDeviceProps();
   return Props->timestampValidBits;
 }
 
 unsigned long CHIPEventLevel0::getFinishTime() {
   CHIPContextLevel0 *ChipCtxLz = (CHIPContextLevel0 *)ChipContext_;
-  CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevices()[0];
+  CHIPDeviceLevel0 *ChipDevLz = (CHIPDeviceLevel0 *)ChipCtxLz->getDevice();
   auto Props = ChipDevLz->getDeviceProps();
 
   uint64_t TimerResolution = Props->timerResolution;
@@ -1578,7 +1578,7 @@ void CHIPBackendLevel0::initializeImpl(std::string CHIPPlatformStr,
   CHIPERR_CHECK_LOG_AND_THROW(Status, ZE_RESULT_SUCCESS, hipErrorTbd);
   if (AnyDeviceType || ZeDeviceType == DeviceProperties.type) {
     CHIPDeviceLevel0 *ChipL0Dev = CHIPDeviceLevel0::create(Dev, ChipL0Ctx, 0);
-    ChipL0Ctx->addDevice(ChipL0Dev);
+    ChipL0Ctx->setDevice(ChipL0Dev);
   }
 
   StaleEventMonitor =
@@ -1601,7 +1601,7 @@ void CHIPBackendLevel0::initializeFromNative(const uintptr_t *NativeHandles,
   addContext(ChipCtx);
 
   CHIPDeviceLevel0 *ChipDev = CHIPDeviceLevel0::create(Dev, ChipCtx, 0);
-  ChipCtx->addDevice(ChipDev);
+  ChipCtx->setDevice(ChipDev);
 
   LOCK(Backend->BackendMtx); // CHIPBackendLevel0::StaleEventMonitor
   ChipDev->LegacyDefaultQueue = ChipDev->createQueue(NativeHandles, NumHandles);

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -454,6 +454,7 @@ class CHIPDeviceLevel0 : public CHIPDevice {
   ze_command_queue_desc_t getQueueDesc_(int Priority);
 
 public:
+  virtual CHIPContextLevel0* createContext() override {}
   bool copyQueueIsAvailable() { return CopyQueueAvailable_; }
   ze_command_list_desc_t getCommandListComputeDesc() {
     return CommandListComputeDesc_;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -454,7 +454,7 @@ class CHIPDeviceLevel0 : public CHIPDevice {
   ze_command_queue_desc_t getQueueDesc_(int Priority);
 
 public:
-  virtual CHIPContextLevel0* createContext() override {}
+  virtual CHIPContextLevel0 *createContext() override {}
   bool copyQueueIsAvailable() { return CopyQueueAvailable_; }
   ze_command_list_desc_t getCommandListComputeDesc() {
     return CommandListComputeDesc_;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -790,11 +790,9 @@ CHIPKernelOpenCL::CHIPKernelOpenCL(const cl::Kernel &&ClKernel,
 
 bool CHIPContextOpenCL::allDevicesSupportFineGrainSVM() {
   bool allFineGrainSVM = true;
-  for (auto &D : ChipDevices_) {
-    if (!static_cast<CHIPDeviceOpenCL *>(D)->supportsFineGrainSVM()) {
-      allFineGrainSVM = false;
-      break;
-    }
+  if (!static_cast<CHIPDeviceOpenCL *>(this->ChipDevice_)
+           ->supportsFineGrainSVM()) {
+    allFineGrainSVM = false;
   }
   return allFineGrainSVM;
 }
@@ -1405,7 +1403,7 @@ void CHIPBackendOpenCL::initializeImpl(std::string CHIPPlatformStr,
   CHIPDeviceOpenCL *ChipDev = CHIPDeviceOpenCL::create(clDev, ChipContext, 0);
 
   // Add device to context & backend
-  ChipContext->addDevice(ChipDev);
+  ChipContext->setDevice(ChipDev);
   logTrace("OpenCL Context Initialized.");
 };
 
@@ -1426,7 +1424,7 @@ void CHIPBackendOpenCL::initializeFromNative(const uintptr_t *NativeHandles,
   logTrace("CHIPDeviceOpenCL {}", ChipDev->ClDevice->getInfo<CL_DEVICE_NAME>());
 
   // Add device to context & backend
-  ChipContext->addDevice(ChipDev);
+  ChipContext->setDevice(ChipDev);
 
   setActiveDevice(ChipDev);
 

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -165,7 +165,7 @@ private:
                    int Idx);
 
 public:
-  virtual CHIPContextOpenCL* createContext() override {}
+  virtual CHIPContextOpenCL *createContext() override {}
 
   static CHIPDeviceOpenCL *create(cl::Device *ClDevice,
                                   CHIPContextOpenCL *ChipContext, int Idx);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -165,6 +165,8 @@ private:
                    int Idx);
 
 public:
+  virtual CHIPContextOpenCL* createContext() override {}
+
   static CHIPDeviceOpenCL *create(cl::Device *ClDevice,
                                   CHIPContextOpenCL *ChipContext, int Idx);
   cl::Device *ClDevice;

--- a/src/hipCtx.hh
+++ b/src/hipCtx.hh
@@ -130,22 +130,27 @@ hipError_t hipCtxGetDevice(hipDevice_t *device) {
 }
 
 hipError_t hipCtxGetApiVersion(hipCtx_t ctx, int *apiVersion) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
 hipError_t hipCtxGetCacheConfig(hipFuncCache_t *cacheConfig) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
 hipError_t hipCtxSetCacheConfig(hipFuncCache_t cacheConfig) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
 hipError_t hipCtxSetSharedMemConfig(hipSharedMemConfig config) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
 hipError_t hipCtxGetSharedMemConfig(hipSharedMemConfig *pConfig) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
@@ -161,15 +166,18 @@ hipError_t hipCtxSynchronize(void) {
 }
 
 hipError_t hipCtxGetFlags(unsigned int *flags) {
+  // Unimplemented in hipamd
   UNIMPLEMENTED(hipErrorNotSupported);
 }
 
 hipError_t hipCtxEnablePeerAccess(hipCtx_t peerCtx, unsigned int flags) {
-  UNIMPLEMENTED(hipErrorNotSupported);
+  // hipamd implementation
+  RETURN(hipSuccess);
 }
 
 hipError_t hipCtxDisablePeerAccess(hipCtx_t peerCtx) {
-  UNIMPLEMENTED(hipErrorNotSupported);
+  // hipamd implementation
+  RETURN(hipSuccess);
 }
 
 hipError_t hipDevicePrimaryCtxRelease(hipDevice_t Device) {

--- a/src/hipCtx.hh
+++ b/src/hipCtx.hh
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2021-23 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file CHIPBindings.hh
+ * @author Paulius Velesko (pvelesko@pglc.io)
+ * @brief Implementations of the HIP API functions using the CHIP interface
+ * providing basic functionality such hipMemcpy, host and device function
+ * registration, hipLaunchByPtr, etc.
+ * These functions operate on base CHIP class pointers allowing for backend
+ * selection at runtime and backend-specific implementations are done by
+ * inheriting from base CHIP classes and overriding virtual member functions.
+ * @version 0.1
+ * @date 2023-02-02
+ *
+ * @copyright Copyright (c) 2021
+ *
+ */
+#ifndef CHIP_HIPCTX_H
+#define CHIP_HIPCTX_H
+
+#include "hip/hip_runtime_api.h"
+
+hipError_t hipCtxCreate(hipCtx_t *ctx, unsigned int flags, hipDevice_t device) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  ERROR_CHECK_DEVNUM(device);
+
+  auto ChipCtx = Backend->getDevices()[device]->getContext();
+  ChipCtx->retain();
+  *ctx = ChipCtx;
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxDestroy(hipCtx_t ctx) {
+  CHIP_TRY
+  CHIPInitialize();
+  auto ChipCtx = static_cast<CHIPContext *>(ctx);
+  if (ChipCtx == nullptr) {
+    RETURN(hipErrorInvalidValue);
+  }
+
+  // Need to remove the ctx of calling thread if its the top one
+  if (!ChipCtxStack.empty() && ChipCtxStack.top() == ChipCtx) {
+    ChipCtxStack.pop();
+  }
+
+  // decrease refcount and delete if 0
+  ChipCtx->release();
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxPopCurrent(hipCtx_t *ctx) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  if (ChipCtxStack.empty()) {
+    *ctx = nullptr;
+  } else {
+    *ctx = ChipCtxStack.top();
+    ChipCtxStack.pop();
+  }
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxPushCurrent(hipCtx_t ctx) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  auto ChipCtx = static_cast<CHIPContext *>(ctx);
+  if (!ChipCtx) {
+    if (!ChipCtxStack.empty()) {
+      ChipCtxStack.pop();
+    }
+  } else {
+    ChipCtxStack.push(ChipCtx);
+  }
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxSetCurrent(hipCtx_t ctx) {
+  CHIP_TRY
+  CHIPInitialize();
+  Backend->setActiveContext(static_cast<CHIPContext *>(ctx));
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxGetCurrent(hipCtx_t *ctx) {
+  CHIP_TRY
+  CHIPInitialize();
+  *ctx = Backend->getActiveContext();
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxGetDevice(hipDevice_t *device) {
+  CHIP_TRY
+  CHIPInitialize();
+  *device = Backend->getActiveContext()->getDevice()->getDeviceId();
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxGetApiVersion(hipCtx_t ctx, int *apiVersion) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxGetCacheConfig(hipFuncCache_t *cacheConfig) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxSetCacheConfig(hipFuncCache_t cacheConfig) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxSetSharedMemConfig(hipSharedMemConfig config) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxGetSharedMemConfig(hipSharedMemConfig *pConfig) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxSynchronize(void) {
+  CHIP_TRY
+  CHIPInitialize();
+  auto Dev = Backend->getActiveDevice();
+  for (auto &Q : Dev->getQueues()) {
+    Q->finish();
+  }
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipCtxGetFlags(unsigned int *flags) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxEnablePeerAccess(hipCtx_t peerCtx, unsigned int flags) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipCtxDisablePeerAccess(hipCtx_t peerCtx) {
+  UNIMPLEMENTED(hipErrorNotSupported);
+}
+
+hipError_t hipDevicePrimaryCtxRelease(hipDevice_t Device) {
+
+  // hipamd implementation
+  // HIP_INIT_API(hipDevicePrimaryCtxRelease, dev);
+
+  // if (static_cast<unsigned int>(dev) >= g_devices.size()) {
+  //   HIP_RETURN(hipErrorInvalidDevice);
+  // }
+
+  // HIP_RETURN(hipSuccess);
+
+
+  CHIP_TRY
+  CHIPInitialize();
+
+  ERROR_CHECK_DEVNUM(Device);
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipDevicePrimaryCtxRetain(hipCtx_t *Context, hipDevice_t Device) {
+  // hipamd implementation
+  // HIP_INIT_API(hipDevicePrimaryCtxRetain, pctx, dev);
+
+  // if (static_cast<unsigned int>(dev) >= g_devices.size()) {
+  //   HIP_RETURN(hipErrorInvalidDevice);
+  // }
+  // if (pctx == nullptr) {
+  //   HIP_RETURN(hipErrorInvalidValue);
+  // }
+
+  // *pctx = reinterpret_cast<hipCtx_t>(g_devices[dev]);
+
+  // HIP_RETURN(hipSuccess);
+
+  CHIP_TRY
+  CHIPInitialize();
+
+  NULLCHECK(Context);
+  ERROR_CHECK_DEVNUM(Device);
+
+  *Context = Backend->getDevices()[Device]->getContext();
+  RETURN(hipSuccess);
+
+  CHIP_CATCH
+}
+
+hipError_t hipDevicePrimaryCtxReset(hipDevice_t Device) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  ERROR_CHECK_DEVNUM(Device);
+
+  Backend->getDevices()[Device]->getContext()->reset();
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+hipError_t hipDevicePrimaryCtxSetFlags(hipDevice_t Device, unsigned int Flags) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  if (static_cast<unsigned int>(Device) >= Backend->getDevices().size()) {
+    RETURN(hipErrorInvalidDevice);
+  } else {
+    RETURN(hipErrorContextAlreadyInUse);
+  }
+
+  CHIP_CATCH
+}
+
+hipError_t hipDevicePrimaryCtxGetState(hipDevice_t Device, unsigned int *Flags,
+                                       int *Active) {
+  CHIP_TRY
+  CHIPInitialize();
+
+  if (static_cast<unsigned int>(Device) >= Backend->getDevices().size()) {
+    RETURN(hipErrorInvalidDevice);
+  }
+
+  if (Flags != nullptr) {
+    *Flags = 0;
+  }
+
+  if (Active != nullptr) {
+    auto ActiveDev = Backend->getActiveDevice();
+    auto TestDev = Backend->getDevices()[Device];
+    *Active = ActiveDev == TestDev;
+  }
+
+  RETURN(hipSuccess);
+  CHIP_CATCH
+}
+
+#endif // CHIP_HIPCTX_H

--- a/src/hipCtx.hh
+++ b/src/hipCtx.hh
@@ -183,7 +183,6 @@ hipError_t hipDevicePrimaryCtxRelease(hipDevice_t Device) {
 
   // HIP_RETURN(hipSuccess);
 
-
   CHIP_TRY
   CHIPInitialize();
 


### PR DESCRIPTION
Implemented based on HIPAMD. Most of it is unimplemented there as well. 
Main difference is that we now switch from having an active device to having an active context. 
This context is now `thread_local` so resolves some multithreaded tests relied on `hipSetDevice()`