### PR TITLE
MemMap Fixes

### DIFF
--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -13,6 +13,10 @@ list(APPEND DGPU_LEVEL0_FAILED_TESTS " ")
 list(APPEND CPU_POCL_FAILED_TESTS " ") 
 list(APPEND GPU_POCL_FAILED_TESTS " ")  # TODO
 
+list(APPEND FAILING_FOR_ALL "Unit_hipMultiThreadStreams1_AsyncSync") # Pinned Memory Missing mutex?
+list(APPEND FAILING_FOR_ALL "Unit_hipMultiThreadStreams1_AsyncAsync") # Pinned Memory Missing mutex?
+list(APPEND FAILING_FOR_ALL "Unit_hipMultiThreadStreams1_AsyncSame") # Pinned Memory Missing mutex?
+list(APPEND FAILING_FOR_ALL "Unit_hipMultiThreadStreams2") # Pinned Memory Missing mutex?
 list(APPEND FAILING_FOR_ALL "RecursiveGaussian") # Flaky
 list(APPEND FAILING_FOR_ALL "Unit_deviceFunctions_CompileTest___double2float_rd_float") # Unimplemented
 list(APPEND FAILING_FOR_ALL "Unit_deviceFunctions_CompileTest___double2float_rn_float") # Unimplemented
@@ -515,7 +519,6 @@ list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj2DCheckRGBAModes") # Fail
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj2DCheckSRGBAModes") # Failed
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") # Failed
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") # Failed
-list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipClassKernel_Value") # Subprocess aborted
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Basic") # Failed
 list(APPEND CPU_OPENCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Threaded") # Subprocess aborted
@@ -897,7 +900,6 @@ list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipStreamAddCallback_MultipleThreads"
 list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipStreamAddCallback_StrmSyncTiming") # Failed
 list(APPEND IGPU_OPENCL_FAILED_TESTS "cuda-simpleCallback") # SEGFAULT
 list(APPEND IGPU_OPENCL_FAILED_TESTS "stream") # SEGFAULT
-list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND IGPU_OPENCL_FAILED_TESTS "hipKernelLaunchIsNonBlocking") # Timeout
 list(APPEND IGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 list(APPEND IGPU_OPENCL_FAILED_TESTS "syncthreadsExitedThreads") # Timeout
@@ -1302,10 +1304,7 @@ list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj2DCheckSRGBAModes") # Fa
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMemFaultStackAllocation_Check") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") # Failed
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams1_AsyncSync") # Failed
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams1_AsyncAsync") # Subprocess aborted
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams1_AsyncSame") # Subprocess aborted
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
+
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Basic") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Threaded") # Subprocess aborted
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Basic") # Failed
@@ -1318,7 +1317,6 @@ list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipEvent") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMemsetFunctional_PartialSet_3D") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "hipMultiThreadAddCallback") # Subprocess aborted
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMemset3DAsync_ConcurrencyMthread") # Timeout
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND DGPU_OPENCL_FAILED_TESTS "hipKernelLaunchIsNonBlocking") # Timeout
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 list(APPEND DGPU_OPENCL_FAILED_TESTS "syncthreadsExitedThreads") # Timeout
@@ -1702,7 +1700,6 @@ list(APPEND DGPU_LEVEL0_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Threaded"
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "hipDynamicShared") # SEGFAULT
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "Unit_hipMemFaultStackAllocation_Check") # SEGFAULT
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "hip_sycl_interop") # SEGFAULT
-list(APPEND DGPU_LEVEL0_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "hipKernelLaunchIsNonBlocking") # Timeout
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "syncthreadsExitedThreads") # Timeout
@@ -2076,12 +2073,10 @@ list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Basic") #
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Threaded") # Subprocess aborted
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "hipDynamicShared") # SEGFAULT
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "hipDynamicShared2") # SEGFAULT
-list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipGraphAddEventRecordNode_MultipleRun") # Timeout
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipGraphAddEventWaitNode_MultipleRun") # Timeout
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipMemFaultStackAllocation_Check") # SEGFAULT
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "hip_sycl_interop") # SEGFAULT
-list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "hipKernelLaunchIsNonBlocking") # Timeout
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functional") # Subprocess aborted
 list(APPEND IGPU_LEVEL0_FAILED_TESTS "syncthreadsExitedThreads") # Timeout
@@ -2474,7 +2469,6 @@ list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipTextureObj2DCheckRGBAModes") # Failed
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipTextureObj2DCheckSRGBAModes") # Failed
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") # NUMERICAL
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") # NUMERICAL
-list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipMultiThreadStreams2") # Subprocess aborted
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Basic") # Failed
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipGetLastError_Positive_Threaded") # Subprocess aborted
 list(APPEND CPU_POCL_FAILED_TESTS "Unit_hipPeekAtLastError_Positive_Basic") # Failed

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -1326,7 +1326,6 @@ list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipGraphMemcpyNodeSetParams_Functiona
 list(APPEND DGPU_OPENCL_FAILED_TESTS "syncthreadsExitedThreads") # Timeout
 
 # dGPU Level Zero Unit Test Failures
-list(APPEND DGPU_LEVEL0_FAILED_TESTS "Unit_hipStreamPerThread_MultiThread") # Flaky
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "hipStreamSemantics") # SEGFAULT
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "BitonicSort") # Assertion `!Deleted_ && "Event use after delete!"' failed.
 list(APPEND DGPU_LEVEL0_FAILED_TESTS "FloydWarshall") # Assertion `!Deleted_ && "Event use after delete!"' failed.

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -1299,8 +1299,6 @@ list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj1DCheckRGBAModes - buffe
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj1DCheckSRGBAModes - buffer") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj2DCheckRGBAModes") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipTextureObj2DCheckSRGBAModes") # Failed
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_Basic") # Timeout
-list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipStreamPerThread_MemcpyAsync") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipMemFaultStackAllocation_Check") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") # Failed
 list(APPEND DGPU_OPENCL_FAILED_TESTS "Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") # Failed

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1569,17 +1569,17 @@ void CHIPQueue::memCopyAsync(void *Dst, const void *Src, size_t Size) {
     auto AllocInfoSrc =
         Backend->getActiveDevice()->AllocationTracker->getAllocInfo(Src);
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
-      Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoDst);
+      this->MemUnmap(AllocInfoDst);
     if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
-      Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoSrc);
+      this->MemUnmap(AllocInfoSrc);
 
     ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
 
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
-      Backend->getActiveDevice()->getDefaultQueue()->MemMap(
+      this->MemMap(
           AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
     if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
-      Backend->getActiveDevice()->getDefaultQueue()->MemMap(
+      this->MemMap(
           AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
 
     ChipEvent->Msg = "memCopyAsync";

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1544,10 +1544,10 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
 
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_WRITE);
+          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
     if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_WRITE);
+          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
 
     ChipEvent->Msg = "memCopy";
     updateLastEvent(ChipEvent);
@@ -1561,12 +1561,33 @@ void CHIPQueue::memCopyAsync(void *Dst, const void *Src, size_t Size) {
 #ifdef ENFORCE_QUEUE_SYNC
   ChipContext_->syncQueues(this);
 #endif
-  auto ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
-  ChipEvent->Msg = "memCopyAsync";
-  updateLastEvent(ChipEvent);
+  CHIPEvent *ChipEvent;
+  // Scope this so that we release mutex for finish()
+  {
+    auto AllocInfoDst =
+        Backend->getActiveDevice()->AllocationTracker->getAllocInfo(Dst);
+    auto AllocInfoSrc =
+        Backend->getActiveDevice()->AllocationTracker->getAllocInfo(Src);
+    if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
+      Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoDst);
+    if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
+      Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoSrc);
+
+    ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
+
+    if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
+      Backend->getActiveDevice()->getDefaultQueue()->MemMap(
+          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+    if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
+      Backend->getActiveDevice()->getDefaultQueue()->MemMap(
+          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+
+    ChipEvent->Msg = "memCopyAsync";
+    updateLastEvent(ChipEvent);
+  }
   ChipEvent->track();
-  return;
 }
+
 void CHIPQueue::memFill(void *Dst, size_t Size, const void *Pattern,
                         size_t PatternSize) {
   {

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1678,7 +1678,7 @@ CHIPEvent *CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
         MemUnmap(&AllocInfo);
       else
         MemMap(&AllocInfo,
-               CHIPQueue::MEM_MAP_TYPE::HOST_WRITE); // TODO fixOpenCLTests -
+               CHIPQueue::MEM_MAP_TYPE::HOST_READ); // TODO fixOpenCLTests -
                                                      // print ptr
     } else if (AllocInfo.HostPtr &&
                AllocInfo.MemoryType == hipMemoryTypeManaged) {

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1544,10 +1544,10 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
 
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
     if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
 
     ChipEvent->Msg = "memCopy";
     updateLastEvent(ChipEvent);
@@ -1577,10 +1577,10 @@ void CHIPQueue::memCopyAsync(void *Dst, const void *Src, size_t Size) {
 
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+          AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
     if (AllocInfoSrc && AllocInfoSrc->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
-          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ);
+          AllocInfoSrc, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
 
     ChipEvent->Msg = "memCopyAsync";
     updateLastEvent(ChipEvent);
@@ -1699,8 +1699,7 @@ CHIPEvent *CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
         MemUnmap(&AllocInfo);
       else
         MemMap(&AllocInfo,
-               CHIPQueue::MEM_MAP_TYPE::HOST_READ); // TODO fixOpenCLTests -
-                                                     // print ptr
+               CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE); 
     } else if (AllocInfo.HostPtr &&
                AllocInfo.MemoryType == hipMemoryTypeManaged) {
       void *Src = PreKernel ? AllocInfo.HostPtr : AllocInfo.DevPtr;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2020,6 +2020,7 @@ public:
   enum MEM_MAP_TYPE {
     HOST_READ,
     HOST_WRITE,
+    HOST_READ_WRITE
   };
   virtual void MemMap(const AllocationInfo *AllocInfo, MEM_MAP_TYPE MapType) {}
   virtual void MemUnmap(const AllocationInfo *AllocInfo) {}

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -607,10 +607,7 @@ protected:
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;
 
-#ifndef NDEBUG
-  // A debug flag for cathing use-after-delete.
-  bool Deleted_ = false;
-#endif
+
 
   // reference count
   size_t *Refc_;
@@ -629,6 +626,10 @@ protected:
   CHIPEvent() = default;
 
 public:
+#ifndef NDEBUG
+  // A debug flag for cathing use-after-delete.
+  bool Deleted_ = false;
+#endif
   bool isUserEvent() { return UserEvent_; }
   void addDependency(CHIPEvent *Event) {
     assert(!Deleted_ && "Event use after delete!");

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -607,7 +607,10 @@ protected:
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;
 
-
+#ifndef NDEBUG
+  // A debug flag for cathing use-after-delete.
+  bool Deleted_ = false;
+#endif
 
   // reference count
   size_t *Refc_;
@@ -626,10 +629,6 @@ protected:
   CHIPEvent() = default;
 
 public:
-// #ifndef NDEBUG
-  // A debug flag for cathing use-after-delete.
-  bool Deleted_ = false;
-// #endif
   bool isUserEvent() { return UserEvent_; }
   void addDependency(CHIPEvent *Event) {
     assert(!Deleted_ && "Event use after delete!");

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -626,10 +626,10 @@ protected:
   CHIPEvent() = default;
 
 public:
-#ifndef NDEBUG
+// #ifndef NDEBUG
   // A debug flag for cathing use-after-delete.
   bool Deleted_ = false;
-#endif
+// #endif
   bool isUserEvent() { return UserEvent_; }
   void addDependency(CHIPEvent *Event) {
     assert(!Deleted_ && "Event use after delete!");

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -305,8 +305,10 @@ public:
     // go through all pools and try to get an allocated event
     for (size_t i = 0; i < EventPools_.size(); i++) {
       CHIPEventLevel0 *Event = EventPools_[i]->getEvent();
-      if (Event)
+      if (Event) {
+        Event->Deleted_ = false;
         return Event;
+      }
     }
 
     // no events available, create new pool, get event from there and return

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -305,10 +305,8 @@ public:
     // go through all pools and try to get an allocated event
     for (size_t i = 0; i < EventPools_.size(); i++) {
       CHIPEventLevel0 *Event = EventPools_[i]->getEvent();
-      if (Event) {
-        Event->Deleted_ = false;
+      if (Event)
         return Event;
-      }
     }
 
     // no events available, create new pool, get event from there and return

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -937,12 +937,17 @@ void CHIPQueueOpenCL::MemMap(const AllocationInfo *AllocInfo,
   if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_READ) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ");
     Status =
-        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ | CL_MAP_WRITE,
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ,
                         AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
   } else if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_WRITE");
     Status =
-        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_WRITE | CL_MAP_READ,
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ,
+                        AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
+  } else if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE) {
+    logDebug("CHIPQueueOpenCL::MemMap HOST_READ_WRITE");
+    Status =
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ | CL_MAP_WRITE,
                         AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
   } else {
     assert(0 && "Invalid MemMap Type");

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -942,7 +942,7 @@ void CHIPQueueOpenCL::MemMap(const AllocationInfo *AllocInfo,
   } else if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_WRITE");
     Status =
-        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ,
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_WRITE,
                         AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
   } else if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ_WRITE");

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -937,12 +937,12 @@ void CHIPQueueOpenCL::MemMap(const AllocationInfo *AllocInfo,
   if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_READ) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_READ");
     Status =
-        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ,
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_READ | CL_MAP_WRITE,
                         AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
   } else if (Type == CHIPQueue::MEM_MAP_TYPE::HOST_WRITE) {
     logDebug("CHIPQueueOpenCL::MemMap HOST_WRITE");
     Status =
-        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_WRITE,
+        clEnqueueSVMMap(ClQueue_->get(), CL_TRUE, CL_MAP_WRITE | CL_MAP_READ,
                         AllocInfo->HostPtr, AllocInfo->Size, 0, NULL, NULL);
   } else {
     assert(0 && "Invalid MemMap Type");


### PR DESCRIPTION
* ~~Fix assert that event use after delete (recycled events would not get their `Deleted_` reset~~
* Registered memory map/unmap was not getting applied to async memcpy
* Registered memcopy mapped to `HOST_READ` in all cases instead of `HOST_WRITE` seems that `HOST_WRITE` doesn't guarantee a proper read whereas using `HOST_READ` allows to both write and read host pointers. 


fixes #430 