### PR TITLE
Shared ptr events

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/CHIP-SPV/hip-testsuite.git
 [submodule "bitcode/ROCm-Device-Libs"]
 	path = bitcode/ROCm-Device-Libs
-	url = https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
+	url = https://github.com/CHIP-SPV/ROCm-Device-Libs.git
 [submodule "HIPCC"]
 	path = HIPCC
 	url = https://github.com/CHIP-SPV/HIPCC.git

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -59,5 +59,5 @@ work_dir, device_type, backend, num_threads, num_tries, timeout, env_vars = proc
 
 os.chdir(work_dir)
 
-cmd = "{env_vars} ctest --output-on-failure --timeout {timeout} --repeat until-fail:{num_tries} -j {num_threads} -E \"`cat ./test_lists/{device_type}_{backend}_failed_tests.txt`\"".format(work_dir=work_dir, num_tries=num_tries, env_vars=env_vars, num_threads=num_threads, device_type=device_type, backend=backend, timeout=timeout)
+cmd = "{env_vars} ctest --output-on-failure --timeout {timeout} --repeat until-fail:{num_tries} -j {num_threads} -E \"`cat ./test_lists/{device_type}_{backend}_failed_tests.txt`\"  -O checkpy_{device_type}_{backend}.txt".format(work_dir=work_dir, num_tries=num_tries, env_vars=env_vars, num_threads=num_threads, device_type=device_type, backend=backend, timeout=timeout)
 run_cmd(cmd)

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -29,7 +29,6 @@ else
   exit 1
 fi
 
-source /opt/intel/oneapi/setvars.sh intel64 &> /dev/null
 source /etc/profile.d/modules.sh &> /dev/null
 export MODULEPATH=$MODULEPATH:/home/pvelesko/modulefiles:/opt/intel/oneapi/modulefiles
 export IGC_EnableDPEmulation=1
@@ -40,6 +39,7 @@ export CHIP_LOGLEVEL=err
 module load $CLANG
 module load opencl/pocl-cpu-$LLVM
 output=$(clinfo -l 2>&1 | grep "Platform #0")
+echo $output
 if [ $? -ne 0 ]; then
     echo "clinfo failed to execute."
     exit 1

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -36,9 +36,6 @@ export IGC_EnableDPEmulation=1
 export OverrideDefaultFP64Settings=1
 export CHIP_LOGLEVEL=err
 
-sudo /opt/ocl-icd/scripts/igpu_unbind &> /dev/null
-sudo /opt/ocl-icd/scripts/dgpu_unbind &> /dev/null
-
 # Use OpenCL for building/test discovery to prevent Level Zero from being used in multi-thread/multi-process environment
 module load $CLANG
 module load opencl/pocl-cpu-$LLVM

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -214,20 +214,20 @@ void CHIPEvent::sanityCheck() {
 void CHIPEvent::sanityCheckNoLock() {
 #ifndef NDEBUG
   bool Sane = true;
-//   auto Found = std::find(Backend->Events.begin(), Backend->Events.end(), this);
-//   if (TrackCalled_ && Found == Backend->Events.end()) {
-//     logCritical(
-//         "CHIPEvent::sanityCheck({}) Tracked event not found in Backend->Events",
-//         (void *)this);
-//     Sane = false;
-//   }
+  //   auto Found = std::find(Backend->Events.begin(), Backend->Events.end(),
+  //   this); if (TrackCalled_ && Found == Backend->Events.end()) {
+  //     logCritical(
+  //         "CHIPEvent::sanityCheck({}) Tracked event not found in
+  //         Backend->Events", (void *)this);
+  //     Sane = false;
+  //   }
 
-//   if (!TrackCalled_ && Found != Backend->Events.end()) {
-//     logCritical(
-//         "CHIPEvent::sanityCheck({}) Untracked event found in Backend->Events",
-//         (void *)this);
-//     Sane = false;
-//   }
+  //   if (!TrackCalled_ && Found != Backend->Events.end()) {
+  //     logCritical(
+  //         "CHIPEvent::sanityCheck({}) Untracked event found in
+  //         Backend->Events", (void *)this);
+  //     Sane = false;
+  //   }
 
   if (UserEvent_ && TrackCalled_) {
     logCritical("CHIPEvent::sanityCheck({}) UserEvent is Tracked",
@@ -236,7 +236,8 @@ void CHIPEvent::sanityCheckNoLock() {
   }
 
   if (Deleted_) {
-    logCritical("CHIPEvent::sanityCheck({}) Event use after delete", (void *)this);
+    logCritical("CHIPEvent::sanityCheck({}) Event use after delete",
+                (void *)this);
     Sane = false;
   }
 
@@ -245,9 +246,8 @@ void CHIPEvent::sanityCheckNoLock() {
 }
 
 CHIPEvent::CHIPEvent(CHIPContext *Ctx, CHIPEventFlags Flags)
-    : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags),
-      ChipContext_(Ctx), Msg("") {
-}
+    : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags), ChipContext_(Ctx),
+      Msg("") {}
 
 void CHIPEvent::releaseDependencies() {
   assert(!Deleted_ && "Event use after delete!");
@@ -1105,7 +1105,6 @@ void CHIPContext::syncQueues(CHIPQueue *TargetQueue) {
     TargetQueue->updateLastEvent(SyncQueuesEvent);
   }
   Backend->trackEvent(SyncQueuesEvent);
-
 }
 
 CHIPDevice *CHIPContext::getDevice() {
@@ -1232,19 +1231,19 @@ CHIPBackend::CHIPBackend() {
 
 CHIPBackend::~CHIPBackend() {
   logDebug("CHIPBackend Destructor. Deleting all pointers.");
-//   assert(Events.size() == 0);
+  //   assert(Events.size() == 0);
   for (auto &Ctx : ChipContexts) {
     Backend->removeContext(Ctx);
     delete Ctx;
   }
 }
 
- void CHIPBackend::trackEvent(std::shared_ptr<CHIPEvent> Event) {
+void CHIPBackend::trackEvent(std::shared_ptr<CHIPEvent> Event) {
   LOCK(Backend->EventsMtx); // trackImpl CHIPBackend::Events
-  LOCK(Event->EventMtx);           // writing bool CHIPEvent::TrackCalled_
-//   assert(!isUserEvent() && "Attemped to track a user event!");
-//   assert(!Deleted_ && "Event use after delete!");
-//   assert(!TrackCalled_ && "Event already tracked!");
+  LOCK(Event->EventMtx);    // writing bool CHIPEvent::TrackCalled_
+  //   assert(!isUserEvent() && "Attemped to track a user event!");
+  //   assert(!Deleted_ && "Event use after delete!");
+  //   assert(!TrackCalled_ && "Event already tracked!");
 
   logDebug("Tracking CHIPEvent {} in CHIPBackend::Events", (void *)this);
   Backend->Events.push_back(Event);
@@ -1601,7 +1600,8 @@ void CHIPQueue::memFill(void *Dst, size_t Size, const void *Pattern,
     ChipContext_->syncQueues(this);
 #endif
 
-    std::shared_ptr<CHIPEvent> ChipEvent = memFillAsyncImpl(Dst, Size, Pattern, PatternSize);
+    std::shared_ptr<CHIPEvent> ChipEvent =
+        memFillAsyncImpl(Dst, Size, Pattern, PatternSize);
     ChipEvent->Msg = "memFill";
     updateLastEvent(ChipEvent);
     Backend->trackEvent(ChipEvent);
@@ -1616,7 +1616,8 @@ void CHIPQueue::memFillAsync(void *Dst, size_t Size, const void *Pattern,
   ChipContext_->syncQueues(this);
 #endif
 
-  std::shared_ptr<CHIPEvent> ChipEvent = memFillAsyncImpl(Dst, Size, Pattern, PatternSize);
+  std::shared_ptr<CHIPEvent> ChipEvent =
+      memFillAsyncImpl(Dst, Size, Pattern, PatternSize);
   ChipEvent->Msg = "memFillAsync";
   updateLastEvent(ChipEvent);
   Backend->trackEvent(ChipEvent);
@@ -1626,7 +1627,8 @@ void CHIPQueue::memCopy2D(void *Dst, size_t DPitch, const void *Src,
 #ifdef ENFORCE_QUEUE_SYNC
   ChipContext_->syncQueues(this);
 #endif
-  std::shared_ptr<CHIPEvent> ChipEvent = memCopy2DAsyncImpl(Dst, DPitch, Src, SPitch, Width, Height);
+  std::shared_ptr<CHIPEvent> ChipEvent =
+      memCopy2DAsyncImpl(Dst, DPitch, Src, SPitch, Width, Height);
   ChipEvent->Msg = "memCopy2D";
   finish();
   updateLastEvent(ChipEvent);
@@ -1656,8 +1658,8 @@ void CHIPQueue::memCopy3D(void *Dst, size_t DPitch, size_t DSPitch,
   ChipContext_->syncQueues(this);
 #endif
 
-  std::shared_ptr<CHIPEvent> ChipEvent = memCopy3DAsyncImpl(Dst, DPitch, DSPitch, Src, SPitch,
-                                      SSPitch, Width, Height, Depth);
+  std::shared_ptr<CHIPEvent> ChipEvent = memCopy3DAsyncImpl(
+      Dst, DPitch, DSPitch, Src, SPitch, SSPitch, Width, Height, Depth);
   ChipEvent->Msg = "memCopy3D";
   finish();
   updateLastEvent(ChipEvent);
@@ -1671,8 +1673,8 @@ void CHIPQueue::memCopy3DAsync(void *Dst, size_t DPitch, size_t DSPitch,
   ChipContext_->syncQueues(this);
 #endif
 
-  std::shared_ptr<CHIPEvent> ChipEvent = memCopy3DAsyncImpl(Dst, DPitch, DSPitch, Src, SPitch,
-                                      SSPitch, Width, Height, Depth);
+  std::shared_ptr<CHIPEvent> ChipEvent = memCopy3DAsyncImpl(
+      Dst, DPitch, DSPitch, Src, SPitch, SSPitch, Width, Height, Depth);
   ChipEvent->Msg = "memCopy3DAsync";
   updateLastEvent(ChipEvent);
   Backend->trackEvent(ChipEvent);
@@ -1687,8 +1689,9 @@ void CHIPQueue::updateLastNode(CHIPGraphNode *NewNode) {
 
 void CHIPQueue::initCaptureGraph() { CaptureGraph_ = new CHIPGraph(); }
 
-std::shared_ptr<CHIPEvent> CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
-                                        MANAGED_MEM_STATE ExecState) {
+std::shared_ptr<CHIPEvent>
+CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
+                             MANAGED_MEM_STATE ExecState) {
 
   // TODO: Inspect kernel code for indirect allocation accesses. If
   //       the kernel does not have any, we only need inspect kernels
@@ -1719,13 +1722,13 @@ std::shared_ptr<CHIPEvent> CHIPQueue::RegisteredVarCopy(CHIPExecItem *ExecItem,
   if (CopyEvents.empty())
     return nullptr;
 
-// We don't need to updateLastEvent because this function is always part of the kernel launch sequence which update the last event anyway
-// CHIPEvent* BackEvent = CopyEvents.back();
-//   updateLastEvent(std::shared_ptr<CHIPEvent>(BackEvent));
+  // We don't need to updateLastEvent because this function is always part of
+  // the kernel launch sequence which update the last event anyway CHIPEvent*
+  // BackEvent = CopyEvents.back();
+  //   updateLastEvent(std::shared_ptr<CHIPEvent>(BackEvent));
 
-
-   for (auto Ev : CopyEvents)
-      Backend->trackEvent(Ev);
+  for (auto Ev : CopyEvents)
+    Backend->trackEvent(Ev);
 
   return CopyEvents.back();
 }
@@ -1783,10 +1786,10 @@ void CHIPQueue::launch(CHIPExecItem *ExecItem) {
                           hipErrorLaunchFailure);
   }
 
-  std::shared_ptr<CHIPEvent>  RegisteredVarInEvent =
+  std::shared_ptr<CHIPEvent> RegisteredVarInEvent =
       RegisteredVarCopy(ExecItem, MANAGED_MEM_STATE::PRE_KERNEL);
   std::shared_ptr<CHIPEvent> LaunchEvent = launchImpl(ExecItem);
-  std::shared_ptr<CHIPEvent>  RegisteredVarOutEvent =
+  std::shared_ptr<CHIPEvent> RegisteredVarOutEvent =
       RegisteredVarCopy(ExecItem, MANAGED_MEM_STATE::POST_KERNEL);
 
   RegisteredVarOutEvent ? updateLastEvent(RegisteredVarOutEvent)
@@ -1795,16 +1798,18 @@ void CHIPQueue::launch(CHIPExecItem *ExecItem) {
   Backend->trackEvent(LaunchEvent);
 }
 
-std::shared_ptr<CHIPEvent> 
-CHIPQueue::enqueueBarrier(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
-  std::shared_ptr<CHIPEvent>  ChipEvent = std::shared_ptr<CHIPEvent> (enqueueBarrierImpl(EventsToWaitFor));
+std::shared_ptr<CHIPEvent> CHIPQueue::enqueueBarrier(
+    std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
+  std::shared_ptr<CHIPEvent> ChipEvent =
+      std::shared_ptr<CHIPEvent>(enqueueBarrierImpl(EventsToWaitFor));
   ChipEvent->Msg = "enqueueBarrier";
   updateLastEvent(ChipEvent);
   Backend->trackEvent(ChipEvent);
   return ChipEvent;
 }
 std::shared_ptr<CHIPEvent> CHIPQueue::enqueueMarker() {
-  std::shared_ptr<CHIPEvent> ChipEvent = std::shared_ptr<CHIPEvent> (enqueueMarkerImpl());
+  std::shared_ptr<CHIPEvent> ChipEvent =
+      std::shared_ptr<CHIPEvent>(enqueueMarkerImpl());
   ChipEvent->Msg = "enqueueMarker";
   updateLastEvent(ChipEvent);
   Backend->trackEvent(ChipEvent);
@@ -1816,7 +1821,8 @@ void CHIPQueue::memPrefetch(const void *Ptr, size_t Count) {
   ChipContext_->syncQueues(this);
 #endif
 
-  std::shared_ptr<CHIPEvent>  ChipEvent = std::shared_ptr<CHIPEvent> (memPrefetchImpl(Ptr, Count));
+  std::shared_ptr<CHIPEvent> ChipEvent =
+      std::shared_ptr<CHIPEvent>(memPrefetchImpl(Ptr, Count));
   ChipEvent->Msg = "memPrefetch";
   updateLastEvent(ChipEvent);
   Backend->trackEvent(ChipEvent);

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1758,7 +1758,7 @@ void CHIPQueue::launch(CHIPExecItem *ExecItem) {
 }
 
 std::shared_ptr<CHIPEvent> CHIPQueue::enqueueBarrier(
-    std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
+    const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor) {
   std::shared_ptr<CHIPEvent> ChipEvent =
       std::shared_ptr<CHIPEvent>(enqueueBarrierImpl(EventsToWaitFor));
   ChipEvent->Msg = "enqueueBarrier";

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -212,8 +212,8 @@ void CHIPEvent::sanityCheck() {
 }
 
 void CHIPEvent::sanityCheckNoLock() {
-// #ifndef NDEBUG
-//   bool Sane = true;
+#ifndef NDEBUG
+  bool Sane = true;
 //   auto Found = std::find(Backend->Events.begin(), Backend->Events.end(), this);
 //   if (TrackCalled_ && Found == Backend->Events.end()) {
 //     logCritical(
@@ -229,14 +229,19 @@ void CHIPEvent::sanityCheckNoLock() {
 //     Sane = false;
 //   }
 
-//   if (UserEvent_ && TrackCalled_) {
-//     logCritical("CHIPEvent::sanityCheck({}) UserEvent is Tracked",
-//                 (void *)this);
-//     Sane = false;
-//   }
+  if (UserEvent_ && TrackCalled_) {
+    logCritical("CHIPEvent::sanityCheck({}) UserEvent is Tracked",
+                (void *)this);
+    Sane = false;
+  }
+
+  if (Deleted_) {
+    logCritical("CHIPEvent::sanityCheck({}) Event use after delete", (void *)this);
+    Sane = false;
+  }
 
 //   assert(Sane);
-// #endif
+#endif
 }
 
 CHIPEvent::CHIPEvent(CHIPContext *Ctx, CHIPEventFlags Flags)

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -240,24 +240,14 @@ void CHIPEvent::sanityCheckNoLock() {
 }
 
 CHIPEvent::CHIPEvent(CHIPContext *Ctx, CHIPEventFlags Flags)
-    : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags), Refc_(new size_t()),
+    : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags),
       ChipContext_(Ctx), Msg("") {
-  *Refc_ = 1;
 }
 
 void CHIPEvent::releaseDependencies() {
   assert(!Deleted_ && "Event use after delete!");
-  for (auto Event : DependsOnList) {
-    Event->decreaseRefCount("An event that depended on this one has finished");
-  }
   LOCK(EventMtx); // CHIPEvent::DependsOnList
   DependsOnList.clear();
-}
-
-size_t CHIPEvent::getCHIPRefc() {
-  LOCK(this->EventMtx); // CHIPEvent::Refc_
-  assert(!Deleted_ && "Event use after delete!");
-  return *Refc_;
 }
 
 // CHIPModuleflags_

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -204,46 +204,6 @@ CHIPAllocationTracker::getAllocInfoCheckPtrRanges(void *DevPtr) {
 
 // CHIPEvent
 // ************************************************************************
-void CHIPEvent::sanityCheck() {
-#ifndef NDEBUG
-  LOCK(Backend->EventsMtx); // CHIPBackend::Events
-  sanityCheckNoLock();
-#endif
-}
-
-void CHIPEvent::sanityCheckNoLock() {
-#ifndef NDEBUG
-  bool Sane = true;
-  //   auto Found = std::find(Backend->Events.begin(), Backend->Events.end(),
-  //   this); if (TrackCalled_ && Found == Backend->Events.end()) {
-  //     logCritical(
-  //         "CHIPEvent::sanityCheck({}) Tracked event not found in
-  //         Backend->Events", (void *)this);
-  //     Sane = false;
-  //   }
-
-  //   if (!TrackCalled_ && Found != Backend->Events.end()) {
-  //     logCritical(
-  //         "CHIPEvent::sanityCheck({}) Untracked event found in
-  //         Backend->Events", (void *)this);
-  //     Sane = false;
-  //   }
-
-  if (UserEvent_ && TrackCalled_) {
-    logCritical("CHIPEvent::sanityCheck({}) UserEvent is Tracked",
-                (void *)this);
-    Sane = false;
-  }
-
-  if (Deleted_) {
-    logCritical("CHIPEvent::sanityCheck({}) Event use after delete",
-                (void *)this);
-    Sane = false;
-  }
-
-//   assert(Sane);
-#endif
-}
 
 CHIPEvent::CHIPEvent(CHIPContext *Ctx, CHIPEventFlags Flags)
     : EventStatus_(EVENT_STATUS_INIT), Flags_(Flags), ChipContext_(Ctx),
@@ -1547,7 +1507,6 @@ hipError_t CHIPQueue::memCopy(void *Dst, const void *Src, size_t Size) {
       Backend->getActiveDevice()->getDefaultQueue()->MemUnmap(AllocInfoSrc);
 
     ChipEvent = memCopyAsyncImpl(Dst, Src, Size);
-    ChipEvent->sanityCheck();
 
     if (AllocInfoDst && AllocInfoDst->MemoryType == hipMemoryTypeHost)
       Backend->getActiveDevice()->getDefaultQueue()->MemMap(

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1772,7 +1772,9 @@ public:
   mutable std::mutex BackendMtx;
   std::mutex CallbackQueueMtx;
   std::vector<std::shared_ptr<CHIPEvent>> Events;
+  std::vector<std::shared_ptr<CHIPEvent>> UserEvents;
   std::mutex EventsMtx;
+  std::mutex UserEventsMtx;
 
   std::queue<CHIPCallbackData *> CallbackQueue;
 
@@ -1965,17 +1967,10 @@ public:
    * prevent it from being garbage collected.
    * @return CHIPEvent* Event
    */
-  virtual CHIPEvent *createCHIPEvent(CHIPContext *ChipCtx,
-                                     CHIPEventFlags Flags = CHIPEventFlags(),
-                                     bool UserEvent = false) = 0;
-                                     
-  std::shared_ptr<CHIPEvent> createCHIPEventShared(CHIPContext *ChipCtx,
+  virtual std::shared_ptr<CHIPEvent> createCHIPEvent(CHIPContext *ChipCtx,
                                                    CHIPEventFlags Flags =
                                                        CHIPEventFlags(),
-                                                   bool UserEvent = false) {
-    return std::shared_ptr<CHIPEvent>(
-        createCHIPEvent(ChipCtx, Flags, UserEvent));
-  }
+                                                   bool UserEvent = false) = 0;
   /**
    * @brief Create a Callback Obj object
    * Each backend must implement this function which calls a derived

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -631,7 +631,8 @@ protected:
    * constructor should be called.
    *
    */
-  CHIPEvent() : UserEvent_(false), TrackCalled_(false) {}
+  CHIPEvent() : TrackCalled_(false), UserEvent_(false) {}
+  virtual ~CHIPEvent() {};
 
 public:
   void markTracked() { TrackCalled_ = true; }
@@ -649,7 +650,6 @@ public:
   CHIPEventFlags getFlags() { return Flags_; }
   std::mutex EventMtx;
   std::string Msg;
-  virtual ~CHIPEvent() = default;
   // Optionally provide a field for origin of this event
   /**
    * @brief CHIPEvent constructor. Must always be created with some context.
@@ -1755,6 +1755,15 @@ protected:
   std::shared_ptr<spdlog::logger> Logger;
 
 public:
+  std::shared_ptr<CHIPEvent> userEventLookup(CHIPEvent* EventPtr) {
+    std::lock_guard<std::mutex> Lock(UserEventsMtx);
+    for (auto &UserEvent : UserEvents) {
+      if (UserEvent.get() == EventPtr) {
+        return UserEvent;
+      }
+    }
+    return nullptr;
+  }
   void trackEvent(std::shared_ptr<CHIPEvent> Event);
 
 #ifdef DUBIOUS_LOCKS

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -620,9 +620,6 @@ protected:
   bool Deleted_ = false;
 #endif
 
-  // reference count
-  size_t *Refc_;
-
   /**
    * @brief Events are always created with a context
    *
@@ -652,9 +649,6 @@ public:
   CHIPEventFlags getFlags() { return Flags_; }
   std::mutex EventMtx;
   std::string Msg;
-  size_t getCHIPRefc();
-  virtual size_t decreaseRefCount(std::string Reason) = 0;
-  virtual size_t increaseRefCount(std::string Reason) = 0;
   virtual ~CHIPEvent() = default;
   // Optionally provide a field for origin of this event
   /**
@@ -2226,7 +2220,6 @@ public:
       return true;
 
     if (LastEvent_->updateFinishStatus(false))
-      // LastEvent_->decreaseRefCount("query(): event became ready");
       if (LastEvent_->isFinished())
         return true;
 

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -648,7 +648,7 @@ public:
     DependsOnList.push_back(Event);
   }
   void releaseDependencies();
-  virtual void track();
+  virtual std::shared_ptr<CHIPEvent> track();
   CHIPEventFlags getFlags() { return Flags_; }
   std::mutex EventMtx;
   std::string Msg;
@@ -2031,7 +2031,7 @@ protected:
 
   enum class MANAGED_MEM_STATE { PRE_KERNEL, POST_KERNEL };
 
-  CHIPEvent *RegisteredVarCopy(CHIPExecItem *ExecItem,
+  std::shared_ptr<CHIPEvent> RegisteredVarCopy(CHIPExecItem *ExecItem,
                                MANAGED_MEM_STATE ExecState);
 
 public:

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -632,7 +632,7 @@ protected:
    *
    */
   CHIPEvent() : TrackCalled_(false), UserEvent_(false) {}
-  virtual ~CHIPEvent() {};
+  virtual ~CHIPEvent(){};
 
 public:
   void markTracked() { TrackCalled_ = true; }
@@ -1755,7 +1755,7 @@ protected:
   std::shared_ptr<spdlog::logger> Logger;
 
 public:
-  std::shared_ptr<CHIPEvent> userEventLookup(CHIPEvent* EventPtr) {
+  std::shared_ptr<CHIPEvent> userEventLookup(CHIPEvent *EventPtr) {
     std::lock_guard<std::mutex> Lock(UserEventsMtx);
     for (auto &UserEvent : UserEvents) {
       if (UserEvent.get() == EventPtr) {
@@ -1976,10 +1976,9 @@ public:
    * prevent it from being garbage collected.
    * @return CHIPEvent* Event
    */
-  virtual std::shared_ptr<CHIPEvent> createCHIPEvent(CHIPContext *ChipCtx,
-                                                   CHIPEventFlags Flags =
-                                                       CHIPEventFlags(),
-                                                   bool UserEvent = false) = 0;
+  virtual std::shared_ptr<CHIPEvent>
+  createCHIPEvent(CHIPContext *ChipCtx, CHIPEventFlags Flags = CHIPEventFlags(),
+                  bool UserEvent = false) = 0;
   /**
    * @brief Create a Callback Obj object
    * Each backend must implement this function which calls a derived
@@ -2031,7 +2030,7 @@ protected:
   enum class MANAGED_MEM_STATE { PRE_KERNEL, POST_KERNEL };
 
   std::shared_ptr<CHIPEvent> RegisteredVarCopy(CHIPExecItem *ExecItem,
-                               MANAGED_MEM_STATE ExecState);
+                                               MANAGED_MEM_STATE ExecState);
 
 public:
   enum MEM_MAP_TYPE { HOST_READ, HOST_WRITE, HOST_READ_WRITE };
@@ -2136,8 +2135,8 @@ public:
    * @param size Transfer size
    * @return hipError_t
    */
-  virtual std::shared_ptr<CHIPEvent> memCopyAsyncImpl(void *Dst, const void *Src,
-                                      size_t Size) = 0;
+  virtual std::shared_ptr<CHIPEvent>
+  memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) = 0;
   void memCopyAsync(void *Dst, const void *Src, size_t Size);
 
   /**
@@ -2160,8 +2159,8 @@ public:
    * @param pattern_size
    */
   virtual std::shared_ptr<CHIPEvent> memFillAsyncImpl(void *Dst, size_t Size,
-                                      const void *Pattern,
-                                      size_t PatternSize) = 0;
+                                                      const void *Pattern,
+                                                      size_t PatternSize) = 0;
   virtual void memFillAsync(void *Dst, size_t Size, const void *Pattern,
                             size_t PatternSize);
 
@@ -2169,9 +2168,9 @@ public:
   virtual void memCopy2D(void *Dst, size_t DPitch, const void *Src,
                          size_t SPitch, size_t Width, size_t Height);
 
-  virtual std::shared_ptr<CHIPEvent> memCopy2DAsyncImpl(void *Dst, size_t DPitch,
-                                        const void *Src, size_t SPitch,
-                                        size_t Width, size_t Height) = 0;
+  virtual std::shared_ptr<CHIPEvent>
+  memCopy2DAsyncImpl(void *Dst, size_t DPitch, const void *Src, size_t SPitch,
+                     size_t Width, size_t Height) = 0;
   virtual void memCopy2DAsync(void *Dst, size_t DPitch, const void *Src,
                               size_t SPitch, size_t Width, size_t Height);
 
@@ -2180,11 +2179,10 @@ public:
                          const void *Src, size_t SPitch, size_t SSPitch,
                          size_t Width, size_t Height, size_t Depth);
 
-  virtual std::shared_ptr<CHIPEvent> memCopy3DAsyncImpl(void *Dst, size_t DPitch,
-                                        size_t DSPitch, const void *Src,
-                                        size_t SPitch, size_t SSPitch,
-                                        size_t Width, size_t Height,
-                                        size_t Depth) = 0;
+  virtual std::shared_ptr<CHIPEvent>
+  memCopy3DAsyncImpl(void *Dst, size_t DPitch, size_t DSPitch, const void *Src,
+                     size_t SPitch, size_t SSPitch, size_t Width, size_t Height,
+                     size_t Depth) = 0;
   virtual void memCopy3DAsync(void *Dst, size_t DPitch, size_t DSPitch,
                               const void *Src, size_t SPitch, size_t SSPitch,
                               size_t Width, size_t Height, size_t Depth);
@@ -2237,9 +2235,10 @@ public:
    * @return true
    * @return false
    */
-  virtual std::shared_ptr<CHIPEvent> 
-  enqueueBarrierImpl(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) = 0;
-  virtual std::shared_ptr<CHIPEvent> enqueueBarrier(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor);
+  virtual std::shared_ptr<CHIPEvent> enqueueBarrierImpl(
+      std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) = 0;
+  virtual std::shared_ptr<CHIPEvent>
+  enqueueBarrier(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor);
 
   virtual std::shared_ptr<CHIPEvent> enqueueMarkerImpl() = 0;
   std::shared_ptr<CHIPEvent> enqueueMarker();
@@ -2278,7 +2277,8 @@ public:
    * @return false
    */
 
-  virtual std::shared_ptr<CHIPEvent> memPrefetchImpl(const void *Ptr, size_t Count) = 0;
+  virtual std::shared_ptr<CHIPEvent> memPrefetchImpl(const void *Ptr,
+                                                     size_t Count) = 0;
   void memPrefetch(const void *Ptr, size_t Count);
 
   /**

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -2234,9 +2234,9 @@ public:
    * @return false
    */
   virtual std::shared_ptr<CHIPEvent> enqueueBarrierImpl(
-      std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) = 0;
+      const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor) = 0;
   virtual std::shared_ptr<CHIPEvent>
-  enqueueBarrier(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor);
+  enqueueBarrier(const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor);
 
   virtual std::shared_ptr<CHIPEvent> enqueueMarkerImpl() = 0;
   std::shared_ptr<CHIPEvent> enqueueMarker();

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -636,8 +636,6 @@ protected:
 
 public:
   void markTracked() { TrackCalled_ = true; }
-  void sanityCheck();
-  void sanityCheckNoLock();
   bool isTrackCalled() { return TrackCalled_; }
   void setTrackCalled(bool Val) { TrackCalled_ = Val; }
   bool isUserEvent() { return UserEvent_; }

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2031,7 +2031,7 @@ hipError_t hipStreamWaitEvent(hipStream_t Stream, hipEvent_t Event,
   }
 
   std::vector<CHIPEvent *> EventsToWaitOn = {static_cast<CHIPEvent *>(Event)};
-  ChipQueue->enqueueBarrier(&EventsToWaitOn);
+//   ChipQueue->enqueueBarrier(&EventsToWaitOn);
 
   RETURN(hipSuccess);
   CHIP_CATCH

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2171,10 +2171,10 @@ hipError_t hipEventDestroy(hipEvent_t Event) {
   NULLCHECK(Event);
   CHIPEvent *ChipEvent = static_cast<CHIPEvent *>(Event);
 
-  size_t Refc = ChipEvent->decreaseRefCount("hipEventDestroy");
-  if(Refc == 0) {
-    Event = nullptr;
-  }
+//   size_t Refc = ChipEvent->decreaseRefCount("hipEventDestroy");
+//   if(Refc == 0) {
+//     Event = nullptr;
+//   }
 
   RETURN(hipSuccess);
 

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2026,13 +2026,13 @@ hipError_t hipStreamWaitEvent(hipStream_t Stream, hipEvent_t Event,
   ERROR_IF((Event == nullptr), hipErrorInvalidResourceHandle);
 
   // Unless the event is in recording state, we can't wait on it
-  if (static_cast<CHIPEvent *>(Event)->getEventStatus() == EVENT_STATUS_INIT) {
+  if (ChipEvent->getEventStatus() == EVENT_STATUS_INIT) {
     RETURN(hipSuccess);
   }
-
-  std::vector<CHIPEvent *> EventsToWaitOn = {static_cast<CHIPEvent *>(Event)};
-//   ChipQueue->enqueueBarrier(&EventsToWaitOn);
-
+  std::shared_ptr<CHIPEvent> ChipEventShared(ChipEvent);
+  std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitOn = {ChipEventShared};
+  auto BarrierEvent = ChipQueue->enqueueBarrier(EventsToWaitOn);
+  Backend->trackEvent(BarrierEvent);
   RETURN(hipSuccess);
   CHIP_CATCH
 }

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -652,7 +652,6 @@ void CHIPStaleEventMonitorLevel0::monitor() {
           std::static_pointer_cast<CHIPEventLevel0>(Backend->Events[EventIdx]);
 
       assert(ChipEvent);
-      ChipEvent->sanityCheckNoLock();
 
       if (ChipEvent->updateFinishStatus(false) && ChipEvent->EventPool) {
         ChipEvent->releaseDependencies();
@@ -1269,7 +1268,6 @@ std::shared_ptr<CHIPEvent> CHIPQueueLevel0::enqueueBarrierImpl(
     std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
   std::shared_ptr<CHIPEvent> EventToSignal =
       static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
-  EventToSignal->sanityCheck();
   EventToSignal->Msg = "barrier";
   size_t NumEventsToWaitFor = 0;
 
@@ -1306,7 +1304,6 @@ std::shared_ptr<CHIPEvent> CHIPQueueLevel0::enqueueBarrierImpl(
   if (EventHandles)
     delete[] EventHandles;
 
-  EventToSignal->sanityCheck();
   return EventToSignal;
 }
 
@@ -1316,7 +1313,6 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
   CHIPContextLevel0 *ChipCtxZe = (CHIPContextLevel0 *)ChipContext_;
   std::shared_ptr<CHIPEvent> MemCopyEvent =
       static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipCtxZe);
-  MemCopyEvent->sanityCheck();
   ze_result_t Status;
   GET_COMMAND_LIST(this);
   // The application must not call this function from simultaneous threads with
@@ -1330,7 +1326,6 @@ CHIPQueueLevel0::memCopyAsyncImpl(void *Dst, const void *Src, size_t Size) {
                               hipErrorInitializationError);
   executeCommandList(CommandList);
 
-  MemCopyEvent->sanityCheck();
   return MemCopyEvent;
 }
 
@@ -1443,7 +1438,6 @@ std::shared_ptr<CHIPEventLevel0> LZEventPool::getEvent() {
     Event = Events_[PoolIndex];
   }
 
-  Event->sanityCheck();
   return Event;
 };
 
@@ -1489,7 +1483,6 @@ CHIPBackendLevel0::createCHIPEvent(CHIPContext *ChipCtx, CHIPEventFlags Flags,
   }
 
   std::static_pointer_cast<CHIPEventLevel0>(Event)->reset();
-  Event->sanityCheck();
   return Event;
 }
 

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1431,7 +1431,6 @@ LZEventPool::~LZEventPool() {
 std::shared_ptr<CHIPEventLevel0> LZEventPool::getEvent() {
   std::shared_ptr<CHIPEventLevel0> Event;
   {
-    LOCK(EventPoolMtx); // LZEventPool::Events_
     int PoolIndex = getFreeSlot();
     if (PoolIndex == -1)
       return nullptr;

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -646,11 +646,6 @@ void CHIPStaleEventMonitorLevel0::monitor() {
 
     LOCK(Backend->EventsMtx); // CHIPBackend::Events
     LOCK(EventMonitorMtx);    // CHIPEventMonitor::Stop
-    // auto LzBackend = (CHIPBackendLevel0 *)Backend;
-    // logTrace("CHIPStaleEventMonitorLevel0::monitor() # events {} # queues
-    // {}",
-    //          Backend->Events.size(),
-    //          LzBackend->EventCommandListMap.size());
 
     for (size_t EventIdx = 0; EventIdx < Backend->Events.size(); EventIdx++) {
       std::shared_ptr<CHIPEventLevel0> ChipEvent =

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1265,7 +1265,7 @@ std::shared_ptr<CHIPEvent> CHIPQueueLevel0::enqueueMarkerImpl() {
 }
 
 std::shared_ptr<CHIPEvent> CHIPQueueLevel0::enqueueBarrierImpl(
-    std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
+    const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor) {
   std::shared_ptr<CHIPEvent> EventToSignal =
       static_cast<CHIPBackendLevel0 *>(Backend)->createCHIPEvent(ChipContext_);
   EventToSignal->Msg = "barrier";

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -1284,7 +1284,7 @@ std::shared_ptr<CHIPEvent> CHIPQueueLevel0::enqueueBarrierImpl(
     for (size_t i = 0; i < NumEventsToWaitFor; i++) {
       std::shared_ptr<CHIPEvent> ChipEvent = EventsToWaitFor[i];
       std::shared_ptr<CHIPEventLevel0> ChipEventLz =
-          std::dynamic_pointer_cast<CHIPEventLevel0>(ChipEvent);
+          std::static_pointer_cast<CHIPEventLevel0>(ChipEvent);
       CHIPASSERT(ChipEventLz);
       EventHandles[i] = ChipEventLz->peek();
       EventToSignal->addDependency(ChipEventLz);

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -312,7 +312,6 @@ public:
     auto NewEventPool = new LZEventPool(this, EVENT_POOL_SIZE);
     Event = NewEventPool->getEvent();
     EventPools_.push_back(NewEventPool);
-    Event->sanityCheck();
     return Event;
   }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -278,7 +278,7 @@ public:
   virtual std::shared_ptr<CHIPEvent> enqueueMarkerImpl() override;
 
   virtual std::shared_ptr<CHIPEvent> enqueueBarrierImpl(
-      std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) override;
+      const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor) override;
 
   virtual std::shared_ptr<CHIPEvent> memPrefetchImpl(const void *Ptr,
                                                      size_t Count) override {

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -179,11 +179,7 @@ public:
   CHIPCallbackDataLevel0(hipStreamCallback_t CallbackF, void *CallbackArgs,
                          CHIPQueue *ChipQueue);
 
-  virtual ~CHIPCallbackDataLevel0() override {
-    delete GpuReady;
-    delete CpuCallbackComplete;
-    delete GpuAck;
-  }
+  virtual ~CHIPCallbackDataLevel0() override {}
 };
 
 class CHIPCallbackEventMonitorLevel0 : public CHIPEventMonitor {
@@ -276,11 +272,11 @@ public:
   virtual void addCallback(hipStreamCallback_t Callback,
                            void *UserData) override;
 
-  virtual CHIPEvent *launchImpl(CHIPExecItem *ExecItem) override;
+  virtual std::shared_ptr<CHIPEvent> launchImpl(CHIPExecItem *ExecItem) override;
 
   virtual void finish() override;
 
-  virtual CHIPEvent *memCopyAsyncImpl(void *Dst, const void *Src,
+  virtual std::shared_ptr<CHIPEvent> memCopyAsyncImpl(void *Dst, const void *Src,
                                       size_t Size) override;
 
   /**
@@ -293,33 +289,33 @@ public:
   ze_command_queue_handle_t getCmdQueue() { return ZeCmdQ_; }
   void *getSharedBufffer() { return SharedBuf_; };
 
-  virtual CHIPEvent *memFillAsyncImpl(void *Dst, size_t Size,
+  virtual std::shared_ptr<CHIPEvent> memFillAsyncImpl(void *Dst, size_t Size,
                                       const void *Pattern,
                                       size_t PatternSize) override;
 
-  virtual CHIPEvent *memCopy2DAsyncImpl(void *Dst, size_t Dpitch,
+  virtual std::shared_ptr<CHIPEvent> memCopy2DAsyncImpl(void *Dst, size_t Dpitch,
                                         const void *Src, size_t Spitch,
                                         size_t Width, size_t Height) override;
 
-  virtual CHIPEvent *memCopy3DAsyncImpl(void *Dst, size_t Dpitch,
+  virtual std::shared_ptr<CHIPEvent> memCopy3DAsyncImpl(void *Dst, size_t Dpitch,
                                         size_t Dspitch, const void *Src,
                                         size_t Spitch, size_t Sspitch,
                                         size_t Width, size_t Height,
                                         size_t Depth) override;
 
-  virtual CHIPEvent *memCopyToImage(ze_image_handle_t TexStorage,
+  virtual std::shared_ptr<CHIPEvent> memCopyToImage(ze_image_handle_t TexStorage,
                                     const void *Src,
                                     const CHIPRegionDesc &SrcRegion);
 
   virtual hipError_t getBackendHandles(uintptr_t *NativeInfo,
                                        int *NumHandles) override;
 
-  virtual CHIPEvent *enqueueMarkerImpl() override;
+  virtual std::shared_ptr<CHIPEvent> enqueueMarkerImpl() override;
 
-  virtual CHIPEvent *
+  virtual std::shared_ptr<CHIPEvent> 
   enqueueBarrierImpl(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) override;
 
-  virtual CHIPEvent *memPrefetchImpl(const void *Ptr, size_t Count) override {
+  virtual std::shared_ptr<CHIPEvent> memPrefetchImpl(const void *Ptr, size_t Count) override {
     UNIMPLEMENTED(nullptr);
   }
 

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -92,41 +92,6 @@ private:
   std::vector<ActionFn> Actions_;
 
 public:
-  virtual size_t decreaseRefCount(std::string Reason) override {
-    LOCK(EventMtx); // CHIPEvent::Refc_
-    assert(!Deleted_ && "Event use after delete!");
-    logDebug("CHIPEvent::decreaseRefCount() {} {} refc {}->{} REASON: {}",
-             (void *)this, Msg.c_str(), *Refc_, *Refc_ - 1, Reason);
-    if (*Refc_ > 0) {
-      (*Refc_)--;
-    } else {
-      assert(false && "CHIPEvent::decreaseRefCount() called when refc == 0");
-      logError("CHIPEvent::decreaseRefCount() called when refc == 0");
-    }
-    // Destructor to be called by event monitor once backend is done using it
-    assert(!(TrackCalled_ && UserEvent_) && "UserEvent has TrackCalled_!");
-    if (!TrackCalled_ && !UserEvent_ && *Refc_ == 0) {
-      delete this;
-      return 0;
-    } else {
-      return *Refc_;
-    }
-
-  }
-
-  virtual size_t increaseRefCount(std::string Reason) override {
-    LOCK(EventMtx); // CHIPEvent::Refc_
-    assert(!Deleted_ && "Event use after delete!");
-    logDebug("CHIPEvent::increaseRefCount() {} {} refc {}->{} REASON: {}",
-             (void *)this, Msg.c_str(), *Refc_, *Refc_ + 1, Reason);
-
-    // Base constructor and CHIPEventLevel0::reset() sets the refc_ to one.
-    assert(*Refc_ > 0 && "Increasing refcount from zero!");
-    (*Refc_)++;
-
-    return *Refc_;
-  }
-
   uint32_t getValidTimestampBits();
   uint64_t getHostTimestamp() { return HostTimestamp_; }
   unsigned int EventPoolIndex;
@@ -155,7 +120,6 @@ public:
   void reset();
 
   ze_event_handle_t peek();
-  ze_event_handle_t get(std::string Msg);
 
   /// Bind an action which is promised to be executed when the event is
   /// finished.

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -301,6 +301,7 @@ public:
     LOCK(ContextMtx); // CHIPContext::EventPools
     std::shared_ptr<CHIPEventLevel0> Event;
     for (auto EventPool : EventPools_) {
+      LOCK(EventPool->EventPoolMtx); // LZEventPool::FreeSlots_
       if (EventPool->EventAvailable())
         return EventPool->getEvent();
     }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -276,8 +276,6 @@ public:
   virtual void addCallback(hipStreamCallback_t Callback,
                            void *UserData) override;
 
-  virtual CHIPEventLevel0 *getLastEvent() override;
-
   virtual CHIPEvent *launchImpl(CHIPExecItem *ExecItem) override;
 
   virtual void finish() override;
@@ -319,7 +317,7 @@ public:
   virtual CHIPEvent *enqueueMarkerImpl() override;
 
   virtual CHIPEvent *
-  enqueueBarrierImpl(std::vector<CHIPEvent *> *EventsToWaitFor) override;
+  enqueueBarrierImpl(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) override;
 
   virtual CHIPEvent *memPrefetchImpl(const void *Ptr, size_t Count) override {
     UNIMPLEMENTED(nullptr);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -590,22 +590,22 @@ std::shared_ptr<CHIPEvent> CHIPBackendOpenCL::createCHIPEvent(CHIPContext *ChipC
 
 void CHIPEventOpenCL::recordStream(CHIPQueue *ChipQueue) {
   logTrace("CHIPEvent::recordStream()");
-  auto MarkerEvent = ChipQueue->enqueueMarker();
-//   this->takeOver(MarkerEvent);
+  std::shared_ptr<CHIPEvent>  MarkerEvent = ChipQueue->enqueueMarker();
+  this->takeOver(MarkerEvent);
 
   this->EventStatus_ = EVENT_STATUS_RECORDING;
   return;
 }
 
-// void CHIPEventOpenCL::takeOver(std::shared_ptr<CHIPEvent> OtherIn) {
-//   logTrace("CHIPEventOpenCL::takeOver");
-//   {
-//     auto *Other = (CHIPEventOpenCL *)OtherIn;
-//     LOCK(EventMtx); // CHIPEvent::Refc_
-//     this->ClEvent = Other->ClEvent;
-//     this->Msg = Other->Msg;
-//   }
-// }
+void CHIPEventOpenCL::takeOver(std::shared_ptr<CHIPEvent> OtherIn) {
+  logTrace("CHIPEventOpenCL::takeOver");
+  {
+    std::shared_ptr<CHIPEventOpenCL> Other = std::static_pointer_cast<CHIPEventOpenCL>(OtherIn);
+    LOCK(EventMtx); // CHIPEvent::Refc_
+    this->ClEvent = Other->ClEvent;
+    this->Msg = Other->Msg;
+  }
+}
 
 bool CHIPEventOpenCL::wait() {
   logTrace("CHIPEventOpenCL::wait()");

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -992,7 +992,7 @@ void CHIPQueueOpenCL::addCallback(hipStreamCallback_t Callback,
 
   // Now the CB can start executing in the background:
   clSetUserEventStatus(HoldBackEvent->ClEvent, CL_COMPLETE);
-//   HoldBackEvent->decreaseRefCount("Notified finished.");
+  //   HoldBackEvent->decreaseRefCount("Notified finished.");
 
   return;
 };
@@ -1215,8 +1215,8 @@ CHIPEvent *CHIPQueueOpenCL::memPrefetchImpl(const void *Ptr, size_t Count) {
   UNIMPLEMENTED(nullptr);
 }
 
-CHIPEvent *
-CHIPQueueOpenCL::enqueueBarrierImpl(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
+CHIPEvent *CHIPQueueOpenCL::enqueueBarrierImpl(
+    std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
 #ifdef DUBIOUS_LOCKS
   LOCK(Backend->DubiousLockOpenCL)
 #endif

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -1040,13 +1040,6 @@ CHIPEvent *CHIPQueueOpenCL::enqueueMarkerImpl() {
   return MarkerEvent;
 }
 
-CHIPEventOpenCL *CHIPQueueOpenCL::getLastEvent() {
-  LOCK(LastEventMtx); // CHIPQueue::LastEvent_
-  // TODO: shouldn't we increment the ref count here, assuming it will be
-  // needed to be kept alive for the client?
-  return (CHIPEventOpenCL *)LastEvent_;
-}
-
 CHIPEvent *CHIPQueueOpenCL::launchImpl(CHIPExecItem *ExecItem) {
   logTrace("CHIPQueueOpenCL->launch()");
   auto *OclContext = static_cast<CHIPContextOpenCL *>(ChipContext_);
@@ -1256,7 +1249,7 @@ CHIPEvent *CHIPQueueOpenCL::memPrefetchImpl(const void *Ptr, size_t Count) {
 }
 
 CHIPEvent *
-CHIPQueueOpenCL::enqueueBarrierImpl(std::vector<CHIPEvent *> *EventsToWaitFor) {
+CHIPQueueOpenCL::enqueueBarrierImpl(std::vector<std::shared_ptr<CHIPEvent>> EventsToWaitFor) {
 #ifdef DUBIOUS_LOCKS
   LOCK(Backend->DubiousLockOpenCL)
 #endif

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -99,7 +99,7 @@ public:
   virtual ~CHIPEventOpenCL() override;
 
   virtual void recordStream(CHIPQueue *ChipQueue) override;
-  void takeOver(CHIPEvent *Other);
+  void takeOver(std::shared_ptr<CHIPEvent> Other);
   bool wait() override;
   float getElapsedTime(CHIPEvent *Other) override;
   virtual void hostSignal() override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -108,9 +108,6 @@ public:
   cl_event &getNativeRef() { return ClEvent; }
   uint64_t getFinishTime();
   size_t getRefCount();
-
-  virtual size_t increaseRefCount(std::string Reason) override;
-  virtual size_t decreaseRefCount(std::string Reason) override;
 };
 
 class CHIPModuleOpenCL : public CHIPModule {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -237,20 +237,20 @@ public:
   CHIPQueueOpenCL(CHIPDevice *ChipDevice, int Priority,
                   cl_command_queue Queue = nullptr);
   virtual ~CHIPQueueOpenCL() override;
-  virtual CHIPEvent *launchImpl(CHIPExecItem *ExecItem) override;
+  virtual std::shared_ptr<CHIPEvent> launchImpl(CHIPExecItem *ExecItem) override;
   virtual void addCallback(hipStreamCallback_t Callback,
                            void *UserData) override;
   virtual void finish() override;
-  virtual CHIPEvent *memCopyAsyncImpl(void *Dst, const void *Src,
+  virtual std::shared_ptr<CHIPEvent> memCopyAsyncImpl(void *Dst, const void *Src,
                                       size_t Size) override;
   cl::CommandQueue *get();
-  virtual CHIPEvent *memFillAsyncImpl(void *Dst, size_t Size,
+  virtual std::shared_ptr<CHIPEvent> memFillAsyncImpl(void *Dst, size_t Size,
                                       const void *Pattern,
                                       size_t PatternSize) override;
-  virtual CHIPEvent *memCopy2DAsyncImpl(void *Dst, size_t Dpitch,
+  virtual std::shared_ptr<CHIPEvent> memCopy2DAsyncImpl(void *Dst, size_t Dpitch,
                                         const void *Src, size_t Spitch,
                                         size_t Width, size_t Height) override;
-  virtual CHIPEvent *memCopy3DAsyncImpl(void *Dst, size_t Dpitch,
+  virtual std::shared_ptr<CHIPEvent> memCopy3DAsyncImpl(void *Dst, size_t Dpitch,
                                         size_t Dspitch, const void *Src,
                                         size_t Spitch, size_t Sspitch,
                                         size_t Width, size_t Height,
@@ -258,10 +258,10 @@ public:
 
   virtual hipError_t getBackendHandles(uintptr_t *NativeInfo,
                                        int *NumHandles) override;
-  virtual CHIPEvent *
-  enqueueBarrierImpl(std::vector<CHIPEvent *> *EventsToWaitFor) override;
-  virtual CHIPEvent *enqueueMarkerImpl() override;
-  virtual CHIPEvent *memPrefetchImpl(const void *Ptr, size_t Count) override;
+  virtual std::shared_ptr<CHIPEvent>
+  enqueueBarrierImpl(const std::vector<std::shared_ptr<CHIPEvent>> &EventsToWaitFor) override;
+  virtual std::shared_ptr<CHIPEvent> enqueueMarkerImpl() override;
+  virtual std::shared_ptr<CHIPEvent> memPrefetchImpl(const void *Ptr, size_t Count) override;
 };
 
 class CHIPKernelOpenCL : public CHIPKernel {
@@ -347,7 +347,7 @@ public:
   virtual int ReqNumHandles() override { return 4; }
 
   virtual CHIPQueue *createCHIPQueue(CHIPDevice *ChipDev) override;
-  virtual CHIPEventOpenCL *
+  virtual std::shared_ptr<CHIPEvent>
   createCHIPEvent(CHIPContext *ChipCtx, CHIPEventFlags Flags = CHIPEventFlags(),
                   bool UserEvent = false) override;
   virtual CHIPCallbackData *createCallbackData(hipStreamCallback_t Callback,

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -242,7 +242,6 @@ public:
   CHIPQueueOpenCL(CHIPDevice *ChipDevice, int Priority,
                   cl_command_queue Queue = nullptr);
   virtual ~CHIPQueueOpenCL() override;
-  virtual CHIPEventOpenCL *getLastEvent() override;
   virtual CHIPEvent *launchImpl(CHIPExecItem *ExecItem) override;
   virtual void addCallback(hipStreamCallback_t Callback,
                            void *UserData) override;

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -98,8 +98,6 @@ public:
                   CHIPEventFlags Flags = CHIPEventFlags());
   virtual ~CHIPEventOpenCL() override;
 
-  virtual void track() override{};
-
   virtual void recordStream(CHIPQueue *ChipQueue) override;
   void takeOver(CHIPEvent *Other);
   bool wait() override;


### PR DESCRIPTION
This PR gets rid of our own reference counting and overall event management.
* `CHIPBackend::createCHIPEvent` pure virtual method now expects a return of a `std::shared_ptr<CHIPEvent>
* * There is no option for returning a non-shared event.
* User events are stored in a new vector: `CHIPBackend::UserEvents` - since all events are created as shared_ptr, destroying these events involves taking the raw pointer and looking it up in `CHIPBackend::UserEvents` 

Fixes #477