### PR TITLE
Revive RDC mode - part one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,21 +350,13 @@ target_include_directories(CHIP
 
 # =============================================================================
 # HIP OFFLOAD FLAGS
-set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ 
-  ${SPIRV_EMITTER_OPTS} ${DISABLE_OPAQUE_PTRS_OPT})
-
-# hipDeviceLink sample requires --offload=spirv64 flag at link time. Why?
-set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  --offload=spirv64
-
+set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_
+  --offload=spirv64 ${SPIRV_EMITTER_OPTS} ${DISABLE_OPAQUE_PTRS_OPT}
   # By default RocmInstallationDetector::AddHIPIncludeArgs in the
   # HIP-Clang inserts include wrapper headers which cause compile
   # errors when compiling HIP sources for SPIR-V target.  This flag
   # excludes the wrappers.
-  "-nohipwrapperinc")
-
-set(HIP_LINK_DEVICELIB_BUILD --hip-path=${CMAKE_BINARY_DIR})
-set(HIP_LINK_DEVICELIB_INSTALL --hip-path=${CMAKE_INSTALL_PREFIX})
+  -nohipwrapperinc)
 
 # Include a header for applying fixups before any user or system includes.
 set(HIP_FIXUPS_HEADER_BUILD
@@ -380,14 +372,14 @@ set(HOST_ARCH "--target=${HOST_ARCH}")
 set(HIP_OFFLOAD_COMPILE_OPTIONS_INSTALL_
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_INSTALL}
+  --hip-path=${CMAKE_INSTALL_PREFIX}
   ${HOST_ARCH}
   ${HIP_FIXUPS_HEADER_INSTALL})
 
 set(HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_
   ${HIP_ENABLE_SPIRV}
   ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_BUILD}
+  --hip-path=${CMAKE_BINARY_DIR}
   ${HOST_ARCH}
   ${HIP_FIXUPS_HEADER_BUILD})
 
@@ -426,24 +418,12 @@ message(STATUS "Generated HIP_OFFLOAD_LINK_OPTIONS: ${HIP_OFFLOAD_LINK_OPTIONS_I
 # TODO: Is there a better way to do this?
 add_library(deviceInternal INTERFACE)
 target_compile_options(deviceInternal INTERFACE
-  -x hip
-  ${HIP_ENABLE_SPIRV}
-  ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_BUILD}
-  ${HIP_FIXUPS_HEADER_BUILD})
-target_link_options(deviceInternal INTERFACE
-  ${HIP_LINK_DEVICELIB_BUILD})
+  -x hip ${HIP_OFFLOAD_COMPILE_OPTIONS_BUILD_})
 target_link_libraries(deviceInternal INTERFACE CHIP)
 
 add_library(device INTERFACE)
 target_compile_options(device INTERFACE
-  -x hip
-  ${HIP_ENABLE_SPIRV}
-  ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-  ${HIP_LINK_DEVICELIB_INSTALL}
-  ${HIP_FIXUPS_HEADER_INSTALL})
-target_link_options(device INTERFACE
-  ${HIP_LINK_DEVICELIB_INSTALL})
+  -x hip ${HIP_OFFLOAD_COMPILE_OPTIONS_INSTALL_})
 target_link_libraries(device INTERFACE CHIP)
 
 # same as device on CHIP-SPV but provides compatibility with AMD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,7 @@ add_to_config(_hipInfo_build
 add_to_config(_hipInfo_build
   HIP_OFFLOAD_LINK_OPTIONS "${HIP_OFFLOAD_LINK_OPTIONS_BUILD}")
 
-INSTALL(TARGETS CHIP host device
+INSTALL(TARGETS CHIP host device deviceRDC
   EXPORT hip-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,14 +223,9 @@ if(NOT CLANG_VERSION_LESS_15)
   set(DISABLE_OPAQUE_PTRS_OPT -Xclang -no-opaque-pointers)
 endif()
 
+set(SPIRV_EMITTER_OPTS "")
 if(LLVM_USE_INTERGRATED_SPIRV)
-  if(CLANG_VERSION_LESS_14)
-    message(FATAL_ERROR "-DLLVM_USE_INTERGRATED_SPIRV=On is not supported for LLVM 13 and less")
-  else()
-    set(SPIRV_EMITTER_OPTS "-fintegrated-objemitter")
-  endif()
-else()
-  set(SPIRV_EMITTER_OPTS "")
+  set(SPIRV_EMITTER_OPTS "-fintegrated-objemitter")
 endif()
 
 if(ENFORCE_QUEUE_SYNCHRONIZATION)
@@ -359,24 +354,17 @@ set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_
   ${SPIRV_EMITTER_OPTS} ${DISABLE_OPAQUE_PTRS_OPT})
 
 # hipDeviceLink sample requires --offload=spirv64 flag at link time. Why?
-if(NOT CLANG_VERSION_LESS_14)
-  set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
-    --offload=spirv64
+set(HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_ ${HIP_OFFLOAD_COMPILE_ONLY_OPTIONS_}
+  --offload=spirv64
 
-    # By default RocmInstallationDetector::AddHIPIncludeArgs in the
-    # HIP-Clang inserts include wrapper headers which cause compile
-    # errors when compiling HIP sources for SPIR-V target.  This flag
-    # excludes the wrappers.
-    "-nohipwrapperinc")
-endif()
+  # By default RocmInstallationDetector::AddHIPIncludeArgs in the
+  # HIP-Clang inserts include wrapper headers which cause compile
+  # errors when compiling HIP sources for SPIR-V target.  This flag
+  # excludes the wrappers.
+  "-nohipwrapperinc")
 
-if(CLANG_VERSION_LESS_14)
-  set(HIP_LINK_DEVICELIB_BUILD --hip-device-lib-path=${CMAKE_BINARY_DIR}/share --hip-device-lib=devicelib.bc --hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes)
-  set(HIP_LINK_DEVICELIB_INSTALL --hip-device-lib-path=${SHARE_INSTALL_DIR} --hip-device-lib=devicelib.bc --hip-llvm-pass-path=${LIB_INSTALL_DIR}/llvm)
-else()
-  set(HIP_LINK_DEVICELIB_BUILD --hip-path=${CMAKE_BINARY_DIR})
-  set(HIP_LINK_DEVICELIB_INSTALL --hip-path=${CMAKE_INSTALL_PREFIX})
-endif()
+set(HIP_LINK_DEVICELIB_BUILD --hip-path=${CMAKE_BINARY_DIR})
+set(HIP_LINK_DEVICELIB_INSTALL --hip-path=${CMAKE_INSTALL_PREFIX})
 
 # Include a header for applying fixups before any user or system includes.
 set(HIP_FIXUPS_HEADER_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,22 @@ set(HIP_FIXUPS_HEADER_BUILD
 set(HIP_FIXUPS_HEADER_INSTALL
   -include ${CMAKE_INSTALL_PREFIX}/include/hip/spirv_fixups.h)
 
+# Flags needed additionally for linking phase with -fgpu-rdc.
+set(HIP_RDC_SUPPLEMENT_LINK_FLAGS
+  # Infors clang the type of the code object inputs (which are different than
+  # in regular host C/C++ linking)
+  --hip-link
+  # Required for selecting HIPSPV toolchain instead of AMD's one in clang.
+  --offload=spirv64
+  # --hip-path is also needed but not included here (different option
+  # value is needed for build and installation).
+)
+
+if (NOT CLANG_VERSION_LESS_15)
+  list(APPEND HIP_RDC_SUPPLEMENT_LINK_FLAGS
+    -no-hip-rt) # Clang 15+: Prevents linking amdhip64 library.
+endif()
+
 # For use by hipcc
 execute_process(COMMAND ${LLVM_CONFIG} --host-target
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE HOST_ARCH)
@@ -429,6 +445,20 @@ target_link_libraries(device INTERFACE CHIP)
 # same as device on CHIP-SPV but provides compatibility with AMD
 add_library(host INTERFACE)
 target_link_libraries(host INTERFACE device)
+
+# Interface libraries for compiling HIP sources conveniently in RDC
+# (relocatable device code) mode.
+add_library(deviceRDCInternal INTERFACE)
+target_compile_options(deviceRDCInternal INTERFACE -fgpu-rdc)
+target_link_options(deviceRDCInternal INTERFACE
+  -fgpu-rdc ${HIP_RDC_SUPPLEMENT_LINK_FLAGS} --hip-path=${CMAKE_BINARY_DIR})
+target_link_libraries(deviceRDCInternal INTERFACE deviceInternal)
+
+add_library(deviceRDC INTERFACE)
+target_compile_options(deviceRDC INTERFACE -fgpu-rdc)
+target_link_options(deviceRDC INTERFACE
+  -fgpu-rdc ${HIP_RDC_SUPPLEMENT_LINK_FLAGS} --hip-path=${CMAKE_INSTALL_PREFIX})
+target_link_libraries(deviceRDC INTERFACE device)
 
 # HIP OFFLOAD FLAGS
 # =============================================================================

--- a/bitcode/CMakeLists.txt
+++ b/bitcode/CMakeLists.txt
@@ -27,9 +27,7 @@ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/BC")
 
 set(EXTRA_FLAGS)
 # Ugly fix for interactions between clang13+ and igc
-if(NOT CLANG_VERSION_LESS_13)
-  list(APPEND EXTRA_FLAGS "-cl-no-stdinc")
-endif()
+list(APPEND EXTRA_FLAGS "-cl-no-stdinc")
 
 # disable opaque pointers for LLVM 15 only
 if(NOT CLANG_VERSION_LESS_15 AND CLANG_VERSION_LESS_16)

--- a/bitcode/_cl_print_str.cl
+++ b/bitcode/_cl_print_str.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-22 CHIP-SPV developers
+ * Copyright (c) 2021-23 CHIP-SPV developers
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
-
-
-void __attribute__((used)) _cl_print_str(__generic const char *S) {
+static void __attribute__((used)) _cl_print_str(__generic const char *S) {
   unsigned Pos = 0;
   char C;
   while ((C = S[Pos]) != 0) {

--- a/cmake/LLVMCheck.cmake
+++ b/cmake/LLVMCheck.cmake
@@ -13,15 +13,9 @@ if((CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang") OR
   endif()
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0.0)
-    message(WARNING "Deprecated clang version '${CMAKE_CXX_COMPILER_VERSION}'. \
-            Support for Clang < 14.0 will be discontinued in the future.")
-    set(CLANG_VERSION_LESS_14 ON)
+    message(FATAL_ERROR
+      "Unsupported clang version '${CMAKE_CXX_COMPILER_VERSION}'")
   endif()
-
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-    set(CLANG_VERSION_LESS_13 ON)
-  endif()
-
 else()
   message(FATAL_ERROR "this project must be compiled with clang. CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
 endif()

--- a/docs/Using.md
+++ b/docs/Using.md
@@ -144,3 +144,10 @@ CHIP-SPV provides a `FindHIP.cmake` module so you can verify that HIP is install
 list(APPEND CMAKE_MODULES_PREFIX <CHIP-SPV install location>/cmake)
 find_package(HIP REQUIRED)
 ```
+
+### Compiling HIP sources in relocatable device mode (RDC) with CMake
+
+```bash
+addLibrary(yourLib <sources>)
+target_link_libraries(yourLib hip::deviceRDC)
+```

--- a/llvm_passes/HipAbort.cpp
+++ b/llvm_passes/HipAbort.cpp
@@ -8,7 +8,8 @@
 //===----------------------------------------------------------------------===//
 // LLVM IR pass to handle kernels with abort() calls.
 //
-// (c) 2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
+// (c) 2023 CHIP-SPV developers
+//     2022 Pekka Jääskeläinen / Parmance for Argonne National Laboratory
 //===----------------------------------------------------------------------===//
 //
 // HIP supports an abort() that is specified as
@@ -45,6 +46,8 @@
 
 #include "HipAbort.h"
 
+#include "../src/common.hh"
+
 #include <set>
 #include <iostream>
 
@@ -59,7 +62,7 @@ HipAbortPass::run(Module &Mod, ModuleAnalysisManager &AM) {
     // Mark modules that do not call abort by just the global flag variable.
     // Ugly, but should allow avoiding the kernel call to check the global
     // variable.
-    GlobalVariable *AbortFlag = Mod.getGlobalVariable(CHIPSPV_ABORT_FLAG_NAME);
+    GlobalVariable *AbortFlag = Mod.getGlobalVariable(ChipDeviceAbortFlagName);
     if (AbortFlag != nullptr) {
       AbortFlag->replaceAllUsesWith(
           Constant::getNullValue(AbortFlag->getType()));
@@ -74,7 +77,7 @@ HipAbortPass::run(Module &Mod, ModuleAnalysisManager &AM) {
   auto *Int32Ty = IntegerType::get(Ctx, 32);
   auto *Int32OneConst = ConstantInt::get(Int32Ty, 1);
 
-  GlobalVariable *AbortFlag = Mod.getGlobalVariable(CHIPSPV_ABORT_FLAG_NAME);
+  GlobalVariable *AbortFlag = Mod.getGlobalVariable(ChipDeviceAbortFlagName);
   assert(AbortFlag != nullptr);
 
   bool Modified = false;

--- a/llvm_passes/HipAbort.h
+++ b/llvm_passes/HipAbort.h
@@ -37,7 +37,4 @@ private:
   Module *M_;
 };
 
-#define CHIPSPV_ABORT_FLAG_NAME "__chipspv_abort_called"
-#define CHIPSPV_ABORT_FLAG_AS 1
-
 #endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -130,9 +130,7 @@ set(SAMPLES
     ccompat
     hipComplex
     hipHostMallocSample
-    # DISABLED for LLVM 15. Fails due to clang inserting -lamdhip64
-    # into the linking phase.
-    # hipDeviceLink # must be last in this list due to how hacky using multiple compilers with CMake is
+    hipDeviceLink
 )
 
 include(mkl_and_icpx)

--- a/samples/hipDeviceLink/CMakeLists.txt
+++ b/samples/hipDeviceLink/CMakeLists.txt
@@ -1,20 +1,14 @@
-# Test symbol access
+# Test compiling sources in RDC (relocatable device code) mode.
 add_chip_binary(
-	hipTestDeviceLink
-	hipDeviceLink.cpp
-	hipDeviceLinkRead.cpp
-	hipDeviceLinkWrite.cpp)
+  hipTestDeviceLink
+  hipDeviceLink.cpp
+  hipDeviceLinkRead.cpp
+  hipDeviceLinkWrite.cpp)
 
-target_compile_options(hipTestDeviceLink PRIVATE -fPIE -fgpu-rdc)
-target_link_libraries(hipTestDeviceLink CHIP deviceInternal)
-target_link_options(hipTestDeviceLink PRIVATE -fPIE -fgpu-rdc --hip-link)
-
-if(DEFINED LLVM_VERSION AND "${LLVM_VERSION}" VERSION_GREATER_EQUAL 14)
-  target_link_options(hipTestDeviceLink PRIVATE --offload=spirv64)
-endif()
+target_link_libraries(hipTestDeviceLink deviceRDCInternal)
 
 add_test(NAME hipTestDeviceLink
-	 	COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hipTestDeviceLink")
+  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hipTestDeviceLink")
 
 set_tests_properties(hipTestDeviceLink PROPERTIES
-	PASS_REGULAR_EXPRESSION PASSED)
+  PASS_REGULAR_EXPRESSION PASSED)

--- a/src/common.hh
+++ b/src/common.hh
@@ -84,4 +84,8 @@ constexpr char ChipNonSymbolResetKernelName[] = "__chip_reset_non_symbols";
 /// variables is '<ChipSpilledArgsVarPrefix><kernel-name>'
 constexpr char ChipSpilledArgsVarPrefix[] = "__chip_spilled_args_";
 
+/// The name of a global variable which indicates, when non-zero, if
+/// the abort() function was called by a kernel.
+constexpr char ChipDeviceAbortFlagName[] = "__chipspv_abort_called";
+
 #endif


### PR DESCRIPTION
* Add interface libraries for compiling HIP sources in relocatable device code (RDC) mode. Refer docs/Using.md for instructions.
* Re-enable samples/hipDeviceLink.
* Other adjustments to enable RDC mode.

Upcoming patch part two brings RDC support for hipcc.

Fixes #368.