### PR TITLE
Fix gcnArchName property is uninitialized

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -527,6 +527,8 @@ CHIPDevice::CHIPDevice(CHIPContext *Ctx, int DeviceIdx)
     : Ctx_(Ctx), Idx_(DeviceIdx) {
   LegacyDefaultQueue = nullptr;
   PerThreadDefaultQueue = nullptr;
+  // Avoid indeterminate values.
+  std::memset(&HipDeviceProps_, 0, sizeof(HipDeviceProps_));
 }
 
 CHIPDevice::~CHIPDevice() {

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2006,6 +2006,11 @@ void CHIPDeviceLevel0::populateDevicePropertiesImpl() {
   HipDeviceProps_.kernelExecTimeoutEnabled = 0;
   HipDeviceProps_.ECCEnabled = 0;
   HipDeviceProps_.asicRevision = 1;
+
+  constexpr char ArchName[] = "unavailable";
+  static_assert(sizeof(ArchName) <= sizeof(HipDeviceProps_.gcnArchName),
+                "Buffer overflow!");
+  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(sizeof(ArchName)));
 }
 
 CHIPQueue *CHIPDeviceLevel0::createQueue(CHIPQueueFlags Flags, int Priority) {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -529,6 +529,11 @@ void CHIPDeviceOpenCL::populateDevicePropertiesImpl() {
   HipDeviceProps_.maxTexture3D[0] = clampToInt(Max3DWidth);
   HipDeviceProps_.maxTexture3D[1] = clampToInt(Max3DHeight);
   HipDeviceProps_.maxTexture3D[2] = clampToInt(Max3DDepth);
+
+  constexpr char ArchName[] = "unavailable";
+  static_assert(sizeof(ArchName) <= sizeof(HipDeviceProps_.gcnArchName),
+                "Buffer overflow!");
+  std::strncpy(HipDeviceProps_.gcnArchName, ArchName, sizeof(sizeof(ArchName)));
 }
 
 void CHIPDeviceOpenCL::resetImpl() { UNIMPLEMENTED(); }


### PR DESCRIPTION
Fixes a issue found in #467 that caused confusion.

Along the way made sure that all other possibly uninitialized device property fields are defined (although not necessarily correct).