### PR TITLE
Add LLVM pass for sanity checks

### DIFF
--- a/bitcode/devicelib.cl
+++ b/bitcode/devicelib.cl
@@ -346,7 +346,7 @@ EXPORT float __chip_norm_f32(int dim, const float *a) {
   return sqrt(r);
 }
 
-  EXPORT float __chip_rnorm_f64(int dim, const double *a) { 
+  EXPORT double __chip_rnorm_f64(int dim, const double *a) {
   double r = 0;
   while (dim--) {
     r += a[0] * a[0];

--- a/include/hip/devicelib/double_precision/dp_math.hh
+++ b/include/hip/devicelib/double_precision/dp_math.hh
@@ -214,14 +214,16 @@ extern "C++" inline __device__ double rnorm4d(double a, double b, double c,
 extern "C++" __device__ double round(double x); // OpenCL
 extern "C++" __device__ double rsqrt(double x); // OpenCL
 
-extern "C" __device__  double __ocml_scalbn_f64(double x, long int n);
+extern "C" __device__  double __ocml_scalb_f64(double x, double n);
 extern "C++" inline __device__ double scalbln(double x, long int n) {
-  return ::__ocml_scalbn_f64(x, n);
+  // No implementatin for scalbln(double, long) in OCML so promote 'n'
+  // and call OCML's scalb instead.
+  return ::__ocml_scalb_f64(x, n);
 }
 
-extern "C" __device__  double __ocml_scalb_f64(double x, int n);
+extern "C" __device__  double __ocml_scalbn_f64(double x, int n);
 extern "C++" inline __device__ double scalbn(double x, int n)  {
-  return ::__ocml_scalb_f64(x, n);
+  return ::__ocml_scalbn_f64(x, n);
 }
 
 extern "C++" __device__ int 	signbit ( double  a ); // OpenCL

--- a/llvm_passes/CMakeLists.txt
+++ b/llvm_passes/CMakeLists.txt
@@ -94,7 +94,7 @@ add_library(LLVMHipPasses MODULE HipPasses.cpp
     HipDynMem.cpp HipStripUsedIntrinsics.cpp HipDefrost.cpp
     HipPrintf.cpp HipGlobalVariables.cpp HipTextureLowering.cpp HipAbort.cpp
     HipEmitLoweredNames.cpp HipWarps.cpp HipKernelArgSpiller.cpp
-    HipLowerZeroLengthArrays.cpp ${EXTRA_OBJS})
+    HipLowerZeroLengthArrays.cpp HipSanityChecks.cpp ${EXTRA_OBJS})
 
 if("${LLVM_VERSION}" VERSION_GREATER_EQUAL 14.0)
   set_target_properties(LLVMHipPasses PROPERTIES

--- a/llvm_passes/HipPasses.cpp
+++ b/llvm_passes/HipPasses.cpp
@@ -26,6 +26,7 @@
 #include "HipEmitLoweredNames.h"
 #include "HipKernelArgSpiller.h"
 #include "HipLowerZeroLengthArrays.h"
+#include "HipSanityChecks.h"
 
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
@@ -83,6 +84,8 @@ public:
 };
 
 static void addFullLinkTimePasses(ModulePassManager &MPM) {
+  MPM.addPass(HipSanityChecksPass());
+
   /// For extracting name expression to lowered name expressions (hiprtc).
   MPM.addPass(HipEmitLoweredNamesPass());
 

--- a/llvm_passes/HipSanityChecks.cpp
+++ b/llvm_passes/HipSanityChecks.cpp
@@ -1,0 +1,85 @@
+//===- HipSanityChecks.cpp ------------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Does sanity checks on the LLVM IR just before HIP-to-SPIR-V lowering.
+//
+// (c) 2023 CHIP-SPV developers
+//===----------------------------------------------------------------------===//
+#include "HipSanityChecks.h"
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/ADT/BitVector.h"
+
+using namespace llvm;
+
+namespace {
+enum Check { IndirectCall, NumChecks };
+}
+
+static void checkCallInst(CallInst *CI, BitVector &CaughtChecks) {
+  assert(CI);
+  if (!CI->getCalledFunction()) {
+    Value *CallValue = CI->getCalledOperand()->stripPointerCasts();
+    if (auto *F = dyn_cast<Function>(CallValue)) {
+      // A function bitcast between the call function operand and the function.
+      // Sunch case appears when multiple TUs (and device library) are linked
+      // together and a function declared in both have different return and/or
+      // parameter types. E.g.
+      //
+      //   a.hip: extern "C" __device__ int foo(float x) { ... }
+      //   b.hip: extern "C" __device__ int foo(double x);
+      //          int bar() { return foo(1.0); }
+      //
+      // This kind of code is very likely leads to breakage due to potential ABI
+      // issues.
+
+      // TODO: Fix the printf signature - skip diagnostic as it works now in all
+      //       tested backends & driversdespite the type mismatch.
+      if (F->getName() == "printf")
+        return;
+
+      dbgs() << "Warning: Function type mismatch between caller and callee!\n"
+             << "called func: " << F->getName() << "\n"
+             << "caller type: " << *CI->getFunctionType() << "\n"
+             << "callee type: " << *F->getFunctionType() << "\n"
+             << "Unportable or broken code may be generated!\n";
+
+#ifndef NDEBUG
+      // Fail visibly, but only for debug build, so issues like these won't slip
+      // in silently only to be detected very much later in an obscure way.
+      dbgs() << "Aborting (CHIP-SPV debug build mode policy)\n";
+      abort();
+#endif
+    } else {
+      // Actual indirect call? Core SPIR-V does not have modeling for indirect
+      // calls.
+      if (CaughtChecks.test(Check::IndirectCall)) { // Warn once per module.
+        CaughtChecks.set(Check::IndirectCall);
+        dbgs() << "Warning: Indirect calls are not yet supported in CHIP-SPV.";
+        dbgs() << "Call origin: " << *CI->getParent()->getParent() << "\n";
+      }
+
+#ifndef NDEBUG
+      dbgs() << "Aborting (CHIP-SPV debug build mode policy)\n";
+      abort();
+#endif
+    }
+  }
+}
+
+PreservedAnalyses HipSanityChecksPass::run(Module &M,
+                                           ModuleAnalysisManager &AM) {
+  BitVector CaughtChecks(Check::NumChecks);
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB)
+        if (auto *CI = dyn_cast<CallInst>(&I))
+          checkCallInst(CI, CaughtChecks);
+
+  return PreservedAnalyses::all();
+}

--- a/llvm_passes/HipSanityChecks.h
+++ b/llvm_passes/HipSanityChecks.h
@@ -1,0 +1,27 @@
+//===- HipSanityChecks.h --------------------------------------------------===//
+//
+// Part of the CHIP-SPV Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Does sanity checks on the LLVM IR just before HIP-to-SPIR-V lowering.
+//
+// (c) 2023 CHIP-SPV developers
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_PASSES_HIP_SANITYCHECKS_H
+#define LLVM_PASSES_HIP_SANITYCHECKS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+class HipSanityChecksPass : public PassInfoMixin<HipSanityChecksPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static bool isRequired() { return true; }
+};
+
+#endif // LLVM_PASSES_HIP_SANITYCHECKS_H


### PR DESCRIPTION
Starting with checks for:

* indirect calls which are not supported yet.
* caller and callee disagreements on the the function type. (E.g. there is a call to `foo(double)` but the linked-in definition is actually `foo(float)`).

With sanity checks few devicelib issues were fixed:

* Fix return type mismatch on __chip_rnorm_f64().
* Fix call to scalbln(double, long) in OCML but it does not define one.
* Fix call to scalb(double, int) in OCML but second argument type is incorrect.

