### PR TITLE
Add a workaround for unsupported __float128 issue ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,21 +376,30 @@ else()
   set(HIP_LINK_DEVICELIB_INSTALL --hip-path=${CMAKE_INSTALL_PREFIX})
 endif()
 
+# Include a header for applying fixups before any user or system includes.
+set(HIP_FIXUPS_HEADER_BUILD
+  -include ${CMAKE_BINARY_DIR}/include/hip/spirv_fixups.h)
+set(HIP_FIXUPS_HEADER_INSTALL
+  -include ${CMAKE_INSTALL_PREFIX}/include/hip/spirv_fixups.h)
+
 # For use by hipcc
-execute_process(COMMAND ${LLVM_CONFIG} --host-target OUTPUT_VARIABLE HOST_ARCH)
+execute_process(COMMAND ${LLVM_CONFIG} --host-target
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE HOST_ARCH)
 set(HOST_ARCH "--target=${HOST_ARCH}")
 
 set(HIP_OFFLOAD_COMPILE_OPTIONS_INSTALL_
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
   ${HIP_LINK_DEVICELIB_INSTALL}
-  ${HOST_ARCH})
+  ${HOST_ARCH}
+  ${HIP_FIXUPS_HEADER_INSTALL})
 
 set(HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
   ${HIP_LINK_DEVICELIB_BUILD}
-  ${HOST_ARCH})
+  ${HOST_ARCH}
+  ${HIP_FIXUPS_HEADER_BUILD})
 
 # HIP applications need to link against libCHIP.so; add it to rpath
 list(APPEND HIP_OFFLOAD_LINK_OPTIONS_INSTALL_ "-L${LIB_INSTALL_DIR}" "-lCHIP")
@@ -430,7 +439,8 @@ target_compile_options(deviceInternal INTERFACE
   -x hip
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_BUILD})
+  ${HIP_LINK_DEVICELIB_BUILD}
+  ${HIP_FIXUPS_HEADER_BUILD})
 target_link_options(deviceInternal INTERFACE
   ${HIP_LINK_DEVICELIB_BUILD})
 target_link_libraries(deviceInternal INTERFACE CHIP)
@@ -440,7 +450,8 @@ target_compile_options(device INTERFACE
   -x hip
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_INSTALL})
+  ${HIP_LINK_DEVICELIB_INSTALL}
+  ${HIP_FIXUPS_HEADER_INSTALL})
 target_link_options(device INTERFACE
   ${HIP_LINK_DEVICELIB_INSTALL})
 target_link_libraries(device INTERFACE CHIP)

--- a/include/hip/spirv_fixups.h
+++ b/include/hip/spirv_fixups.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 CHIP-SPV developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// A header for applying fixups. To take effect, this header must be first to be
+// included before anything else (before any include in user code, before
+// all -include options).
+
+#ifndef SPIRV_COMPILER_FIXUPS_H
+#define SPIRV_COMPILER_FIXUPS_H
+
+// A workaround for device side compilation when using -std=gnu++##. Clang
+// incorrectly defines these macros which enable unsupported float128
+// code in some libraries (e.g. in libstdc++).
+//
+// AFAIK, these macros leak from the host target. Clang bundles target specific
+// macro defines for both the device and host target together and passes them to
+// both the host and device compilation pipelines. SPIR-V target does not define
+// the macros but x86_64 does.
+#ifdef __HIP_DEVICE_COMPILE__
+#undef __FLOAT128__
+#undef __SIZEOF_FLOAT128__
+#endif
+
+#endif // SPIRV_COMPILER_FIXUPS_H

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -52,3 +52,6 @@ add_hipcc_test(TestAPIObjects.hip HIPCC_OPTIONS -c)
 add_hipcc_test(TestHipRuntimeHeaderInclude.cpp
   TEST_NAME hip-runtime-header-cpp-mode
   HIPCC_OPTIONS -x c++ -fsyntax-only)
+
+add_hipcc_test(TestFloat128Macros.hip TEST_NAME TestFloat128gnupp14
+  HIPCC_OPTIONS -std=gnu++14 -fsyntax-only)

--- a/tests/compiler/TestFloat128Macros.hip
+++ b/tests/compiler/TestFloat128Macros.hip
@@ -1,0 +1,16 @@
+// SPIR-V target does not support __float128. Some libraries use them
+// when one of the following macros in the below are defined.
+
+#if defined(__HIP_DEVICE_COMPILE__)
+#  if defined(__FLOAT128__)
+#    error Falsely advertised __FLOAT128__ macro on the device side compilation.
+#  endif
+#  if defined(__SIZEOF_FLOAT128__)
+#    error Falsely advertised __SIZEOF_FLOAT128__ macro on the device side compilation.
+#  endif
+#endif
+
+// A library known to enable __float128 when __FLOAT128__ or
+// __SIZEOF_FLOAT128__ is defined and -std=gnu++<something> is set.
+// The device side compilation has known to fail in such cases.
+#include <sstream>


### PR DESCRIPTION
... which may appear with `-std=g++##` and some libstdc++ versions. Without it the device side compilation may fail with the following error message:

```
  /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/type_traits:436:39: error: __float128 is not supported on this target
    struct __is_floating_point_helper<__float128>
```

AFAIK, the clang incorrectly defines couple macros (`__FLOAT128__`, `__SIZEOF_FLOAT128`) for the device side compilation. It seems these macros leak from the host target. Clang bundles target macro defines for both the device and host target together and passes them to both the host and device compilation pipelines. The SPIR-V target does not define the macros as it does not support `__float128` but the host target may (in my case the x86_64 target defines them).

Also, as a byproduct, fixed `HOST_ARCH` variable from eating strings appearing after it by stripping whitespace in execute_process().