### PR TITLE
Implement `__device__ __assert_fail()`

### DIFF
--- a/include/hip/spirv_hip.hh
+++ b/include/hip/spirv_hip.hh
@@ -146,9 +146,12 @@ extern "C" __device__ int printf(const char *fmt, ...)
     __attribute__((format(printf, 1, 2)));
 extern "C" __device__ void abort();
 
-// The assert part mimiced from amd_device_functions.h of amdhip.
-// We assume assert.h defines assert such that it calls __assert_fail
-// when it fails.
+// The assert part mimiced from amd_device_functions.h of amdhip.  We
+// assume assert.h defines assert such that it calls __assert_fail
+// when it fails. Some users forward declares the __assert_fail, with
+// a signature copied from the AMD's headers, in their
+// applications. If we don't reflect the function signature the
+// compiler may give obscure warnings about it.
 
 extern "C" {
 #if defined(_WIN32) || defined(_WIN64)

--- a/llvm_passes/HipAbort.cpp
+++ b/llvm_passes/HipAbort.cpp
@@ -90,7 +90,8 @@ HipAbortPass::run(Module &Mod, ModuleAnalysisManager &AM) {
           continue;
         CallInst *Call = cast<CallInst>(&I);
         CallsToHandle.insert(Call);
-        if (Call->getCalledFunction()->getName() == "__chipspv_abort")
+        if (Call->getCalledFunction() &&
+            Call->getCalledFunction()->getName() == "__chipspv_abort")
           AbortCallsToHandle.insert(Call);
       }
     }

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -250,8 +250,11 @@ static void handleAbortRequest(CHIPQueue &Q, CHIPModule &M) {
 
   // Disable host-side abort behavior for making the unit testing of abort
   // cases easier.
-  if (!getenv("CHIP_HOST_IGNORES_DEVICE_ABORT"))
+  if (!getenv("CHIP_HOST_IGNORES_DEVICE_ABORT")) {
+    // Intel CPU OpenCL doesn't seem flush after the kernel completion.
+    std::cout << std::flush;
     abort();
+  }
 
   // Just act like nothing happened. Reset the flag so we let there be more
   // aborts.

--- a/src/SPVRegister.cc
+++ b/src/SPVRegister.cc
@@ -93,6 +93,12 @@ void SPVRegister::bindVariable(SPVRegister::Handle Handle, HostPtr Ptr,
       (Name == ChipDeviceAbortFlagName && HostPtrLookup_[Ptr]->Name == Name) &&
           "Host-pointer is already mapped.");
 
+  if (Name == ChipDeviceAbortFlagName) {
+    if (SrcMod->HasAbortFlag)
+      return; // Ignore duplicate abort flag variable.
+    SrcMod->HasAbortFlag = true;
+  }
+
   SrcMod->Variables.emplace_back(SPVVariable{{SrcMod, Ptr, Name}, Size});
   HostPtrLookup_.emplace(std::make_pair(Ptr, &SrcMod->Variables.back()));
 }

--- a/src/SPVRegister.hh
+++ b/src/SPVRegister.hh
@@ -80,6 +80,8 @@ public:
   // Using lists for iterator stability.
   std::list<SPVFunction> Kernels;
   std::list<SPVVariable> Variables;
+  /// True if the module has flag variable for signaling device side abort.
+  bool HasAbortFlag = false;
 
   std::string_view getBinary() const {
     assert(FinalizedBinary_.size() && "Has not finalized yet!");

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -64,4 +64,5 @@ add_hip_runtime_test(TestHIPMathFunctions.hip)
 add_hip_runtime_test(TestAtomics.hip)
 add_hip_runtime_test(TestIndirectMappedHostAlloc.hip)
 
+add_shell_test(TestAssert.bash)
 add_shell_test(TestAssertFail.bash)

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -41,6 +41,14 @@ function(add_hip_runtime_test MAIN_SOURCE)
     SKIP_REGULAR_EXPRESSION "SKIP")
 endfunction()
 
+# add_shell_test(<script-file>)
+function(add_shell_test SCRIPT)
+  get_filename_component(TEST_NAME ${SCRIPT} NAME_WLE)
+  configure_file(${SCRIPT} ${SCRIPT} @ONLY)
+  add_test(NAME ${TEST_NAME}
+    COMMAND /bin/bash ${CMAKE_CURRENT_BINARY_DIR}/${SCRIPT})
+endfunction()
+
 add_hip_runtime_test(TestLazyModuleInit.cpp)
 add_hip_runtime_test(TestKernelArgs.hip)
 add_hip_runtime_test(TestUndefKernelArg.hip)
@@ -55,3 +63,5 @@ add_hip_runtime_test(TestStlFunctionsDouble.hip)
 add_hip_runtime_test(TestHIPMathFunctions.hip)
 add_hip_runtime_test(TestAtomics.hip)
 add_hip_runtime_test(TestIndirectMappedHostAlloc.hip)
+
+add_shell_test(TestAssertFail.bash)

--- a/tests/runtime/TestAssert.bash
+++ b/tests/runtime/TestAssert.bash
@@ -17,6 +17,6 @@ ${HIPCC} ${SRC_DIR}/inputs/Assert.hip -o assert
 
 grep -c "Assert.hip:5: void k(): Device-side assertion .false [&][&] \"Hello, World!\". failed." \
      output.log ||  {
-    echo "FAIL: excepted assertion error message was not found."
+    echo "FAIL: expected assertion error message was not found."
     exit 1
 }

--- a/tests/runtime/TestAssert.bash
+++ b/tests/runtime/TestAssert.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+
+SRC_DIR=@CMAKE_CURRENT_SOURCE_DIR@
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=@CMAKE_BINARY_DIR@/bin/hipcc.bin
+
+mkdir -p ${OUT_DIR}
+cd ${OUT_DIR}
+
+${HIPCC} ${SRC_DIR}/inputs/Assert.hip -o assert
+
+! ./assert >output.log 2>&1 || {
+    echo "FAIL: Expected error code."
+    exit 1
+}
+
+grep -c "Assert.hip:5: void k(): Device-side assertion .false [&][&] \"Hello, World!\". failed." \
+     output.log ||  {
+    echo "FAIL: excepted assertion error message was not found."
+    exit 1
+}

--- a/tests/runtime/TestAssertFail.bash
+++ b/tests/runtime/TestAssertFail.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+
+SRC_DIR=@CMAKE_CURRENT_SOURCE_DIR@
+OUT_DIR=@CMAKE_CURRENT_BINARY_DIR@/@TEST_NAME@.d
+HIPCC=@CMAKE_BINARY_DIR@/bin/hipcc.bin
+
+mkdir -p ${OUT_DIR}
+cd ${OUT_DIR}
+
+${HIPCC} ${SRC_DIR}/inputs/AssertFail.hip -o assert-fail
+
+! ./assert-fail >output.log 2>&1 || {
+    echo "FAIL: Expected error code."
+    exit 1
+}
+
+grep -c "file:123: function: Device-side assertion .expression. failed." \
+     output.log ||  {
+    echo "FAIL: excepted assertion error message was not found."
+    exit 1
+}

--- a/tests/runtime/TestAssertFail.bash
+++ b/tests/runtime/TestAssertFail.bash
@@ -17,6 +17,6 @@ ${HIPCC} ${SRC_DIR}/inputs/AssertFail.hip -o assert-fail
 
 grep -c "file:123: function: Device-side assertion .expression. failed." \
      output.log ||  {
-    echo "FAIL: excepted assertion error message was not found."
+    echo "FAIL: Expected assertion error message was not found."
     exit 1
 }

--- a/tests/runtime/inputs/Assert.hip
+++ b/tests/runtime/inputs/Assert.hip
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/CHIP-SPV/hipstar/issues/387.
+#include <hip/hip_runtime.h>
+#include <cassert>
+
+__global__ void k() { assert(false && "Hello, World!"); }
+
+int main() {
+  k<<<1, 1>>>();
+  (void)hipDeviceSynchronize();
+  return 0;
+}

--- a/tests/runtime/inputs/AssertFail.hip
+++ b/tests/runtime/inputs/AssertFail.hip
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/CHIP-SPV/hipstar/issues/387.
+#include <hip/hip_runtime.h>
+
+__global__ void k() { __assert_fail("expression", "file", 123, "function"); }
+
+int main() {
+  k<<<1, 1>>>();
+  (void)hipDeviceSynchronize();
+  return 0;
+}


### PR DESCRIPTION
... which is needed for assert() being called from device code. Also, some HIP applications calls it directly.

Along the way, fixed HipAbort pass crashing on indirect calls.

Resolves #387.