### PR TITLE
OpenCL: Implement CUDA callbacks using OCL CBs and user event hacks

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -60,7 +60,6 @@ function(add_chip_test EXEC_NAME TEST_NAME TEST_PASS SOURCE)
              PASS_REGULAR_EXPRESSION "${TEST_PASS}"
              LABELS internal)
 
-
 endfunction()
 
 

--- a/samples/hipStreamSemantics/CMakeLists.txt
+++ b/samples/hipStreamSemantics/CMakeLists.txt
@@ -1,2 +1,6 @@
 
 add_chip_test(hipStreamSemantics hipStreamSemantics PASSED hipStreamSemantics.cc)
+set_tests_properties(hipStreamSemantics PROPERTIES
+  FAIL_REGULAR_EXPRESSION "Failed"
+  LABELS internal)
+

--- a/samples/hipStreamSemantics/hipStreamSemantics.cc
+++ b/samples/hipStreamSemantics/hipStreamSemantics.cc
@@ -117,7 +117,6 @@ bool TestStreamSemantics_2() {
   hipLaunchKernelGGL(addOne, 1, 1, 0, 0, dev_ptr);
   CHECK(hipGetLastError());
   CHECK(hipMemcpyAsync(host_ptr, dev_ptr, size, hipMemcpyDefault));
-  CHECK(hipStreamSynchronize(0));
   // printf("End of null stream task\n");fflush(stdout);
 
   bool testStatus = true;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -176,7 +176,7 @@ private:
                    int Idx);
 
 public:
-  virtual CHIPContextOpenCL *createContext() override {}
+  virtual CHIPContextOpenCL *createContext() override { return nullptr; }
 
   static CHIPDeviceOpenCL *create(cl::Device *ClDevice,
                                   CHIPContextOpenCL *ChipContext, int Idx);


### PR DESCRIPTION
hipStreamSemantics tests behavior that CUDA callbacks are asynchronously executed in the background whereas OpenCL might or might not execute them in the background. It could execute the callback in the user thread in case the command it is calling back from was finished before the CB was set.

Hack around this by creating a barrier which listens to a user event which is triggered only after setting the CB, forcing parallel execution of the callback. That is, in case the OpenCL platform supports parallel execution of callbacks the first place. I don't believe that's required to be the case, so this is down to implementation still.

Might Fix #421 and #418.


With this my local test envs now pass the expected tests once again.