### PR TITLE
Add experimental support for indirect calls

### DIFF
--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -154,6 +154,10 @@ list(APPEND FAILING_FOR_ALL "Unit_deviceFunctions_CompileTest_atomicXor_system_u
 list(APPEND FAILING_FOR_ALL "Unit_deviceFunctions_CompileTest_atomicXor_system_unsigned_long_long") # Unimplemented
 list(APPEND FAILING_FOR_ALL "hipStreamSemantics") # SEGFAULT - likely due to main thread exiting without calling join
 list(APPEND FAILING_FOR_ALL "Unit_hipMultiStream_multimeDevice") # SEGFAULT - likely due to multiple GPU support
+# Not included in any target because no driver (so far) reports support
+# for indirect calls. Despite this, this test is known to pass on Intel
+# OpenCL CPU & GPU and Intel Level Zero (however, your mileage may vary).
+list(APPEND FAILING_FOR_ALL "TestIndirectCall")
 
 # CPU OpenCL Unit Test Failures
 list(APPEND CPU_OPENCL_FAILED_TESTS "hipStreamSemantics") # SEGFAULT

--- a/llvm_passes/HipSanityChecks.cpp
+++ b/llvm_passes/HipSanityChecks.cpp
@@ -57,18 +57,16 @@ static void checkCallInst(CallInst *CI, BitVector &CaughtChecks) {
 #endif
     } else {
       // Actual indirect call? Core SPIR-V does not have modeling for indirect
-      // calls.
+      // calls and SPV_INTEL_function_pointers extension will be used to model
+      // them. So far no drivers advertise support for the extension but code
+      // with indirect calls is known to work on Inter drivers (by luck?).
       if (!CaughtChecks.test(Check::IndirectCall)) { // Warn once per module.
         CaughtChecks.set(Check::IndirectCall);
-        dbgs() << "Warning: Indirect calls are not yet supported in CHIP-SPV.\n"
+        dbgs() << "Warning: Indirect call support is experimental.\nHIP "
+                  "programs with them  may encounter failures or even crash!\n"
                << "Call origin: " << CI->getParent()->getParent()->getName()
                << "\n";
       }
-
-#ifndef NDEBUG
-      dbgs() << "Aborting (CHIP-SPV debug build mode policy)\n";
-      abort();
-#endif
     }
   }
 }

--- a/llvm_passes/HipSanityChecks.cpp
+++ b/llvm_passes/HipSanityChecks.cpp
@@ -63,7 +63,7 @@ static void checkCallInst(CallInst *CI, BitVector &CaughtChecks) {
       if (!CaughtChecks.test(Check::IndirectCall)) { // Warn once per module.
         CaughtChecks.set(Check::IndirectCall);
         dbgs() << "Warning: Indirect call support is experimental.\nHIP "
-                  "programs with them  may encounter failures or even crash!\n"
+                  "programs with them may encounter failures or even crash!\n"
                << "Call origin: " << CI->getParent()->getParent()->getName()
                << "\n";
       }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -67,3 +67,6 @@ add_hip_runtime_test(TestIndirectMappedHostAlloc.hip)
 add_shell_test(TestAssert.bash)
 add_shell_test(TestAssertFail.bash)
 add_shell_test(TestForgottenModuleUnload.bash)
+
+add_hip_runtime_test(TestIndirectCall.hip)
+add_hip_runtime_test(TestStructWithFnPtr.hip)

--- a/tests/runtime/TestIndirectCall.hip
+++ b/tests/runtime/TestIndirectCall.hip
@@ -1,0 +1,35 @@
+// Test kernel with an indirect call.
+//
+// NOTES:
+//
+// * Core SPIR-V does not support indirect calls without an extension. In this
+//   case the llvm-spirv inserts SPV_INTEL_function_pointers extension so this
+//   program is only runnable in environments that supports it.
+//
+// * Invalid SPIR-V binary is known to be generated.
+//   OpConstantFunctionPointerINTEL instruction is generated with a reference to
+//   an undeclared OpFunction (missing forward declaration).
+
+#include <hip/hip_runtime.h>
+
+static __device__ int add123(int Val) { return Val + 123; }
+static __device__ int sub321(int Val) { return Val - 321; }
+
+// NOTE: it's possible that Clang's optimizer could optimize the indirect
+//       calls away.  So far it does not happen on this kernel with
+//       Clang-16 + -O3.
+typedef int (*ICall)(int);
+__global__ void k(int *Data, int Sel) {
+  ICall Fns[] = {add123, sub321};
+  *Data = Fns[Sel](*Data);
+}
+
+int main() {
+  int *DataD = nullptr, DataH = 1000;
+  (void)hipMalloc(&DataD, sizeof(int));
+  (void)hipMemcpy(DataD, &DataH, sizeof(int), hipMemcpyHostToDevice);
+  k<<<1,1>>>(DataD, 0);
+  k<<<1,1>>>(DataD, 1);
+  (void)hipMemcpy(&DataH, DataD, sizeof(int), hipMemcpyDeviceToHost);
+  return !(DataH == 802);
+}

--- a/tests/runtime/TestIndirectCall.hip
+++ b/tests/runtime/TestIndirectCall.hip
@@ -9,6 +9,7 @@
 // * Invalid SPIR-V binary is known to be generated.
 //   OpConstantFunctionPointerINTEL instruction is generated with a reference to
 //   an undeclared OpFunction (missing forward declaration).
+//   https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2043.
 
 #include <hip/hip_runtime.h>
 

--- a/tests/runtime/TestStructWithFnPtr.hip
+++ b/tests/runtime/TestStructWithFnPtr.hip
@@ -1,0 +1,18 @@
+// A regression test for "SPIR-V Parser: Failed to find size for type id #"
+// error which subsequently lead to incorrect struct size calculation.
+#include <hip/hip_runtime.h>
+
+struct Foo {
+  void (*SomeFn)(int) = nullptr; // Not used in device code
+  int Val = 123;
+};
+
+__global__ void k(int *Out, Foo TheFoo) { *Out = TheFoo.Val; }
+
+int main() {
+  int *OutD, OutH = 0;
+  (void)hipMalloc(&OutD, sizeof(int));
+  k<<<1, 1>>>(OutD, Foo());
+  (void)hipMemcpy(&OutH, OutD, sizeof(int), hipMemcpyDeviceToHost);
+  return !(OutH == 123);
+}


### PR DESCRIPTION
Allow/enable device modules with indirect calls to be compiled and run which requires support of SPV_INTEL_function_pointers extension in the driver. Beware, no driver I know expresses support for the extension. Despite this, indirect calls are known to work on Intel Level Zero and Intel OpenCL CPU & GPU (perhaps, by luck). You may try to compile and run TestIndirectCall.hip to see if indirect calls are supported on your system.

Along the way, fixed #462. This patch may also fix #52.
