### PR TITLE
User Event Destruction + EventPool release

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1518,7 +1518,7 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
       Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoSrc);
 
     ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
-
+    assert(!ChipEvent->isUserEvent());
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
           AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
@@ -1529,7 +1529,10 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
     ChipEvent->Msg = "memCopy";
     updateLastEvent(ChipEvent);
     this->finish();
+    assert(!ChipEvent->isUserEvent());
+    assert(!ChipEvent->TrackCalled_);
   }
+  assert(!ChipEvent->isUserEvent());
   ChipEvent->track();
 
   return hipSuccess;

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1211,11 +1211,7 @@ CHIPBackend::CHIPBackend() {
 
 CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
-  // if (StaleEventMonitor_)
-  //   StaleEventMonitor_->stop();
-  // if (CallbackEventMonitor_)
-  //   CallbackEventMonitor_->stop();
-  Events.clear();
+  assert(Events.size() == 0);
   for (auto &Ctx : ChipContexts) {
     Backend->removeContext(Ctx);
     delete Ctx;
@@ -1518,7 +1514,7 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
       Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoSrc);
 
     ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
-    assert(!ChipEvent->isUserEvent());
+
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(
           AllocInfoDst, CHIPQueue::MEM_MAP_TYPE::HOST_READ_WRITE);
@@ -1529,10 +1525,9 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
     ChipEvent->Msg = "memCopy";
     updateLastEvent(ChipEvent);
     this->finish();
-    assert(!ChipEvent->isUserEvent());
-    assert(!ChipEvent->TrackCalled_);
   }
   assert(!ChipEvent->isUserEvent());
+  assert(!ChipEvent->isTrackCalled());
   ChipEvent->track();
 
   return hipSuccess;

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -814,6 +814,7 @@ void CHIPDevice::addQueue(CHIPQueue *ChipQueue) {
 void CHIPEvent::track() {
   LOCK(Backend->EventsMtx); // trackImpl CHIPBackend::Events
   LOCK(EventMtx);           // writing bool CHIPEvent::TrackCalled_
+  assert(!isUserEvent() && "Attemped to track a user event!");
   assert(!Deleted_ && "Event use after delete!");
   if (!TrackCalled_) {
     Backend->Events.push_back(this);
@@ -1210,10 +1211,10 @@ CHIPBackend::CHIPBackend() {
 
 CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
-  if (StaleEventMonitor_)
-    StaleEventMonitor_->stop();
-  if (CallbackEventMonitor_)
-    CallbackEventMonitor_->stop();
+  // if (StaleEventMonitor_)
+  //   StaleEventMonitor_->stop();
+  // if (CallbackEventMonitor_)
+  //   CallbackEventMonitor_->stop();
   Events.clear();
   for (auto &Ctx : ChipContexts) {
     Backend->removeContext(Ctx);

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -220,30 +220,6 @@ void CHIPEvent::releaseDependencies() {
   DependsOnList.clear();
 }
 
-void CHIPEvent::decreaseRefCount(std::string Reason) {
-  LOCK(EventMtx); // CHIPEvent::Refc_
-  assert(!Deleted_ && "Event use after delete!");
-  // logDebug("CHIPEvent::decreaseRefCount() {} {} refc {}->{} REASON: {}",
-  //          (void *)this, Msg.c_str(), *Refc_, *Refc_ - 1, Reason);
-  if (*Refc_ > 0) {
-    (*Refc_)--;
-  } else {
-    assert(false && "CHIPEvent::decreaseRefCount() called when refc == 0");
-    logError("CHIPEvent::decreaseRefCount() called when refc == 0");
-  }
-  // Destructor to be called by event monitor once backend is done using it
-}
-void CHIPEvent::increaseRefCount(std::string Reason) {
-  LOCK(EventMtx); // CHIPEvent::Refc_
-  assert(!Deleted_ && "Event use after delete!");
-  // logDebug("CHIPEvent::increaseRefCount() {} {} refc {}->{} REASON: {}",
-  //          (void *)this, Msg.c_str(), *Refc_, *Refc_ + 1, Reason);
-
-  // Base constructor and CHIPEventLevel0::reset() sets the refc_ to one.
-  assert(*Refc_ > 0 && "Increasing refcount from zero!");
-  (*Refc_)++;
-}
-
 size_t CHIPEvent::getCHIPRefc() {
   LOCK(this->EventMtx); // CHIPEvent::Refc_
   assert(!Deleted_ && "Event use after delete!");

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -608,10 +608,9 @@ public:
 };
 
 class CHIPEvent : public ihipEvent_t {
-public:
+protected:
   bool TrackCalled_ = false;
   bool UserEvent_ = false;
-protected:
   event_status_e EventStatus_;
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;
@@ -637,7 +636,10 @@ protected:
    */
   CHIPEvent() : UserEvent_(false), TrackCalled_(false) {}
 public:
+  bool isTrackCalled() { return TrackCalled_; }
+  bool setTrackCalled(bool Val) { TrackCalled_ = Val; }
   bool isUserEvent() { return UserEvent_; }
+  bool setUserEvent(bool Val) { UserEvent_ = Val; }
   void addDependency(CHIPEvent *Event) {
     assert(!Deleted_ && "Event use after delete!");
     DependsOnList.push_back(Event);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -637,9 +637,9 @@ protected:
   CHIPEvent() : UserEvent_(false), TrackCalled_(false) {}
 public:
   bool isTrackCalled() { return TrackCalled_; }
-  bool setTrackCalled(bool Val) { TrackCalled_ = Val; }
+  void setTrackCalled(bool Val) { TrackCalled_ = Val; }
   bool isUserEvent() { return UserEvent_; }
-  bool setUserEvent(bool Val) { UserEvent_ = Val; }
+  void setUserEvent(bool Val) { UserEvent_ = Val; }
   void addDependency(CHIPEvent *Event) {
     assert(!Deleted_ && "Event use after delete!");
     DependsOnList.push_back(Event);

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -635,8 +635,7 @@ protected:
    * constructor should be called.
    *
    */
-  CHIPEvent() = default;
-
+  CHIPEvent() : UserEvent_(false), TrackCalled_(false) {}
 public:
   bool isUserEvent() { return UserEvent_; }
   void addDependency(CHIPEvent *Event) {

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -610,8 +610,8 @@ public:
 class CHIPEvent : public ihipEvent_t {
 public:
   bool TrackCalled_ = false;
-protected:
   bool UserEvent_ = false;
+protected:
   event_status_e EventStatus_;
   CHIPEventFlags Flags_;
   std::vector<CHIPEvent *> DependsOnList;

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -640,8 +640,8 @@ public:
   std::mutex EventMtx;
   std::string Msg;
   size_t getCHIPRefc();
-  virtual void decreaseRefCount(std::string Reason);
-  virtual void increaseRefCount(std::string Reason);
+  virtual void decreaseRefCount(std::string Reason) = 0;
+  virtual void increaseRefCount(std::string Reason) = 0;
   virtual ~CHIPEvent() = default;
   // Optionally provide a field for origin of this event
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -335,11 +335,11 @@ public:
   std::mutex EventMonitorMtx;
   volatile bool Stop = false;
 
-  void join() { 
+  void join() {
     assert(Thread_);
     logDebug("Joining Event Monitor Thread {}", Thread_);
-    int Status = pthread_join(Thread_, nullptr); 
-    if(Status != 0) {
+    int Status = pthread_join(Thread_, nullptr);
+    if (Status != 0) {
       logError("Failed to call join() {}", Status);
     }
   }
@@ -635,6 +635,7 @@ protected:
    *
    */
   CHIPEvent() : UserEvent_(false), TrackCalled_(false) {}
+
 public:
   bool isTrackCalled() { return TrackCalled_; }
   void setTrackCalled(bool Val) { TrackCalled_ = Val; }
@@ -645,7 +646,7 @@ public:
     DependsOnList.push_back(Event);
   }
   void releaseDependencies();
-  void track();
+  virtual void track();
   CHIPEventFlags getFlags() { return Flags_; }
   std::mutex EventMtx;
   std::string Msg;
@@ -753,10 +754,10 @@ public:
   virtual void hostSignal() = 0;
 
 #ifndef NDEBUG
-  void markDeleted(bool State = true) { 
+  void markDeleted(bool State = true) {
     LOCK(EventMtx); // Deleted_
-    Deleted_ = State; 
-    }
+    Deleted_ = State;
+  }
 #endif
 };
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2170,9 +2170,7 @@ hipError_t hipEventDestroy(hipEvent_t Event) {
   CHIPEvent *ChipEvent = static_cast<CHIPEvent *>(Event);
 
   ChipEvent->decreaseRefCount("hipEventDestroy");
-  if (ChipEvent->getCHIPRefc() != 0) {
-    logError("hipEventDestroy was called but remaining refcount is not 0");
-  }
+
   RETURN(hipSuccess);
 
   CHIP_CATCH

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2168,7 +2168,10 @@ hipError_t hipEventDestroy(hipEvent_t Event) {
   NULLCHECK(Event);
   CHIPEvent *ChipEvent = static_cast<CHIPEvent *>(Event);
 
-  ChipEvent->decreaseRefCount("hipEventDestroy");
+  size_t Refc = ChipEvent->decreaseRefCount("hipEventDestroy");
+  if(Refc == 0) {
+    Event = nullptr;
+  }
 
   RETURN(hipSuccess);
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2137,7 +2137,6 @@ hipError_t hipEventCreateWithFlags(hipEvent_t *Event, unsigned Flags) {
 
   auto ChipEvent =
       Backend->createCHIPEvent(Backend->getActiveContext(), EventFlags, true);
-  ChipEvent->increaseRefCount("hipEventCreateWithFlags");
 
   *Event = ChipEvent;
   RETURN(hipSuccess);

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -20,7 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
 #ifndef SRC_UTILS_HH
 #define SRC_UTILS_HH
 
@@ -31,6 +30,7 @@
 #include <optional>
 #include <cstring>
 #include <string_view>
+#include <iomanip>
 
 std::string readEnvVar(std::string EnvVar, bool Lower = true);
 void dumpSpirv(std::string_view Spirv);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -666,7 +666,7 @@ void CHIPStaleEventMonitorLevel0::monitor() {
 
       assert(ChipEvent);
       assert(!ChipEvent->isUserEvent());
-      assert(ChipEvent->TrackCalled_ && "Event found in backend list but TrackCalled_ is false");
+      assert(ChipEvent->isTrackCalled() && "Event found in backend list but TrackCalled_ is false");
       auto E = (CHIPEventLevel0 *)ChipEvent;
 
       // do not change refcount for user events
@@ -1512,7 +1512,7 @@ CHIPEventLevel0 *CHIPBackendLevel0::createCHIPEvent(CHIPContext *ChipCtx,
   CHIPEventLevel0 *Event;
   if (UserEvent) {
     Event = new CHIPEventLevel0((CHIPContextLevel0 *)ChipCtx, Flags);
-    Event->UserEvent_ = true;
+    Event->setUserEvent(true);
     // Event->increaseRefCount("hipEventCreate");
   } else {
     auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -254,6 +254,13 @@ CHIPEventLevel0::~CHIPEventLevel0() {
     // '~CHIPEventLevel0' has a non-throwing exception specification
     assert(Status == ZE_RESULT_SUCCESS);
   }
+
+  if (isUserEvent()) {
+    assert(EventPool && "EventPoolHandle_ is set but EventPool is nullptr");
+    auto Status = zeEventPoolDestroy(EventPoolHandle_);
+    assert(Status == ZE_RESULT_SUCCESS);
+  }
+
   Event_ = nullptr;
   EventPoolHandle_ = nullptr;
   EventPool = nullptr;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1351,7 +1351,7 @@ CHIPEvent *CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src,
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   CHIPEventLevel0 *MemCopyEvent =
       (CHIPEventLevel0 *)Backend->createCHIPEvent(ChipCtxZe);
-
+  assert(!MemCopyEvent->isUserEvent());
   ze_result_t Status;
   CHIPASSERT(MemCopyEvent->peek());
   GET_COMMAND_LIST(this);

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1472,6 +1472,7 @@ CHIPEventLevel0 *LZEventPool::getEvent() {
     return nullptr;
   auto Event = Events_[PoolIndex];
   Event->reset();
+  assert(Event->isUserEvent() == false);
 
   return Event;
 };
@@ -1511,6 +1512,7 @@ CHIPEventLevel0 *CHIPBackendLevel0::createCHIPEvent(CHIPContext *ChipCtx,
   CHIPEventLevel0 *Event;
   if (UserEvent) {
     Event = new CHIPEventLevel0((CHIPContextLevel0 *)ChipCtx, Flags);
+    Event->UserEvent_ = true;
     // Event->increaseRefCount("hipEventCreate");
   } else {
     auto ZeCtx = (CHIPContextLevel0 *)ChipCtx;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -256,7 +256,7 @@ CHIPEventLevel0::~CHIPEventLevel0() {
   }
 
   if (isUserEvent()) {
-    assert(EventPool && "EventPoolHandle_ is set but EventPool is nullptr");
+    assert(EventPoolHandle_ && "UserEvent has a null event pool handle!");
     auto Status = zeEventPoolDestroy(EventPoolHandle_);
     assert(Status == ZE_RESULT_SUCCESS);
   }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -104,7 +104,7 @@ public:
       logError("CHIPEvent::decreaseRefCount() called when refc == 0");
     }
     // Destructor to be called by event monitor once backend is done using it
-    if (!TrackCalled_) {
+    if (!TrackCalled_ && !UserEvent_ && *Refc_ == 0) {
       delete this;
       return 0;
     } else {

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -104,7 +104,7 @@ public:
       logError("CHIPEvent::decreaseRefCount() called when refc == 0");
     }
     // Destructor to be called by event monitor once backend is done using it
-    assert(!isTrackCalled() && isUserEvent() && "UserEvent has TrackCalled_!");
+    assert(!(TrackCalled_ && UserEvent_) && "UserEvent has TrackCalled_!");
     if (!TrackCalled_ && !UserEvent_ && *Refc_ == 0) {
       delete this;
       return 0;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -104,6 +104,7 @@ public:
       logError("CHIPEvent::decreaseRefCount() called when refc == 0");
     }
     // Destructor to be called by event monitor once backend is done using it
+    assert(!isTrackCalled() && isUserEvent() && "UserEvent has TrackCalled_!");
     if (!TrackCalled_ && !UserEvent_ && *Refc_ == 0) {
       delete this;
       return 0;

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -92,7 +92,7 @@ private:
   std::vector<ActionFn> Actions_;
 
 public:
-  virtual void decreaseRefCount(std::string Reason) override {
+  virtual size_t decreaseRefCount(std::string Reason) override {
     LOCK(EventMtx); // CHIPEvent::Refc_
     assert(!Deleted_ && "Event use after delete!");
     // logDebug("CHIPEvent::decreaseRefCount() {} {} refc {}->{} REASON: {}",
@@ -104,11 +104,16 @@ public:
       logError("CHIPEvent::decreaseRefCount() called when refc == 0");
     }
     // Destructor to be called by event monitor once backend is done using it
-    if (!TrackCalled_)
+    if (!TrackCalled_) {
       delete this;
+      return 0;
+    } else {
+      return *Refc_;
+    }
+
   }
 
-  virtual void increaseRefCount(std::string Reason) override {
+  virtual size_t increaseRefCount(std::string Reason) override {
     LOCK(EventMtx); // CHIPEvent::Refc_
     assert(!Deleted_ && "Event use after delete!");
     // logDebug("CHIPEvent::increaseRefCount() {} {} refc {}->{} REASON: {}",
@@ -117,6 +122,8 @@ public:
     // Base constructor and CHIPEventLevel0::reset() sets the refc_ to one.
     assert(*Refc_ > 0 && "Increasing refcount from zero!");
     (*Refc_)++;
+
+    return *Refc_;
   }
 
   uint32_t getValidTimestampBits();

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -686,7 +686,7 @@ float CHIPEventOpenCL::getElapsedTime(CHIPEvent *OtherIn) {
 
 void CHIPEventOpenCL::hostSignal() { UNIMPLEMENTED(); }
 
-void CHIPEventOpenCL::increaseRefCount(std::string Reason) {
+size_t CHIPEventOpenCL::increaseRefCount(std::string Reason) {
   LOCK(EventMtx); // CHIPEvent::Refc_
   auto status = clRetainEvent(this->ClEvent);
   if (!UserEvent_)
@@ -698,9 +698,10 @@ void CHIPEventOpenCL::increaseRefCount(std::string Reason) {
   assert(*Refc_ = getRefCount() - 1);
   // logDebug("CHIPEventOpenCL::increaseRefCount() {} OpenCL RefCount: {}",
   //          (void *)this, getRefCount());
+  return *Refc_;
 }
 
-void CHIPEventOpenCL::decreaseRefCount(std::string Reason) {
+size_t CHIPEventOpenCL::decreaseRefCount(std::string Reason) {
   LOCK(EventMtx); // CHIPEvent::Refc_
   // logDebug("CHIPEventOpenCL::decreaseRefCount() {} OpenCL RefCount: {}",
   //          (void *)this, getRefCount());
@@ -713,6 +714,7 @@ void CHIPEventOpenCL::decreaseRefCount(std::string Reason) {
     logError("CHIPEvent::decreaseRefCount() called when refc == 0");
   }
   clReleaseEvent(this->ClEvent);
+  return *Refc_;
 }
 
 // CHIPModuleOpenCL

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -108,8 +108,8 @@ public:
   uint64_t getFinishTime();
   size_t getRefCount();
 
-  virtual void increaseRefCount(std::string Reason) override;
-  virtual void decreaseRefCount(std::string Reason) override;
+  virtual size_t increaseRefCount(std::string Reason) override;
+  virtual size_t decreaseRefCount(std::string Reason) override;
 };
 
 class CHIPModuleOpenCL : public CHIPModule {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -97,6 +97,9 @@ public:
   CHIPEventOpenCL(CHIPContextOpenCL *ChipContext,
                   CHIPEventFlags Flags = CHIPEventFlags());
   virtual ~CHIPEventOpenCL() override;
+
+  virtual void track() override{};
+
   virtual void recordStream(CHIPQueue *ChipQueue) override;
   void takeOver(CHIPEvent *Other);
   bool wait() override;


### PR DESCRIPTION
While running CP2K I could see app crash. It is indicating system is out of memory (OOM) hence the crash. Exact error message is "CHIP error [TID 431805] [1684153005.314770770] : hipErrorTbd (ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY Level Zero Event_ pool creation fail! ) in /nfs/site/home/sarbojit/src/chip-spv/src/backend/Level0/CHIPBackendLevel0.cc:312:CHIPEventLevel0"

I could notice multiple issues in CHIP-SPV event management

Even though hipEventDestroy() was called reference count was always more than 1 hence runtime can't destroy the event. I could reproduce the issue with simple hipEventCreate and hipEventDestroy sample attached here. [hipEvent_test.cc.txt](https://github.com/CHIP-SPV/chip-spv/files/11486904/hipEvent_test.cc.txt)
RT was never destroying event pool handle created as part of new event creation. Since CP2K is creating ~60k events system was getting OOM.
With the fix proposed in the PR I could run CP2K multiple times successfully without any crash.

Fixes #451
